### PR TITLE
Activate LADSPA subsystem only if "synth.ladspa.active" is true 

### DIFF
--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -40,9 +40,13 @@
 #define L(x);
 
 fluid_LADSPA_FxUnit_t* new_fluid_LADSPA_FxUnit(fluid_synth_t* synth){
+  if(synth == NULL)
+    return NULL;
+
   fluid_LADSPA_FxUnit_t* FxUnit=FLUID_NEW(fluid_LADSPA_FxUnit_t);
-  assert(FxUnit);
-  assert(synth);
+  if(FxUnit == NULL)
+    return NULL;
+
   /* The default state is 'bypassed'. The Fx unit has to be turned on explicitly by the user. */
   /* Those settings have to be done in order to allow fluid_LADSPA_clean. */
   FxUnit->Bypass=fluid_LADSPA_Bypassed;

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -221,7 +221,11 @@ fluid_LADSPA_handle_start(fluid_synth_t* synth, int ac, char** av, fluid_ostream
 
   L(fluid_ostream_printf(out,"ladspa_start: starting..."));
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
 
   /* When calling fluid_ladspastart, the Fx unit must be 'cleared' (no plugins, no libs, no nodes). Verify this here. */
   if (FxUnit->NumberPlugins || FxUnit->NumberLibs){
@@ -990,7 +994,11 @@ int fluid_LADSPA_handle_add(fluid_synth_t* synth, int ac, char** av, fluid_ostre
   char ** CommandLine;
   fluid_LADSPA_FxUnit_t* FxUnit;
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
   if (ac>=FLUID_LADSPA_MaxTokens){
     /* Can't be tested. fluidsynth limits the number of tokens. */
     printf("***Error001***\n"
@@ -1036,7 +1044,11 @@ int fluid_LADSPA_handle_declnode(fluid_synth_t* synth, int ac, char** av, fluid_
   fluid_real_t NodeValue;
   fluid_LADSPA_FxUnit_t* FxUnit;
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
 
   if (ac<2){
     printf("***Error028***\n"
@@ -1067,7 +1079,11 @@ int fluid_LADSPA_handle_setnode(fluid_synth_t* synth, int ac, char** av, fluid_o
   fluid_LADSPA_FxUnit_t* FxUnit;
   fluid_LADSPA_Node_t* CurrentNode;
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
 
   if (ac!=2){
     printf("***Error029***\n"
@@ -1102,7 +1118,11 @@ int fluid_LADSPA_handle_setnode(fluid_synth_t* synth, int ac, char** av, fluid_o
 int fluid_LADSPA_handle_clear(fluid_synth_t* synth, int ac, char** av, fluid_ostream_t out){
   fluid_LADSPA_FxUnit_t* FxUnit;
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
   fluid_LADSPA_clear(FxUnit);
   return(FLUID_OK);
 };

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -555,7 +555,7 @@ new_fluid_synth(fluid_settings_t *settings)
   fluid_sfloader_t* loader;
   double gain;
   int i, nbuf;
-
+  int with_ladspa = 0;
   
   /* initialize all the conversion tables and other stuff */
   if (fluid_synth_initialized == 0)
@@ -694,8 +694,11 @@ new_fluid_synth(fluid_settings_t *settings)
 
 #ifdef LADSPA
   /* Create and initialize the Fx unit.*/
-  synth->LADSPA_FxUnit = new_fluid_LADSPA_FxUnit(synth);
-  fluid_rvoice_mixer_set_ladspa(synth->eventhandler->mixer, synth->LADSPA_FxUnit);
+  fluid_settings_getint(settings, "synth.ladspa.active", &with_ladspa);
+  if (with_ladspa) {
+    synth->LADSPA_FxUnit = new_fluid_LADSPA_FxUnit(synth);
+    fluid_rvoice_mixer_set_ladspa(synth->eventhandler->mixer, synth->LADSPA_FxUnit);
+  }
 #endif
   
   /* allocate and add the default sfont loader */
@@ -905,8 +908,10 @@ delete_fluid_synth(fluid_synth_t* synth)
 
 #ifdef LADSPA
   /* Release the LADSPA Fx unit */
-  fluid_LADSPA_shutdown(synth->LADSPA_FxUnit);
-  FLUID_FREE(synth->LADSPA_FxUnit);
+  if (synth->LADSPA_FxUnit) {
+    fluid_LADSPA_shutdown(synth->LADSPA_FxUnit);
+    FLUID_FREE(synth->LADSPA_FxUnit);
+  }
 #endif
 
   fluid_rec_mutex_destroy(synth->mutex);

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -697,6 +697,10 @@ new_fluid_synth(fluid_settings_t *settings)
   fluid_settings_getint(settings, "synth.ladspa.active", &with_ladspa);
   if (with_ladspa) {
     synth->LADSPA_FxUnit = new_fluid_LADSPA_FxUnit(synth);
+    if(synth->LADSPA_FxUnit == NULL) {
+      FLUID_LOG(FLUID_ERR, "Out of memory");
+      goto error_recovery;
+    }
     fluid_rvoice_mixer_set_ladspa(synth->eventhandler->mixer, synth->LADSPA_FxUnit);
   }
 #endif


### PR DESCRIPTION
When LADSPA support is enabled at compile time, the LADSPA machinery is *always* active. The "synth.ladspa.active" setting is not being used anywhere in the code.

This pull requests adds code to check synth.ladspa.active when a new synth is being created. It also adds checks in all ladspa command handlers to ensure that FluidSynth doesn't crash if any of those commands are used with an inactive LADSPA (i.e. without a valid synth->LADSPA_FxUnit).