### PR TITLE
refactor modulator handling

### DIFF
--- a/fluidsynth/src/synth/fluid_mod.c
+++ b/fluidsynth/src/synth/fluid_mod.c
@@ -154,7 +154,9 @@ fluid_mod_get_amount(fluid_mod_t* mod)
   return (double) mod->amount;
 }
 
-
+/*
+ * retrieves the initial value from the given source of the modulator
+ */
 static fluid_real_t
 fluid_mod_get_source_value(const unsigned char mod_src,
                            const unsigned char mod_flags,
@@ -202,9 +204,18 @@ fluid_mod_get_source_value(const unsigned char mod_src,
     return val;
 }
 
+/**
+ * transforms the initial value retrieved by \c fluid_mod_get_source_value into [0.0;1.0]
+ */
 static fluid_real_t
 fluid_mod_transform_source_value(fluid_real_t val, unsigned char mod_flags, const fluid_real_t range)
 {
+    /* normalized value, i.e. usually in the range [0;1]
+     * 
+     * if val was retrieved from pitch_bend then [-0.5;0.5]
+     */
+    const fluid_real_t val_norm = val / range;
+    
     /* we could also only switch case the lower nibble of mod_flags, however
      * this would keep us from adding further mod types in the future
      * 
@@ -215,52 +226,56 @@ fluid_mod_transform_source_value(fluid_real_t val, unsigned char mod_flags, cons
     switch (mod_flags/* & 0x0f*/)
     {
     case FLUID_MOD_LINEAR | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE: /* =0 */
-      val /= range;
+      val = val_norm;
       break;
     case FLUID_MOD_LINEAR | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* =1 */
-      val = 1.0f - val / range;
+      val = 1.0f - val_norm;
       break;
     case FLUID_MOD_LINEAR | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* =2 */
-      val = -1.0f + 2.0f * val / range;
+      val = -1.0f + 2.0f * val_norm;
       break;
     case FLUID_MOD_LINEAR | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* =3 */
-      val = 1.0f - 2.0f * val / range;
+      val = 1.0f - 2.0f * val_norm;
       break;
     case FLUID_MOD_CONCAVE | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE: /* =4 */
-      val = fluid_concave(val);
+      val = fluid_concave(127 * (val_norm));
       break;
     case FLUID_MOD_CONCAVE | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* =5 */
-      val = fluid_concave(127 - val);
+      val = fluid_concave(127 * (1.0f - val_norm));
       break;
     case FLUID_MOD_CONCAVE | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* =6 */
-      val = (val > 64)? fluid_concave(2 * (val - 64)) : -fluid_concave(2 * (64 - val));
+      val = (val_norm > 0.5f) ?  fluid_concave(127 * 2 * (val_norm - 0.5f)) 
+                              : -fluid_concave(127 * 2 * (0.5f - val_norm));
       break;
     case FLUID_MOD_CONCAVE | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* =7 */
-      val = (val > 64)? -fluid_concave(2 * (val - 64)) : fluid_concave(2 * (64 - val));
+      val = (val_norm > 0.5f) ? -fluid_concave(127 * 2 * (val_norm - 0.5f))
+                              :  fluid_concave(127 * 2 * (0.5f - val_norm));
       break;
     case FLUID_MOD_CONVEX | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE: /* =8 */
-      val = fluid_convex(val);
+      val = fluid_convex(127 * (val_norm));
       break;
     case FLUID_MOD_CONVEX | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* =9 */
-      val = fluid_convex(127 - val);
+      val = fluid_convex(127 * (1.0f - val_norm));
       break;
     case FLUID_MOD_CONVEX | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* =10 */
-      val = (val > 64)? fluid_convex(2 * (val - 64)) : -fluid_convex(2 * (64 - val));
+      val = (val_norm > 0.5f) ?  fluid_convex(127 * 2 * (val_norm - 0.5f)) 
+                              : -fluid_convex(127 * 2 * (0.5f - val_norm));
       break;
     case FLUID_MOD_CONVEX | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* =11 */
-      val = (val > 64)? -fluid_convex(2 * (val - 64)) : fluid_convex(2 * (64 - val));
+      val = (val_norm > 0.5f) ? -fluid_convex(127 * 2 * (val_norm - 0.5f))
+                              :  fluid_convex(127 * 2 * (0.5f - val_norm));
       break;
     case FLUID_MOD_SWITCH | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE: /* =12 */
-      val = (val >= 64)? 1.0f : 0.0f;
+      val = (val_norm >= 0.5f)? 1.0f : 0.0f;
       break;
     case FLUID_MOD_SWITCH | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* =13 */
-      val = (val >= 64)? 0.0f : 1.0f;
+      val = (val_norm >= 0.5f)? 0.0f : 1.0f;
       break;
     case FLUID_MOD_SWITCH | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* =14 */
-      val = (val >= 64)? 1.0f : -1.0f;
+      val = (val_norm >= 0.5f)? 1.0f : -1.0f;
       break;
     case FLUID_MOD_SWITCH | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* =15 */
-      val = (val >= 64)? -1.0f : 1.0f;
+      val = (val_norm >= 0.5f)? -1.0f : 1.0f;
       break;
     default:
       FLUID_LOG(FLUID_ERR, "Unknown modulator type %d, disabling modulator.", mod_flags);

--- a/fluidsynth/src/synth/fluid_mod.c
+++ b/fluidsynth/src/synth/fluid_mod.c
@@ -198,6 +198,7 @@ fluid_mod_get_source_value(const unsigned char mod_src,
             val = fluid_channel_get_pitch_wheel_sensitivity (chan);
             break;
         default:
+	    FLUID_LOG(FLUID_ERR, "Unknown modulator source '%d', disabling modulator.", mod_src);
             val = 0.0;
         }
     }
@@ -278,7 +279,7 @@ fluid_mod_transform_source_value(fluid_real_t val, unsigned char mod_flags, cons
       val = (val_norm >= 0.5f)? -1.0f : 1.0f;
       break;
     default:
-      FLUID_LOG(FLUID_ERR, "Unknown modulator type %d, disabling modulator.", mod_flags);
+      FLUID_LOG(FLUID_ERR, "Unknown modulator type '%d', disabling modulator.", mod_flags);
       val = 0.0f;
       break;
     }

--- a/fluidsynth/src/synth/fluid_voice.c
+++ b/fluidsynth/src/synth/fluid_voice.c
@@ -1330,13 +1330,14 @@ fluid_voice_add_mod(fluid_voice_t* voice, fluid_mod_t* mod, int mode)
    */
 
   if (((mod->flags1 & FLUID_MOD_CC) == 0)
-      && ((mod->src1 != 0)          /* SF2.01 section 8.2.1: Constant value */
-	  && (mod->src1 != 2)       /* Note-on velocity */
-	  && (mod->src1 != 3)       /* Note-on key number */
-	  && (mod->src1 != 10)      /* Poly pressure */
-	  && (mod->src1 != 13)      /* Channel pressure */
-	  && (mod->src1 != 14)      /* Pitch wheel */
-	  && (mod->src1 != 16))) {  /* Pitch wheel sensitivity */
+      && ((mod->src1 != FLUID_MOD_NONE)            /* SF2.01 section 8.2.1: Constant value */
+       && (mod->src1 != FLUID_MOD_VELOCITY)        /* Note-on velocity */
+       && (mod->src1 != FLUID_MOD_KEY)             /* Note-on key number */
+       && (mod->src1 != FLUID_MOD_KEYPRESSURE)     /* Poly pressure */
+       && (mod->src1 != FLUID_MOD_CHANNELPRESSURE) /* Channel pressure */
+       && (mod->src1 != FLUID_MOD_PITCHWHEEL)      /* Pitch wheel */
+       && (mod->src1 != FLUID_MOD_PITCHWHEELSENS)))/* Pitch wheel sensitivity */
+  {
     FLUID_LOG(FLUID_WARN, "Ignoring invalid controller, using non-CC source %i.", mod->src1);
     return;
   }

--- a/fluidsynth/src/synth/fluid_voice.c
+++ b/fluidsynth/src/synth/fluid_voice.c
@@ -1371,6 +1371,10 @@ fluid_voice_add_mod(fluid_voice_t* voice, fluid_mod_t* mod, int mode)
   if (voice->mod_count < FLUID_NUM_MOD) {
     fluid_mod_clone(&voice->mod[voice->mod_count++], mod);
   }
+  else
+  {
+    FLUID_LOG(FLUID_WARN, "Voice %i has more modulators than supported, ignoring.", voice->id);
+  }
 }
 
 /**


### PR DESCRIPTION
Refactors the calculation and treatment of modulators:

* fixes incorrect convex and biploar linear calculations for source2
* fixes calculations if pitchbend used as (non-linear) source