### PR TITLE
Correct use of FLUID_INLINE in all sources.

### DIFF
--- a/src/rvoice/fluid_adsr_env.h
+++ b/src/rvoice/fluid_adsr_env.h
@@ -111,7 +111,7 @@ fluid_adsr_env_set_data(fluid_adsr_env_t* env,
                         fluid_real_t min,
                         fluid_real_t max);
 
-static inline void 
+static FLUID_INLINE void 
 fluid_adsr_env_reset(fluid_adsr_env_t* env)
 {
   env->count = 0;
@@ -119,25 +119,25 @@ fluid_adsr_env_reset(fluid_adsr_env_t* env)
   env->val = 0.0f;
 }
 
-static inline fluid_real_t 
+static FLUID_INLINE fluid_real_t 
 fluid_adsr_env_get_val(fluid_adsr_env_t* env)
 {
   return env->val;
 }
 
-static inline void
+static FLUID_INLINE void
 fluid_adsr_env_set_val(fluid_adsr_env_t* env, fluid_real_t val)
 {
   env->val = val;
 }
 
-static inline fluid_adsr_env_section_t
+static FLUID_INLINE fluid_adsr_env_section_t
 fluid_adsr_env_get_section(fluid_adsr_env_t* env)
 {
   return env->section;
 }
 
