### PR TITLE
Prevent loopstart mangling by fixup_sample if equal to sample start

### DIFF
--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -3179,7 +3179,7 @@ fixup_sample (SFData * sf)
 	  return (OK);
 	}
       else if (sam->loopend > sam->end || sam->loopstart >= sam->loopend
-	|| sam->loopstart <= sam->start)
+	|| sam->loopstart < sam->start)
 	{			/* loop is fowled?? (cluck cluck :) */
 	  /* can pad loop by 8 samples and ensure at least 4 for loop (2*8+4) */
 	  if ((sam->end - sam->start) >= 20)

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -3159,6 +3159,7 @@ fixup_sample (SFData * sf)
 {
   fluid_list_t *p;
   SFSample *sam;
+  int invalid_loops=FALSE;
 
   p = sf->sample;
   while (p)
@@ -3181,6 +3182,10 @@ fixup_sample (SFData * sf)
       else if (sam->loopend > sam->end || sam->loopstart >= sam->loopend
 	|| sam->loopstart < sam->start)
 	{			/* loop is fowled?? (cluck cluck :) */
+          FLUID_LOG (FLUID_DBG, _("Sample '%s' has invalid loop,"
+              " extending loop to full sample"), sam->name);
+          invalid_loops |= TRUE;
+	  
 	  /* can pad loop by 8 samples and ensure at least 4 for loop (2*8+4) */
 	  if ((sam->end - sam->start) >= 20)
 	    {
@@ -3200,6 +3205,11 @@ fixup_sample (SFData * sf)
       sam->loopend -= sam->start;
 
       p = fluid_list_next (p);
+    }
+
+    if(invalid_loops)
+    {
+      FLUID_LOG (FLUID_WARN, _("Found samples with invalid loops, audible glitches possible."));
     }
 
   return (OK);

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -3171,7 +3171,7 @@ fixup_sample (SFData * sf)
       /* The SoundFont 2.4 spec defines the loop start index as the first sample point of the loop */
       inv_start = (sam->loopstart < sam->start) || (sam->loopstart >= sam->loopend);
       /* while loop end is the first point AFTER the last sample of the loop */
-      inv_end = (sam->loopend > sam->end+1) || (sam->loopstart >= sam->loopend);
+      inv_end = (sam->loopend > sam->end) || (sam->loopstart >= sam->loopend);
       
       /* if sample is not a ROM sample and end is over the sample data chunk
          or sam start is greater than 4 less than the end (at least 4 samples) */
@@ -3203,6 +3203,7 @@ fixup_sample (SFData * sf)
 	  {
             FLUID_LOG (FLUID_DBG, _("Sample '%s' has invalid loop stop '%d',"
               " setting to sample stop at '%d'-1"), sam->name, sam->loopend, sam->end);
+            /* since sam->end points after valid sample data, set loopend to last sample available */
             sam->loopend = sam->end - 1;
 	  }
 	}

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -3207,7 +3207,7 @@ fixup_sample (SFData * sf)
           
           if(invalid_loopend)
 	  {
-            FLUID_LOG (FLUID_DBG, _("Sample '%s' has out-of-range loop stop '%d',"
+            FLUID_LOG (FLUID_DBG, _("Sample '%s' has unusable loop stop '%d',"
               " setting to sample stop at '%d'-1"), sam->name, sam->loopend, sam->end);
             /* since sam->end points after valid sample data, set loopend to last sample available */
             sam->loopend = sam->end - 1;
@@ -3216,7 +3216,7 @@ fixup_sample (SFData * sf)
           if(loopend_end_mismatch)
 	  {
             FLUID_LOG (FLUID_DBG, _("Sample '%s' has invalid loop stop '%d',"
-              ", sample stop at '%d', using it anyway"), sam->name, sam->loopend, sam->end);
+              " sample stop at '%d', using it anyway"), sam->name, sam->loopend, sam->end);
 	  }
 	}
 

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -3168,9 +3168,9 @@ fixup_sample (SFData * sf)
     {
       sam = (SFSample *) (p->data);
       
-      // The SoundFont 2.4 spec defines the loop start index as the first sample point of the loop
+      /* The SoundFont 2.4 spec defines the loop start index as the first sample point of the loop */
       inv_start = (sam->loopstart < sam->start) || (sam->loopstart >= sam->loopend);
-      // while loop end is the first point AFTER the last sample of the loop.
+      /* while loop end is the first point AFTER the last sample of the loop */
       inv_end = (sam->loopend > sam->end+1) || (sam->loopstart >= sam->loopend);
       
       /* if sample is not a ROM sample and end is over the sample data chunk
@@ -3187,28 +3187,24 @@ fixup_sample (SFData * sf)
 	  return (OK);
 	}
       else if (inv_start || inv_end)
-	{			/* loop is fowled?? (cluck cluck :) */
-          FLUID_LOG (FLUID_DBG, _("Sample '%s' has invalid loop,"
-              " extending loop to full sample"), sam->name);
+	{
+          /* loop is fowled?? (cluck cluck :) */
           invalid_loops |= TRUE;
 	  
-	  /* can pad loop by 8 samples and ensure at least 4 for loop (2*8+4) */
-	  if ((sam->end - sam->start) >= 20)
-	    {
-              if(inv_start)
-                sam->loopstart = sam->start + 8;
+	  /* force incorrect loop points into the sample range, ignore padding */
+          if(inv_start)
+	  {
+            FLUID_LOG (FLUID_DBG, _("Sample '%s' has invalid loop start '%d',"
+              " setting to sample start at '%d'+1"), sam->name, sam->loopstart, sam->start);
+            sam->loopstart = sam->start + 1;
+	  }
           
-              if(inv_end)
-                sam->loopend = sam->end - 8;
-	    }
-	  else
-	    {			/* loop is fowled, sample is tiny (can't pad 8 samples) */
-              if(inv_start)
-                sam->loopstart = sam->start + 1;
-          
-              if(inv_end)
-                sam->loopend = sam->end - 1;
-	    }
+          if(inv_end)
+	  {
+            FLUID_LOG (FLUID_DBG, _("Sample '%s' has invalid loop stop '%d',"
+              " setting to sample stop at '%d'-1"), sam->name, sam->loopend, sam->end);
+            sam->loopend = sam->end - 1;
+	  }
 	}
 
       /* convert sample end, loopstart, loopend to offsets from sam->start */

--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -3170,8 +3170,12 @@ fixup_sample (SFData * sf)
       
       /* The SoundFont 2.4 spec defines the loop start index as the first sample point of the loop */
       inv_start = (sam->loopstart < sam->start) || (sam->loopstart >= sam->loopend);
-      /* while loop end is the first point AFTER the last sample of the loop */
-      inv_end = (sam->loopend > sam->end) || (sam->loopstart >= sam->loopend);
+      /* while loop end is the first point AFTER the last sample of the loop.
+       * this is as it should be. however we cannot be sure whether any of sam.loopend or sam.end
+       * is correct. hours of thinking through this have concluded, that it would be best practice 
+       * to mangle with loops as little as necessary by only making sure loopend is within
+       * sdtachunk_size. incorrect soundfont shall preferably fail loudly. */
+      inv_end = (sam->loopend > sdtachunk_size) || (sam->loopstart >= sam->loopend);
       
       /* if sample is not a ROM sample and end is over the sample data chunk
          or sam start is greater than 4 less than the end (at least 4 samples) */


### PR DESCRIPTION
fixup_sample in defsloader attempts to repair certain broken sample loop points. But it also mangles the
pointers if sample start and loop start are equal, which leads to weird behavior observed in #171. After applying this fix, the pitch seems to be correct again.

Signed-off-by: Marcus Weseloh <marcus@weseloh.cc>