### PR TITLE
LADSPA fixes

### DIFF
--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -40,9 +40,13 @@
 #define L(x);
 
 fluid_LADSPA_FxUnit_t* new_fluid_LADSPA_FxUnit(fluid_synth_t* synth){
+  if(synth == NULL)
+    return NULL;
+
   fluid_LADSPA_FxUnit_t* FxUnit=FLUID_NEW(fluid_LADSPA_FxUnit_t);
-  assert(FxUnit);
-  assert(synth);
+  if(FxUnit == NULL)
+    return NULL;
+
   /* The default state is 'bypassed'. The Fx unit has to be turned on explicitly by the user. */
   /* Those settings have to be done in order to allow fluid_LADSPA_clean. */
   FxUnit->Bypass=fluid_LADSPA_Bypassed;

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -68,19 +68,12 @@ void fluid_LADSPA_CreateSystemNodes(fluid_LADSPA_FxUnit_t* FxUnit){
   int nr_input_nodes;
   int nr_fx_input_nodes;
   int nr_output_nodes;
-  int temp;
   int i;
 
   /* Retrieve the number of synth / audio out / Fx send nodes */
-  assert(fluid_settings_getint(FxUnit->synth->settings, "synth.audio-groups", &temp) == FLUID_OK);
-  nr_input_nodes=(int) temp;
-  printf("%i audio groups\n", nr_input_nodes);
-
-  assert(fluid_settings_getint(FxUnit->synth->settings, "synth.audio-channels", &temp) == FLUID_OK);
-  nr_output_nodes=temp;
-
-  assert(fluid_settings_getint(FxUnit->synth->settings, "synth.effects-channels", &temp) == FLUID_OK);
-  nr_fx_input_nodes=temp;
+  nr_input_nodes = FxUnit->synth->audio_groups;
+  nr_output_nodes = FxUnit->synth->audio_channels;
+  nr_fx_input_nodes = FxUnit->synth->effects_channels;
 
   /* Create regular input nodes (associated with audio groups) */
   for (i=0; i < nr_input_nodes; i++){
@@ -714,17 +707,11 @@ fluid_LADSPA_run(fluid_LADSPA_FxUnit_t* FxUnit, fluid_real_t* left_buf[], fluid_
   int byte_size = FLUID_BUFSIZE * sizeof(fluid_real_t);
   char str[99];
   fluid_LADSPA_Node_t* n;
-  int temp;
 
   /* Retrieve the number of synth / audio out / Fx send nodes */
-  assert(fluid_settings_getint(FxUnit->synth->settings, "synth.audio-groups", &temp) == FLUID_OK);
-  nr_groups=(int) temp;
-
-  assert(fluid_settings_getint(FxUnit->synth->settings, "synth.audio-channels", &temp) == FLUID_OK);
-  nr_audio_channels=temp;
-
-  assert(fluid_settings_getint(FxUnit->synth->settings, "synth.effects-channels", &temp) == FLUID_OK);
-  nr_fx_sends=temp;
+  nr_groups = FxUnit->synth->audio_groups;
+  nr_audio_channels = FxUnit->synth->audio_channels;
+  nr_fx_sends = FxUnit->synth->effects_channels;
 
   /* Fixme: Retrieving nodes via names is inefficient
    * (but not that bad, because the interesting nodes are always at the start of the list).

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -221,7 +221,11 @@ fluid_LADSPA_handle_start(fluid_synth_t* synth, int ac, char** av, fluid_ostream
 
   L(fluid_ostream_printf(out,"ladspa_start: starting..."));
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
 
   /* When calling fluid_ladspastart, the Fx unit must be 'cleared' (no plugins, no libs, no nodes). Verify this here. */
   if (FxUnit->NumberPlugins || FxUnit->NumberLibs){
@@ -990,7 +994,11 @@ int fluid_LADSPA_handle_add(fluid_synth_t* synth, int ac, char** av, fluid_ostre
   char ** CommandLine;
   fluid_LADSPA_FxUnit_t* FxUnit;
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
   if (ac>=FLUID_LADSPA_MaxTokens){
     /* Can't be tested. fluidsynth limits the number of tokens. */
     printf("***Error001***\n"
@@ -1036,7 +1044,11 @@ int fluid_LADSPA_handle_declnode(fluid_synth_t* synth, int ac, char** av, fluid_
   fluid_real_t NodeValue;
   fluid_LADSPA_FxUnit_t* FxUnit;
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
 
   if (ac<2){
     printf("***Error028***\n"
@@ -1067,7 +1079,11 @@ int fluid_LADSPA_handle_setnode(fluid_synth_t* synth, int ac, char** av, fluid_o
   fluid_LADSPA_FxUnit_t* FxUnit;
   fluid_LADSPA_Node_t* CurrentNode;
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
 
   if (ac!=2){
     printf("***Error029***\n"
@@ -1102,7 +1118,11 @@ int fluid_LADSPA_handle_setnode(fluid_synth_t* synth, int ac, char** av, fluid_o
 int fluid_LADSPA_handle_clear(fluid_synth_t* synth, int ac, char** av, fluid_ostream_t out){
   fluid_LADSPA_FxUnit_t* FxUnit;
   assert(synth);
-  FxUnit=synth->LADSPA_FxUnit; assert(FxUnit);
+  FxUnit=synth->LADSPA_FxUnit;
+  if (!FxUnit) {
+    fluid_ostream_printf(out, "ladspa not active!\n");
+    return FLUID_FAILED;
+  }
   fluid_LADSPA_clear(FxUnit);
   return(FLUID_OK);
 };

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -858,8 +858,8 @@ fluid_LADSPA_CreateNode(fluid_LADSPA_FxUnit_t* FxUnit, char * Name, int flags){
     printf( "***Error026***\n"
 	    "The node name %s starts with a digit / minus sign!\n"
 	    "Please use a letter to start a node name.\n"
-	    "A constant node is created by using `#' as first character,\n"
-	    "for example #-2.5.\n",
+	    "A constant node is created by using `$' as first character,\n"
+	    "for example $-2.5.\n",
 	    Name);
     fluid_LADSPA_clear(FxUnit);
     return NULL;
@@ -889,8 +889,8 @@ fluid_LADSPA_CreateNode(fluid_LADSPA_FxUnit_t* FxUnit, char * Name, int flags){
   NewNode->OutCount=0;
   NewNode->flags=flags;
 
-  /* A nodename starting with "#" means that the node holds a constant value. */
-  if (NewNode->Name[0] == '#'){
+  /* A nodename starting with "$" means that the node holds a constant value. */
+  if (NewNode->Name[0] == '$'){
     assert(flags & fluid_LADSPA_node_is_control);
     /* Skip the first character => +1 */
     NewNode->buf[0]=(LADSPA_Data)atof(NewNode->Name+1);

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -704,7 +704,7 @@ fluid_LADSPA_run(fluid_LADSPA_FxUnit_t* FxUnit, fluid_real_t* left_buf[], fluid_
   int nr_audio_channels;
   int nr_fx_sends;
   int nr_groups;
-  int byte_size = FLUID_BUFSIZE * sizeof(fluid_real_t);
+  int byte_size = FLUID_BUFSIZE * sizeof(LADSPA_Data);
   char str[99];
   fluid_LADSPA_Node_t* n;
 

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -92,7 +92,7 @@ void fluid_LADSPA_CreateSystemNodes(fluid_LADSPA_FxUnit_t* FxUnit){
   };
 
   /* Create output nodes (usually towards the sound card) */
-  for (i=0; i < nr_input_nodes; i++){
+  for (i=0; i < nr_output_nodes; i++){
       sprintf(str, "out%i_L",(i+1));
       fluid_LADSPA_CreateNode(FxUnit, str, fluid_LADSPA_node_is_audio | fluid_LADSPA_node_is_sink);
       sprintf(str, "out%i_R",(i+1));

--- a/src/bindings/fluid_ladspa.h
+++ b/src/bindings/fluid_ladspa.h
@@ -122,7 +122,7 @@ typedef struct {
 
   /* List of Command lines
    * During the setup phase, each ladspa_add command creates one command sequence. For example:
-   * ./aw.so alienwah_stereo Input <- Master_L_Synth Output -> Master_R_Synth Parameter <- #42.0
+   * ./aw.so alienwah_stereo Input <- Master_L_Synth Output -> Master_R_Synth Parameter <- $42.0
    * Those lists are stored in LADSPA_Command_Sequence.
    * One command line results in one plugin => size MaxPlugins.
    */

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -555,7 +555,7 @@ new_fluid_synth(fluid_settings_t *settings)
   fluid_sfloader_t* loader;
   double gain;
   int i, nbuf;
-
+  int with_ladspa = 0;
   
   /* initialize all the conversion tables and other stuff */
   if (fluid_synth_initialized == 0)
@@ -694,8 +694,11 @@ new_fluid_synth(fluid_settings_t *settings)
 
 #ifdef LADSPA
   /* Create and initialize the Fx unit.*/
-  synth->LADSPA_FxUnit = new_fluid_LADSPA_FxUnit(synth);
-  fluid_rvoice_mixer_set_ladspa(synth->eventhandler->mixer, synth->LADSPA_FxUnit);
+  fluid_settings_getint(settings, "synth.ladspa.active", &with_ladspa);
+  if (with_ladspa) {
+    synth->LADSPA_FxUnit = new_fluid_LADSPA_FxUnit(synth);
+    fluid_rvoice_mixer_set_ladspa(synth->eventhandler->mixer, synth->LADSPA_FxUnit);
+  }
 #endif
   
   /* allocate and add the default sfont loader */
@@ -905,8 +908,10 @@ delete_fluid_synth(fluid_synth_t* synth)
 
 #ifdef LADSPA
   /* Release the LADSPA Fx unit */
-  fluid_LADSPA_shutdown(synth->LADSPA_FxUnit);
-  FLUID_FREE(synth->LADSPA_FxUnit);
+  if (synth->LADSPA_FxUnit) {
+    fluid_LADSPA_shutdown(synth->LADSPA_FxUnit);
+    FLUID_FREE(synth->LADSPA_FxUnit);
+  }
 #endif
 
   fluid_rec_mutex_destroy(synth->mutex);

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -697,6 +697,10 @@ new_fluid_synth(fluid_settings_t *settings)
   fluid_settings_getint(settings, "synth.ladspa.active", &with_ladspa);
   if (with_ladspa) {
     synth->LADSPA_FxUnit = new_fluid_LADSPA_FxUnit(synth);
+    if(synth->LADSPA_FxUnit == NULL) {
+      FLUID_LOG(FLUID_ERR, "Out of memory");
+      goto error_recovery;
+    }
     fluid_rvoice_mixer_set_ladspa(synth->eventhandler->mixer, synth->LADSPA_FxUnit);
   }
 #endif


### PR DESCRIPTION
This pull request contains some fixes (and one optimization) to the LADSPA subsystem that make it usable again. After these fixes, I could load a simple LADSPA plugin and hear the effects. There are quite a few additional optimizations that could (and should) be done to the code, but those are for another pull request :-)

Note that the "constant value node" char has changed from '#' to '$', as the command parser treats '#' as the start of a comment. So to load the simple delay.so plugin from the LADSPA sources and connect it to an output port, you could use a command like the following:

`ladspa_add /usr/lib/ladspa/delay.so delay_5s Input <- in1_L Output -> out1_L Output -> out1_R Delay <- $1.0 Dry <- $0.5`
`ladspa_start`
 