-static inline void 
+static FLUID_INLINE void 
 fluid_adsr_env_set_section(fluid_adsr_env_t* env, 
                            fluid_adsr_env_section_t section)
 {
@@ -148,7 +148,7 @@ fluid_adsr_env_set_section(fluid_adsr_env_t* env,
 /* Used for determining which voice to kill. 
    Returns max amplitude from now, and forward in time.
 */
-static inline fluid_real_t
+static FLUID_INLINE fluid_real_t
 fluid_adsr_env_get_max_val(fluid_adsr_env_t* env)
 {
   if (env->section > FLUID_VOICE_ENVATTACK){

--- a/src/rvoice/fluid_iir_filter.c
+++ b/src/rvoice/fluid_iir_filter.c
@@ -174,7 +174,7 @@ fluid_iir_filter_set_q_dB(fluid_iir_filter_t* iir_filter,
 }
 
 
-static inline void 
+static FLUID_INLINE void 
 fluid_iir_filter_calculate_coefficients(fluid_iir_filter_t* iir_filter, 
                                         int transition_samples, 
                                         fluid_real_t output_rate)

--- a/src/rvoice/fluid_lfo.h
+++ b/src/rvoice/fluid_lfo.h
@@ -31,7 +31,7 @@ struct _fluid_lfo_t {
 	fluid_real_t increment;         /* the lfo frequency is converted to a per-buffer increment */
 };
 
-static inline void 
+static FLUID_INLINE void 
 fluid_lfo_reset(fluid_lfo_t* lfo)
 {
   lfo->val = 0.0f;
@@ -41,13 +41,13 @@ fluid_lfo_reset(fluid_lfo_t* lfo)
 void fluid_lfo_set_incr(fluid_lfo_t* lfo, fluid_real_t increment);
 void fluid_lfo_set_delay(fluid_lfo_t* lfo, unsigned int delay);
 
-static inline fluid_real_t
+static FLUID_INLINE fluid_real_t
 fluid_lfo_get_val(fluid_lfo_t* lfo)
 {
   return lfo->val;
 }
 
-static inline void 
+static FLUID_INLINE void 
 fluid_lfo_calc(fluid_lfo_t* lfo, unsigned int cur_delay)
 {
   if (cur_delay < lfo->delay) 

--- a/src/rvoice/fluid_lfo.h
+++ b/src/rvoice/fluid_lfo.h
@@ -21,7 +21,7 @@
 #ifndef _FLUID_LFO_H
 #define _FLUID_LFO_H
 
-#include "fluidsynth_priv.h"
+#include "fluid_sys.h"
 
 typedef struct _fluid_lfo_t fluid_lfo_t;
 

--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -25,7 +25,7 @@
 /**
  * @return -1 if voice has finished, 0 if it's currently quiet, 1 otherwise
  */
-static inline int
+static FLUID_INLINE int
 fluid_rvoice_calc_amp(fluid_rvoice_t* voice)
 {
   fluid_real_t target_amp;	/* target amplitude */
@@ -371,7 +371,7 @@ fluid_rvoice_write (fluid_rvoice_t* voice, fluid_real_t *dsp_buf)
 }
 
 
-static inline fluid_real_t* 
+static FLUID_INLINE fluid_real_t* 
 get_dest_buf(fluid_rvoice_buffers_t* buffers, int index,
              fluid_real_t** dest_bufs, int dest_bufcount)
 {

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -80,7 +80,7 @@ static int fluid_synth_update_polyphony(fluid_synth_t* synth,
                                         char* name, int value);
 static int fluid_synth_update_polyphony_LOCAL(fluid_synth_t* synth, int new_polyphony);
 static void init_dither(void);
-static inline int roundi (float x);
+static FLUID_INLINE int roundi (float x);
 static int fluid_synth_render_blocks(fluid_synth_t* synth, int blockcount);
 
 static fluid_voice_t* fluid_synth_free_voice_by_kill_LOCAL(fluid_synth_t* synth);
@@ -2898,7 +2898,7 @@ init_dither(void)
 }
 
 /* A portable replacement for roundf(), seems it may actually be faster too! */
-static inline int
+static FLUID_INLINE int
 roundi (float x)
 {
   if (x >= 0.0f)

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -104,7 +104,7 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
 #define UPDATE_RVOICE_ENVLFO_R1(proc, envp, rarg) UPDATE_RVOICE_GENERIC_R1(proc, &voice->rvoice->envlfo.envp, rarg) 
 #define UPDATE_RVOICE_ENVLFO_I1(proc, envp, iarg) UPDATE_RVOICE_GENERIC_I1(proc, &voice->rvoice->envlfo.envp, iarg) 
 
-static inline void
+static FLUID_INLINE void
 fluid_voice_update_volenv(fluid_voice_t* voice, 
 			  fluid_adsr_env_section_t section,
                           unsigned int count,
@@ -120,7 +120,7 @@ fluid_voice_update_volenv(fluid_voice_t* voice,
 			    coeff, increment, min, max);
 }
 
-static inline void
+static FLUID_INLINE void
 fluid_voice_update_modenv(fluid_voice_t* voice, 
 			  fluid_adsr_env_section_t section,
                           unsigned int count,
@@ -134,7 +134,7 @@ fluid_voice_update_modenv(fluid_voice_t* voice,
 			    coeff, increment, min, max);
 }
 
-static inline void fluid_sample_null_ptr(fluid_sample_t** sample)
+static FLUID_INLINE void fluid_sample_null_ptr(fluid_sample_t** sample)
 {
   if (*sample != NULL) {
     fluid_sample_decr_ref(*sample);

--- a/src/unused/fluid_dsp_float.c
+++ b/src/unused/fluid_dsp_float.c
@@ -123,7 +123,7 @@ void fluid_dsp_float_config (void)
 }
 
 
-static inline int 
+static FLUID_INLINE int 
 fluid_voice_is_looping(fluid_voice_t *voice)
 {
   return _SAMPLEMODE (voice) == FLUID_LOOP_DURING_RELEASE

--- a/src/unused/fluid_rvoice_handler.c
+++ b/src/unused/fluid_rvoice_handler.c
@@ -112,7 +112,7 @@ fluid_rvoice_handler_remove_voice(fluid_rvoice_handler_t* handler, int index)
  * @return Number of samples written 
  */
 #if 0
-static inline int
+static FLUID_INLINE int
 fluid_rvoice_handler_write_one(fluid_rvoice_handler_t* handler, int index, 
                                fluid_real_t* buf, int blockcount)
 {
@@ -137,7 +137,7 @@ fluid_rvoice_handler_write_one(fluid_rvoice_handler_t* handler, int index,
  * voice has been finished, removed and possibly replaced with another voice.
  * @return Number of samples written 
  */
-static inline int
+static FLUID_INLINE int
 fluid_rvoice_handler_mix_one(fluid_rvoice_handler_t* handler, int index, 
                                fluid_real_t** bufs, unsigned int blockcount, unsigned int bufcount)
 {
@@ -166,7 +166,7 @@ fluid_rvoice_handler_mix_one(fluid_rvoice_handler_t* handler, int index,
   return result;
 }
 
-static inline void
+static FLUID_INLINE void
 fluid_resetbufs(int blockcount, int bufcount, fluid_real_t** bufs)
 {
   int i;
@@ -177,7 +177,7 @@ fluid_resetbufs(int blockcount, int bufcount, fluid_real_t** bufs)
 /**
  * Single-threaded scenario, no worker threads 
  */
-static inline void
+static FLUID_INLINE void
 fluid_rvoice_handler_render_loop_simple(fluid_rvoice_handler_t* handler, 
                             int blockcount, int bufcount, fluid_real_t** bufs)
 {

--- a/src/unused/fluid_rvoice_handler.h
+++ b/src/unused/fluid_rvoice_handler.h
@@ -66,7 +66,7 @@ fluid_rvoice_handler_get_finished_voices(fluid_rvoice_handler_t* handler,
   return handler->finished_voices;
 }
 
-static inline void 
+static FLUID_INLINE void 
 fluid_rvoice_handler_clear_finished_voices(fluid_rvoice_handler_t* handler) 
 {
   handler->finished_voice_count = 0;

--- a/src/utils/fluid_hash.c
+++ b/src/utils/fluid_hash.c
@@ -136,7 +136,7 @@ spaced_primes_closest (unsigned int num)
  * save insertions from having to compute the hash record again for
  * the new record.
  */
-static inline fluid_hashnode_t **
+static FLUID_INLINE fluid_hashnode_t **
 fluid_hashtable_lookup_node (fluid_hashtable_t *hashtable, const void *key,
                              unsigned int *hash_return)
 {
@@ -316,7 +316,7 @@ fluid_hashtable_resize (fluid_hashtable_t *hashtable)
  * Essentially, calls fluid_hashtable_resize() if the table has strayed
  * too far from its ideal size for its number of nodes.
  */
-static inline void
+static FLUID_INLINE void
 fluid_hashtable_maybe_resize (fluid_hashtable_t *hashtable)
 {
   int nnodes = hashtable->nnodes;


### PR DESCRIPTION
Some sources are still using "inline" keyword, while others are using "FLUID_INLINE" macro.
This patch puts all sources at the same level.