### PR TITLE
Add support for sound fonts in SF3 format that contain Ogg Vorbis compressed samples

### DIFF
--- a/fluidsynth/include/fluidsynth/sfont.h
+++ b/fluidsynth/include/fluidsynth/sfont.h
@@ -270,7 +270,7 @@ struct _fluid_sample_t
 #define FLUID_SAMPLETYPE_RIGHT	2       /**< Flag for #fluid_sample_t \a sampletype field for right samples of a stereo pair */
 #define FLUID_SAMPLETYPE_LEFT	4       /**< Flag for #fluid_sample_t \a sampletype field for left samples of a stereo pair */
 #define FLUID_SAMPLETYPE_LINKED	8       /**< Flag for #fluid_sample_t \a sampletype field, not used currently */
-#define FLUID_SAMPLETYPE_OGG_VORBIS	0x10 /**< Flag for #fluid_sample_t \a sampletype field for Ogg Vorbis compressed samples */
+#define FLUID_SAMPLETYPE_OGG_VORBIS	0x10 /**< Flag for #fluid_sample_t \a sampletype field for Ogg Vorbis compressed samples @since 1.1.7 */
 #define FLUID_SAMPLETYPE_ROM	0x8000  /**< Flag for #fluid_sample_t \a sampletype field, ROM sample, causes sample to be ignored */
 
 

--- a/fluidsynth/include/fluidsynth/sfont.h
+++ b/fluidsynth/include/fluidsynth/sfont.h
@@ -270,6 +270,7 @@ struct _fluid_sample_t
 #define FLUID_SAMPLETYPE_RIGHT	2       /**< Flag for #fluid_sample_t \a sampletype field for right samples of a stereo pair */
 #define FLUID_SAMPLETYPE_LEFT	4       /**< Flag for #fluid_sample_t \a sampletype field for left samples of a stereo pair */
 #define FLUID_SAMPLETYPE_LINKED	8       /**< Flag for #fluid_sample_t \a sampletype field, not used currently */
+#define FLUID_SAMPLETYPE_OGG_VORBIS	0x10 /**< Flag for #fluid_sample_t \a sampletype field for Ogg Vorbis compressed samples */
 #define FLUID_SAMPLETYPE_ROM	0x8000  /**< Flag for #fluid_sample_t \a sampletype field, ROM sample, causes sample to be ignored */
 
 

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -1838,7 +1838,7 @@ sfvio_get_filelen(void* user_data)
   fluid_sample_t *sample = (fluid_sample_t *)user_data;
 
   return (sf_count_t)(sample->end + 1 - sample->start);
-};
+}
 
 static sf_count_t
 sfvio_seek(sf_count_t offset, int whence, void* user_data)
@@ -1859,7 +1859,7 @@ sfvio_seek(sf_count_t offset, int whence, void* user_data)
   }
 
   return (sf_count_t)sample->userdata;
-};
+}
 
 static sf_count_t
 sfvio_read(void* ptr, sf_count_t count, void* user_data)
@@ -1873,7 +1873,7 @@ sfvio_read(void* ptr, sf_count_t count, void* user_data)
   sample->userdata = (void *)((intptr_t)sample->userdata + count);
 
   return count;
-};
+}
 
 static sf_count_t
 sfvio_tell (void* user_data)
@@ -1881,7 +1881,7 @@ sfvio_tell (void* user_data)
   fluid_sample_t *sample = (fluid_sample_t *)user_data;
 
   return (sf_count_t)sample->userdata;
-};
+}
 #endif
 
 int

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -1851,7 +1851,7 @@ sfvio_seek(sf_count_t offset, int whence, void* user_data)
       sample->userdata = (void *)offset;
       break;
     case SEEK_CUR:
-      sample->userdata = (void *)((intptr_t)sample->userdata + offset);
+      sample->userdata = (void *)((sf_count_t)sample->userdata + offset);
       break;
     case SEEK_END:
       sample->userdata = (void *)(sfvio_get_filelen(user_data) + offset);
@@ -1870,7 +1870,7 @@ sfvio_read(void* ptr, sf_count_t count, void* user_data)
       count = sfvio_get_filelen(user_data) - (sf_count_t)sample->userdata;
 
   memcpy(ptr, (char *)sample->data + sample->start + (sf_count_t)sample->userdata, count);
-  sample->userdata = (void *)((intptr_t)sample->userdata + count);
+  sample->userdata = (void *)((sf_count_t)sample->userdata + count);
 
   return count;
 }

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -2290,11 +2290,17 @@ process_info (int size, SFData * sf, FILE * fd)
 	    return (FAIL);
 	  }
 
-#if LIBSNDFILE_SUPPORT
-	  if (sf->version.major == 3) {}
-	  else
+	  if (sf->version.major == 3) {
+#if !LIBSNDFILE_SUPPORT
+	    FLUID_LOG (FLUID_WARN,
+		      _("Sound font version is %d.%d but fluidsynth was compiled without"
+			" support for (v3.x)"),
+		      sf->version.major,
+		      sf->version.minor);
+	    return (FAIL);
 #endif
-	  if (sf->version.major > 2) {
+	  }
+	  else if (sf->version.major > 2) {
 	    FLUID_LOG (FLUID_WARN,
 		      _("Sound font version is %d.%d which is newer than"
 			" what this version of FLUID Synth was designed for (v2.0x)"),

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -1865,9 +1865,10 @@ static sf_count_t
 sfvio_read(void* ptr, sf_count_t count, void* user_data)
 {
   fluid_sample_t *sample = (fluid_sample_t *)user_data;
-
-  if (count > sfvio_get_filelen(user_data) - (sf_count_t)sample->userdata)
-      count = sfvio_get_filelen(user_data) - (sf_count_t)sample->userdata;
+  sf_count_t remain = sfvio_get_filelen(user_data) - (sf_count_t)sample->userdata;
+  
+  if (count > remain)
+      count = remain;
 
   memcpy(ptr, (char *)sample->data + sample->start + (sf_count_t)sample->userdata, count);
   sample->userdata = (void *)((sf_count_t)sample->userdata + count);
@@ -1913,7 +1914,7 @@ fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defs
     short *sampledata_ogg;
 
     // initialize file position indicator and SF_INFO structure
-    sample->userdata = NULL;
+    g_assert(sample->userdata == NULL);
     memset(&sfinfo, 0, sizeof(sfinfo));
 
     // open sample as a virtual file in memory

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -1959,23 +1959,7 @@ fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defs
     sample->start = 0;
     sample->end = sfinfo.frames - 1;
 
-    /* loop is fowled?? (cluck cluck :) */
-    if (sample->loopend > sample->end ||
-        sample->loopstart >= sample->loopend ||
-        sample->loopstart <= sample->start)
-    {
-      /* can pad loop by 8 samples and ensure at least 4 for loop (2*8+4) */
-      if ((sample->end - sample->start) >= 20)
-      {
-        sample->loopstart = sample->start + 8;
-        sample->loopend = sample->end - 8;
-      }
-      else /* loop is fowled, sample is tiny (can't pad 8 samples) */
-      {
-        sample->loopstart = sample->start + 1;
-        sample->loopend = sample->end - 1;
-      }
-    }
+    fixup_sample_loop(sample);
 #endif
   }
 


### PR DESCRIPTION
Author: Fabian Greffrath <fabian@debian.org>
Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=740710
Forwarded: https://sourceforge.net/p/fluidsynth/tickets/142/
Last-Update: 2015-11-26

Fixes https://github.com/FluidSynth/fluidsynth/issues/140