### PR TITLE
fluid_settings: fix alignment warnings

### DIFF
--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -42,11 +42,6 @@ static int fluid_settings_tokenize(const char *s, char *buf, char **ptr);
 
 /* Common structure to all settings nodes */
 typedef struct {
-  int type;             /**< fluid_types_enum */
-} fluid_setting_node_t; 
-
-typedef struct {
-  fluid_setting_node_t node;
   char* value;
   char* def;
   int hints;
@@ -56,7 +51,6 @@ typedef struct {
 } fluid_str_setting_t;
 
 typedef struct {
-  fluid_setting_node_t node;
   double value;
   double def;
   double min;
@@ -67,7 +61,6 @@ typedef struct {
 } fluid_num_setting_t;
 
 typedef struct {
-  fluid_setting_node_t node;
   int value;
   int def;
   int min;
@@ -78,152 +71,184 @@ typedef struct {
 } fluid_int_setting_t;
 
 typedef struct {
-  fluid_setting_node_t node;
   fluid_hashtable_t *hashtable;
 } fluid_set_setting_t;
 
+typedef struct {
+  int type;             /**< fluid_types_enum */
+  
+  union
+  {
+      fluid_str_setting_t str;
+      fluid_num_setting_t num;
+      fluid_int_setting_t i;
+      fluid_set_setting_t set;
+  };
+} fluid_setting_node_t;
 
-static fluid_str_setting_t*
+static fluid_setting_node_t*
 new_fluid_str_setting(const char* value, const char* def, int hints, fluid_str_update_t fun, void* data)
 {
+  fluid_setting_node_t* node;
   fluid_str_setting_t* str;
+  
+  node = FLUID_NEW(fluid_setting_node_t);
 
-  str = FLUID_NEW(fluid_str_setting_t);
-
-  if (!str)
+  if (!node)
   {
     FLUID_LOG(FLUID_ERR, "Out of memory");
     return NULL;
   }
 
-  str->node.type = FLUID_STR_TYPE;
+  node->type = FLUID_STR_TYPE;
+  str = &node->str;
+  
   str->value = value? FLUID_STRDUP(value) : NULL;
   str->def = def? FLUID_STRDUP(def) : NULL;
   str->hints = hints;
   str->options = NULL;
   str->update = fun;
   str->data = data;
-  return str;
+  return node;
 }
 
 static void
-delete_fluid_str_setting(fluid_str_setting_t* str)
+delete_fluid_str_setting(fluid_setting_node_t* node)
 {
-  if (!str) return;
+  if (!node) return;
+  
+  FLUID_ASSERT(node->type, FLUID_STR_TYPE);
 
-  if (str->value) FLUID_FREE(str->value);
-  if (str->def) FLUID_FREE(str->def);
+  FLUID_FREE(node->str.value);
+  FLUID_FREE(node->str.def);
 
-  if (str->options) {
-    fluid_list_t* list = str->options;
+  if (node->str.options) {
+    fluid_list_t* list = node->str.options;
 
     while (list) {
       FLUID_FREE (list->data);
       list = fluid_list_next(list);
     }
 
-    delete_fluid_list(str->options);
+    delete_fluid_list(node->str.options);
   }
 
-  FLUID_FREE(str);
+  FLUID_FREE(node);
 }
 
 
-static fluid_num_setting_t*
+static fluid_setting_node_t*
 new_fluid_num_setting(double min, double max, double def,
 		     int hints, fluid_num_update_t fun, void* data)
 {
-  fluid_num_setting_t* setting;
+  fluid_setting_node_t* node;
+  fluid_num_setting_t* num;
 
-  setting = FLUID_NEW(fluid_num_setting_t);
+  node = FLUID_NEW(fluid_setting_node_t);
 
-  if (!setting)
+  if (!node)
   {
     FLUID_LOG(FLUID_ERR, "Out of memory");
     return NULL;
   }
 
-  setting->node.type = FLUID_NUM_TYPE;
-  setting->value = def;
-  setting->def = def;
-  setting->min = min;
-  setting->max = max;
-  setting->hints = hints;
-  setting->update = fun;
-  setting->data = data;
-  return setting;
+  node->type = FLUID_NUM_TYPE;
+  num = &node->num;
+  
+  num->value = def;
+  num->def = def;
+  num->min = min;
+  num->max = max;
+  num->hints = hints;
+  num->update = fun;
+  num->data = data;
+  
+  return node;
 }
 
 static void
-delete_fluid_num_setting(fluid_num_setting_t* setting)
+delete_fluid_num_setting(fluid_setting_node_t* node)
 {
-  if (setting) FLUID_FREE(setting);
+  if (!node) return;
+  
+  FLUID_ASSERT (node->type, FLUID_NUM_TYPE);
+  FLUID_FREE(node);
 }
 
-static fluid_int_setting_t*
+static fluid_setting_node_t*
 new_fluid_int_setting(int min, int max, int def,
 		     int hints, fluid_int_update_t fun, void* data)
 {
-  fluid_int_setting_t* setting;
+  fluid_setting_node_t* node;
+  fluid_int_setting_t* i;
 
-  setting = FLUID_NEW(fluid_int_setting_t);
+  node = FLUID_NEW(fluid_setting_node_t);
 
-  if (!setting)
+  if (!node)
   {
     FLUID_LOG(FLUID_ERR, "Out of memory");
     return NULL;
   }
 
-  setting->node.type = FLUID_INT_TYPE;
-  setting->value = def;
-  setting->def = def;
-  setting->min = min;
-  setting->max = max;
-  setting->hints = hints;
-  setting->update = fun;
-  setting->data = data;
-  return setting;
+  node->type = FLUID_INT_TYPE;
+  i = &node->i;
+  
+  i->value = def;
+  i->def = def;
+  i->min = min;
+  i->max = max;
+  i->hints = hints;
+  i->update = fun;
+  i->data = data;
+  return node;
 }
 
 static void
-delete_fluid_int_setting(fluid_int_setting_t* setting)
+delete_fluid_int_setting(fluid_setting_node_t* node)
 {
-  if (setting) FLUID_FREE(setting);
+  if (!node) return;
+  
+  FLUID_ASSERT (node->type, FLUID_INT_TYPE);
+  FLUID_FREE(node);
 }
 
-static fluid_set_setting_t*
+static fluid_setting_node_t*
 new_fluid_set_setting(void)
 {
-  fluid_set_setting_t* setting;
+  fluid_setting_node_t* node;
+  fluid_set_setting_t* set;
 
-  setting = FLUID_NEW(fluid_set_setting_t);
+  node = FLUID_NEW(fluid_setting_node_t);
 
-  if (!setting)
+  if (!node)
   {
     FLUID_LOG(FLUID_ERR, "Out of memory");
     return NULL;
   }
 
-  setting->node.type = FLUID_SET_TYPE;
-  setting->hashtable = new_fluid_hashtable_full(fluid_str_hash, fluid_str_equal,
+  node->type = FLUID_SET_TYPE;
+  set = &node->set;
+  
+  set->hashtable = new_fluid_hashtable_full(fluid_str_hash, fluid_str_equal,
                                                 fluid_settings_key_destroy_func,
                                                 fluid_settings_value_destroy_func);
-  if (!setting->hashtable)
+  if (!set->hashtable)
   {
-    FLUID_FREE (setting);
+    FLUID_FREE (node);
     return NULL;
   }
 
-  return setting;
+  return node;
 }
 
 static void
-delete_fluid_set_setting(fluid_set_setting_t* setting)
+delete_fluid_set_setting(fluid_setting_node_t* node)
 {
-  if (setting)
+  if (node)
   {
-    delete_fluid_hashtable(setting->hashtable);
-    FLUID_FREE(setting);
+    FLUID_ASSERT (node->type, FLUID_SET_TYPE);
+    delete_fluid_hashtable(node->set.hashtable);
+    FLUID_FREE(node);
   }
 }
 
@@ -274,16 +299,16 @@ fluid_settings_value_destroy_func(void* value)
 
   switch (node->type) {
   case FLUID_NUM_TYPE:
-    delete_fluid_num_setting((fluid_num_setting_t*) value);
+    delete_fluid_num_setting(node);
     break;
   case FLUID_INT_TYPE:
-    delete_fluid_int_setting((fluid_int_setting_t*) value);
+    delete_fluid_int_setting(node);
     break;
   case FLUID_STR_TYPE:
-    delete_fluid_str_setting((fluid_str_setting_t*) value);
+    delete_fluid_str_setting(node);
     break;
   case FLUID_SET_TYPE:
-    delete_fluid_set_setting((fluid_set_setting_t*) value);
+    delete_fluid_set_setting(node);
     break;
   }
 }
@@ -359,7 +384,7 @@ fluid_settings_get(fluid_settings_t* settings, const char *name,
     node = fluid_hashtable_lookup(table, tokens[n]);
     if (!node) return FLUID_FAILED;
 
-    table = (node->type == FLUID_SET_TYPE) ? ((fluid_set_setting_t *)node)->hashtable : NULL;
+    table = (node->type == FLUID_SET_TYPE) ? node->set.hashtable : NULL;
   }
 
   if (value) *value = node;
@@ -376,7 +401,7 @@ fluid_settings_get(fluid_settings_t* settings, const char *name,
  * @return #FLUID_OK if the value has been set, #FLUID_FAILED otherwise
  */
 static int
-fluid_settings_set(fluid_settings_t* settings, const char *name, void* value)
+fluid_settings_set(fluid_settings_t* settings, const char *name, fluid_setting_node_t* value)
 {
   fluid_hashtable_t* table = settings;
   fluid_setting_node_t *node;
@@ -396,7 +421,7 @@ fluid_settings_set(fluid_settings_t* settings, const char *name, void* value)
     if (node) {
 
       if (node->type == FLUID_SET_TYPE) {
-	table = ((fluid_set_setting_t *)node)->hashtable;
+	table = node->set.hashtable;
       } else {
 	/* path ends prematurely */
 	FLUID_LOG(FLUID_WARN, "'%s' is not a node", name[n]);
@@ -405,7 +430,7 @@ fluid_settings_set(fluid_settings_t* settings, const char *name, void* value)
 
     } else {
       /* create a new node */
-      fluid_set_setting_t* setnode;
+      fluid_setting_node_t* setnode;
 
       dupname = FLUID_STRDUP (tokens[n]);
       setnode = new_fluid_set_setting ();
@@ -421,7 +446,7 @@ fluid_settings_set(fluid_settings_t* settings, const char *name, void* value)
       }
 
       fluid_hashtable_insert(table, dupname, setnode);
-      table = setnode->hashtable;
+      table = setnode->set.hashtable;
     }
   }
 
@@ -454,7 +479,6 @@ fluid_settings_register_str(fluid_settings_t* settings, const char* name, const 
 			    fluid_str_update_t fun, void* data)
 {
   fluid_setting_node_t *node;
-  fluid_str_setting_t* setting;
   int retval = FLUID_FAILED;
 
   fluid_return_val_if_fail (settings != NULL, retval);
@@ -464,13 +488,13 @@ fluid_settings_register_str(fluid_settings_t* settings, const char* name, const 
   fluid_rec_mutex_lock (settings->mutex);
 
   if (fluid_settings_get(settings, name, &node) != FLUID_OK) {
-    setting = new_fluid_str_setting(def, def, hints, fun, data);
-    retval = fluid_settings_set(settings, name, setting);
-    if (retval != FLUID_OK) delete_fluid_str_setting (setting);
+    node = new_fluid_str_setting(def, def, hints, fun, data);
+    retval = fluid_settings_set(settings, name, node);
+    if (retval != FLUID_OK) delete_fluid_str_setting (node);
   } else {
     /* if variable already exists, don't change its value. */
     if (node->type == FLUID_STR_TYPE) {
-      setting = (fluid_str_setting_t*) node;
+      fluid_str_setting_t* setting = &node->str;
       setting->update = fun;
       setting->data = data;
       setting->def = def? FLUID_STRDUP(def) : NULL;
@@ -518,14 +542,13 @@ fluid_settings_register_num(fluid_settings_t* settings, const char* name, double
 
   if (fluid_settings_get(settings, name, &node) != FLUID_OK) {
     /* insert a new setting */
-    fluid_num_setting_t* setting;
-    setting = new_fluid_num_setting(min, max, def, hints, fun, data);
-    retval = fluid_settings_set(settings, name, setting);
-    if (retval != FLUID_OK) delete_fluid_num_setting (setting);
+    node = new_fluid_num_setting(min, max, def, hints, fun, data);
+    retval = fluid_settings_set(settings, name, node);
+    if (retval != FLUID_OK) delete_fluid_num_setting (node);
   } else {
     if (node->type == FLUID_NUM_TYPE) {
       /* update the existing setting but don't change its value */
-      fluid_num_setting_t* setting = (fluid_num_setting_t*) node;
+      fluid_num_setting_t* setting = &node->num;
       setting->update = fun;
       setting->data = data;
       setting->min = min;
@@ -576,14 +599,13 @@ fluid_settings_register_int(fluid_settings_t* settings, const char* name, int de
 
   if (fluid_settings_get(settings, name, &node) != FLUID_OK) {
     /* insert a new setting */
-    fluid_int_setting_t* setting;
-    setting = new_fluid_int_setting(min, max, def, hints, fun, data);
-    retval = fluid_settings_set(settings, name, setting);
-    if (retval != FLUID_OK) delete_fluid_int_setting (setting);
+    node = new_fluid_int_setting(min, max, def, hints, fun, data);
+    retval = fluid_settings_set(settings, name, node);
+    if (retval != FLUID_OK) delete_fluid_int_setting (node);
   } else {
     if (node->type == FLUID_INT_TYPE) {
       /* update the existing setting but don't change its value */
-      fluid_int_setting_t* setting = (fluid_int_setting_t*) node;
+      fluid_int_setting_t* setting = &node->i;
       setting->update = fun;
       setting->data = data;
       setting->min = min;
@@ -650,15 +672,15 @@ fluid_settings_get_hints(fluid_settings_t* settings, const char *name, int* hint
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK) {
     if (node->type == FLUID_NUM_TYPE) {
-      fluid_num_setting_t* setting = (fluid_num_setting_t*) node;
+      fluid_num_setting_t* setting = &node->num;
       *hints = setting->hints;
       retval = FLUID_OK;
     } else if (node->type == FLUID_STR_TYPE) {
-      fluid_str_setting_t* setting = (fluid_str_setting_t*) node;
+      fluid_str_setting_t* setting = &node->str;
       *hints = setting->hints;
       retval = FLUID_OK;
     } else if (node->type == FLUID_INT_TYPE) {
-      fluid_int_setting_t* setting = (fluid_int_setting_t*) node;
+      fluid_int_setting_t* setting = &node->i;
       *hints = setting->hints;
       retval = FLUID_OK;
     }
@@ -690,13 +712,13 @@ fluid_settings_is_realtime(fluid_settings_t* settings, const char *name)
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK) {
     if (node->type == FLUID_NUM_TYPE) {
-      fluid_num_setting_t* setting = (fluid_num_setting_t*) node;
+      fluid_num_setting_t* setting = &node->num;
       isrealtime = setting->update != NULL;
     } else if (node->type == FLUID_STR_TYPE) {
-      fluid_str_setting_t* setting = (fluid_str_setting_t*) node;
+      fluid_str_setting_t* setting = &node->str;
       isrealtime = setting->update != NULL;
     } else if (node->type == FLUID_INT_TYPE) {
-      fluid_int_setting_t* setting = (fluid_int_setting_t*) node;
+      fluid_int_setting_t* setting = &node->i;
       isrealtime = setting->update != NULL;
     }
   }
@@ -728,7 +750,7 @@ fluid_settings_setstr(fluid_settings_t* settings, const char *name, const char *
 
   if (fluid_settings_get (settings, name, &node) == FLUID_OK) {
     if (node->type == FLUID_STR_TYPE) {
-      fluid_str_setting_t *setting = (fluid_str_setting_t *)node;
+      fluid_str_setting_t *setting = &node->str;
 
       if (setting->value) FLUID_FREE (setting->value);
       setting->value = str ? FLUID_STRDUP (str) : NULL;
@@ -739,7 +761,7 @@ fluid_settings_setstr(fluid_settings_t* settings, const char *name, const char *
     }
     else if (node->type == FLUID_INT_TYPE)      /* Handle yes/no for boolean values for backwards compatibility */
     {
-      fluid_int_setting_t *setting = (fluid_int_setting_t *)node;
+      fluid_int_setting_t *setting = &node->i;
 
       if (setting->hints & FLUID_HINT_TOGGLED)
       {
@@ -759,10 +781,9 @@ fluid_settings_setstr(fluid_settings_t* settings, const char *name, const char *
     }
   } else {
     /* insert a new setting */
-    fluid_str_setting_t* setting;
-    setting = new_fluid_str_setting(str, NULL, 0, NULL, NULL);
-    retval = fluid_settings_set(settings, name, setting);
-    if (retval != FLUID_OK) delete_fluid_str_setting (setting);
+    node = new_fluid_str_setting(str, NULL, 0, NULL, NULL);
+    retval = fluid_settings_set(settings, name, node);
+    if (retval != FLUID_OK) delete_fluid_str_setting (node);
   }
 
   fluid_rec_mutex_unlock (settings->mutex);
@@ -803,7 +824,7 @@ fluid_settings_copystr(fluid_settings_t* settings, const char *name,
   {
     if (node->type == FLUID_STR_TYPE)
     {
-      fluid_str_setting_t *setting = (fluid_str_setting_t *)node;
+      fluid_str_setting_t *setting = &node->str;
 
       if (setting->value)
       {
@@ -815,7 +836,7 @@ fluid_settings_copystr(fluid_settings_t* settings, const char *name,
     }
     else if (node->type == FLUID_INT_TYPE)      /* Handle boolean integers for backwards compatibility */
     {
-      fluid_int_setting_t *setting = (fluid_int_setting_t *)node;
+      fluid_int_setting_t *setting = &node->i;
 
       if (setting->hints & FLUID_HINT_TOGGLED)
       {
@@ -860,7 +881,7 @@ fluid_settings_dupstr(fluid_settings_t* settings, const char *name, char** str)
   {
     if (node->type == FLUID_STR_TYPE)
     {
-      fluid_str_setting_t *setting = (fluid_str_setting_t *)node;
+      fluid_str_setting_t *setting = &node->str;
 
       if (setting->value)
       {
@@ -872,7 +893,7 @@ fluid_settings_dupstr(fluid_settings_t* settings, const char *name, char** str)
     }
     else if (node->type == FLUID_INT_TYPE)      /* Handle boolean integers for backwards compatibility */
     {
-      fluid_int_setting_t *setting = (fluid_int_setting_t *)node;
+      fluid_int_setting_t *setting = &node->i;
 
       if (setting->hints & FLUID_HINT_TOGGLED)
       {
@@ -915,13 +936,13 @@ fluid_settings_str_equal (fluid_settings_t* settings, const char *name, const ch
   {
     if (node->type == FLUID_STR_TYPE)
     {
-      fluid_str_setting_t *setting = (fluid_str_setting_t *)node;
+      fluid_str_setting_t *setting = &node->str;
       if (setting->value)
           retval = FLUID_STRCMP (setting->value, s) == 0;
     }
     else if (node->type == FLUID_INT_TYPE)      /* Handle boolean integers for backwards compatibility */
     {
-      fluid_int_setting_t *setting = (fluid_int_setting_t *)node;
+      fluid_int_setting_t *setting = &node->i;
 
       if (setting->hints & FLUID_HINT_TOGGLED)
           retval = FLUID_STRCMP (setting->value ? "yes" : "no", s) == 0;
@@ -957,12 +978,12 @@ fluid_settings_getstr_default(fluid_settings_t* settings, const char *name)
   {
     if (node->type == FLUID_STR_TYPE)
     {
-      fluid_str_setting_t* setting = (fluid_str_setting_t*) node;
+      fluid_str_setting_t* setting = &node->str;
       retval = setting->def;
     }
     else if (node->type == FLUID_INT_TYPE)      /* Handle boolean integers for backwards compatibility */
     {
-      fluid_int_setting_t *setting = (fluid_int_setting_t *)node;
+      fluid_int_setting_t *setting = &node->i;
 
       if (setting->hints & FLUID_HINT_TOGGLED)
         retval = setting->def ? "yes" : "no";
@@ -998,7 +1019,7 @@ fluid_settings_add_option(fluid_settings_t* settings, const char *name, const ch
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && (node->type == FLUID_STR_TYPE)) {
-    fluid_str_setting_t* setting = (fluid_str_setting_t*) node;
+    fluid_str_setting_t* setting = &node->str;
     char* copy = FLUID_STRDUP(s);
     setting->options = fluid_list_append(setting->options, copy);
     setting->hints |= FLUID_HINT_OPTIONLIST;
@@ -1033,7 +1054,7 @@ fluid_settings_remove_option(fluid_settings_t* settings, const char *name, const
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && (node->type == FLUID_STR_TYPE)) {
 
-    fluid_str_setting_t* setting = (fluid_str_setting_t*) node;
+    fluid_str_setting_t* setting = &node->str;
     fluid_list_t* list = setting->options;
 
     while (list) {
@@ -1065,7 +1086,6 @@ int
 fluid_settings_setnum(fluid_settings_t* settings, const char *name, double val)
 {
   fluid_setting_node_t *node;
-  fluid_num_setting_t* setting;
   int retval = FLUID_FAILED;
 
   fluid_return_val_if_fail (settings != NULL, retval);
@@ -1076,7 +1096,7 @@ fluid_settings_setnum(fluid_settings_t* settings, const char *name, double val)
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK) {
     if (node->type == FLUID_NUM_TYPE) {
-      setting = (fluid_num_setting_t*) node;
+      fluid_num_setting_t* setting = &node->num;
 
       if (val < setting->min) val = setting->min;
       else if (val > setting->max) val = setting->max;
@@ -1089,11 +1109,10 @@ fluid_settings_setnum(fluid_settings_t* settings, const char *name, double val)
     }
   } else {
     /* insert a new setting */
-    fluid_num_setting_t* setting;
-    setting = new_fluid_num_setting(-1e10, 1e10, 0.0f, 0, NULL, NULL);
-    setting->value = val;
-    retval = fluid_settings_set(settings, name, setting);
-    if (retval != FLUID_OK) delete_fluid_num_setting (setting);
+    node = new_fluid_num_setting(-1e10, 1e10, 0.0f, 0, NULL, NULL);
+    node->num.value = val;
+    retval = fluid_settings_set(settings, name, node);
+    if (retval != FLUID_OK) delete_fluid_num_setting (node);
   }
 
   fluid_rec_mutex_unlock (settings->mutex);
@@ -1124,7 +1143,7 @@ fluid_settings_getnum(fluid_settings_t* settings, const char *name, double* val)
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && (node->type == FLUID_NUM_TYPE)) {
-    fluid_num_setting_t* setting = (fluid_num_setting_t*) node;
+    fluid_num_setting_t* setting = &node->num;
     *val = setting->value;
     retval = FLUID_OK;
   }
@@ -1160,7 +1179,7 @@ fluid_settings_getnum_range(fluid_settings_t* settings, const char *name,
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && (node->type == FLUID_NUM_TYPE)) {
-    fluid_num_setting_t* setting = (fluid_num_setting_t*) node;
+    fluid_num_setting_t* setting = &node->num;
     *min = setting->min;
     *max = setting->max;
     retval = FLUID_OK;
@@ -1194,7 +1213,7 @@ fluid_settings_getnum_default(fluid_settings_t* settings, const char *name, doub
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && (node->type == FLUID_NUM_TYPE)) {
-    fluid_num_setting_t* setting = (fluid_num_setting_t*) node;
+    fluid_num_setting_t* setting = &node->num;
     *val = setting->def;
     retval = FLUID_OK;
   }
@@ -1216,7 +1235,6 @@ int
 fluid_settings_setint(fluid_settings_t* settings, const char *name, int val)
 {
   fluid_setting_node_t *node;
-  fluid_int_setting_t* setting;
   int retval = FLUID_FAILED;
 
   fluid_return_val_if_fail (settings != NULL, retval);
@@ -1227,7 +1245,7 @@ fluid_settings_setint(fluid_settings_t* settings, const char *name, int val)
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK) {
     if (node->type == FLUID_INT_TYPE) {
-      setting = (fluid_int_setting_t*) node;
+      fluid_int_setting_t* setting = &node->i;
 
       if (val < setting->min) val = setting->min;
       else if (val > setting->max) val = setting->max;
@@ -1240,11 +1258,10 @@ fluid_settings_setint(fluid_settings_t* settings, const char *name, int val)
     }
   } else {
     /* insert a new setting */
-    fluid_int_setting_t* setting;
-    setting = new_fluid_int_setting(INT_MIN, INT_MAX, 0, 0, NULL, NULL);
-    setting->value = val;
-    retval = fluid_settings_set(settings, name, setting);
-    if (retval != FLUID_OK) delete_fluid_int_setting (setting);
+    node = new_fluid_int_setting(INT_MIN, INT_MAX, 0, 0, NULL, NULL);
+    node->i.value = val;
+    retval = fluid_settings_set(settings, name, node);
+    if (retval != FLUID_OK) delete_fluid_int_setting (node);
   }
 
   fluid_rec_mutex_unlock (settings->mutex);
@@ -1275,7 +1292,7 @@ fluid_settings_getint(fluid_settings_t* settings, const char *name, int* val)
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && (node->type == FLUID_INT_TYPE)) {
-    fluid_int_setting_t* setting = (fluid_int_setting_t*) node;
+    fluid_int_setting_t* setting = &node->i;
     *val = setting->value;
     retval = FLUID_OK;
   }
@@ -1310,7 +1327,7 @@ fluid_settings_getint_range(fluid_settings_t* settings, const char *name,
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && (node->type == FLUID_INT_TYPE)) {
-    fluid_int_setting_t* setting = (fluid_int_setting_t*) node;
+    fluid_int_setting_t* setting = &node->i;
     *min = setting->min;
     *max = setting->max;
     retval = FLUID_OK;
@@ -1343,7 +1360,7 @@ int fluid_settings_getint_default(fluid_settings_t* settings, const char *name, 
 
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && (node->type == FLUID_INT_TYPE)) {
-    fluid_int_setting_t* setting = (fluid_int_setting_t*) node;
+    fluid_int_setting_t* setting = &node->i;
     *val = setting->def;
     retval = FLUID_OK;
   }
@@ -1387,7 +1404,7 @@ fluid_settings_foreach_option (fluid_settings_t* settings, const char *name,
     return;
   }
 
-  setting = (fluid_str_setting_t*)node;
+  setting = &node->str;
 
   /* Duplicate option list */
   for (p = setting->options; p; p = p->next)
@@ -1425,7 +1442,7 @@ fluid_settings_option_count (fluid_settings_t *settings, const char *name)
   fluid_rec_mutex_lock (settings->mutex);
   if (fluid_settings_get(settings, name, &node) == FLUID_OK
       && node->type == FLUID_STR_TYPE)
-    count = fluid_list_size (((fluid_str_setting_t *)node)->options);
+    count = fluid_list_size (node->str.options);
   fluid_rec_mutex_unlock (settings->mutex);
 
   return (count);
@@ -1465,7 +1482,7 @@ fluid_settings_option_concat (fluid_settings_t *settings, const char *name,
     return (NULL);
   }
 
-  setting = (fluid_str_setting_t*)node;
+  setting = &node->str;
 
   /* Duplicate option list, count options and get total string length */
   for (p = setting->options, count = 0, len = 0; p; p = p->next, count++)
@@ -1541,7 +1558,7 @@ fluid_settings_foreach_iter (void* key, void* value, void* data)
     if (s) bag->names = fluid_list_append (bag->names, s);
     break;
   case FLUID_SET_TYPE:
-    fluid_hashtable_foreach(((fluid_set_setting_t *)value)->hashtable,
+    fluid_hashtable_foreach(node->set.hashtable,
                             fluid_settings_foreach_iter, bag);
     break;
   }


### PR DESCRIPTION
by using a union for `fluid_setting_node_t`