### PR TITLE
Fluidsynth on mcu 1

### DIFF
--- a/bindings/fluidmax/fluidmax.c
+++ b/bindings/fluidmax/fluidmax.c
@@ -1065,7 +1065,7 @@ fluidmax_version(t_object *o)
   post("  Max/MSP integration by Norbert Schnell IMTR IRCAM - Centre Pompidou");
 }
 
-extern fluid_gen_info_t fluid_gen_info[];
+extern const fluid_gen_info_t fluid_gen_info[];
 
 static void 
 fluidmax_print(t_object *o, Symbol *s, short ac, Atom *at)

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -59,6 +59,17 @@ struct _fluid_shell_t {
   fluid_ostream_t out;
 };
 
+/**
+ * Reduced command information structure for constant data.
+ * For internal use only.
+ */
+typedef struct {
+  const char *name;             /**< The name of the command, as typed in the shell */
+  const char *topic;            /**< The help topic group of this command */ 
+  fluid_cmd_func_t handler;     /**< Pointer to the handler for this command */
+  const char *help;             /**< A help string */
+} fluid_cmd_int_t;
+
 static int fluid_shell_run(fluid_shell_t* shell);
 static void fluid_shell_init(fluid_shell_t* shell,
                              fluid_settings_t* settings, fluid_cmd_handler_t* handler,
@@ -75,122 +86,121 @@ void fluid_shell_settings(fluid_settings_t* settings)
 
 /** the table of all handled commands */
 
-static fluid_cmd_t fluid_commands[] = {
-  { "help", "general", (fluid_cmd_func_t) fluid_handle_help, NULL,
+static const fluid_cmd_int_t fluid_commands[] = {
+  { "help", "general", (fluid_cmd_func_t) fluid_handle_help,
     "help                       Show help topics ('help TOPIC' for more info)" },
-  { "quit", "general", (fluid_cmd_func_t) fluid_handle_quit, NULL,
+  { "quit", "general", (fluid_cmd_func_t) fluid_handle_quit,
     "quit                       Quit the synthesizer" },
-  { "source", "general", (fluid_cmd_func_t) fluid_handle_source, NULL,
+  { "source", "general", (fluid_cmd_func_t) fluid_handle_source,
   "source filename            Load a file and parse every line as a command" },
-  { "noteon", "event", (fluid_cmd_func_t) fluid_handle_noteon, NULL,
+  { "noteon", "event", (fluid_cmd_func_t) fluid_handle_noteon,
     "noteon chan key vel        Send noteon" },
-  { "noteoff", "event", (fluid_cmd_func_t) fluid_handle_noteoff, NULL,
+  { "noteoff", "event", (fluid_cmd_func_t) fluid_handle_noteoff,
     "noteoff chan key           Send noteoff"  },
-  { "pitch_bend", "event", (fluid_cmd_func_t) fluid_handle_pitch_bend, NULL,
+  { "pitch_bend", "event", (fluid_cmd_func_t) fluid_handle_pitch_bend,
     "pitch_bend chan offset           Bend pitch"  },
-  { "pitch_bend_range", "event", (fluid_cmd_func_t) fluid_handle_pitch_bend_range, NULL,
+  { "pitch_bend_range", "event", (fluid_cmd_func_t) fluid_handle_pitch_bend_range,
     "pitch_bend chan range           Set bend pitch range"  },
-  { "cc", "event", (fluid_cmd_func_t) fluid_handle_cc, NULL,
+  { "cc", "event", (fluid_cmd_func_t) fluid_handle_cc,
     "cc chan ctrl value         Send control-change message" },
-  { "prog", "event", (fluid_cmd_func_t) fluid_handle_prog, NULL,
+  { "prog", "event", (fluid_cmd_func_t) fluid_handle_prog,
     "prog chan num              Send program-change message" },
-  { "select", "event", (fluid_cmd_func_t) fluid_handle_select, NULL,
+  { "select", "event", (fluid_cmd_func_t) fluid_handle_select,
     "select chan sfont bank prog  Combination of bank-select and program-change" },
-  { "load", "general", (fluid_cmd_func_t) fluid_handle_load, NULL,
+  { "load", "general", (fluid_cmd_func_t) fluid_handle_load,
     "load file [reset] [bankofs] Load SoundFont (reset=0|1, def 1; bankofs=n, def 0)" },
-  { "unload", "general", (fluid_cmd_func_t) fluid_handle_unload, NULL,
+  { "unload", "general", (fluid_cmd_func_t) fluid_handle_unload,
     "unload id [reset]          Unload SoundFont by ID (reset=0|1, default 1)"},
-  { "reload", "general", (fluid_cmd_func_t) fluid_handle_reload, NULL,
+  { "reload", "general", (fluid_cmd_func_t) fluid_handle_reload,
     "reload id                  Reload the SoundFont with the specified ID" },
-  { "fonts", "general", (fluid_cmd_func_t) fluid_handle_fonts, NULL,
+  { "fonts", "general", (fluid_cmd_func_t) fluid_handle_fonts,
     "fonts                      Display the list of loaded SoundFonts" },
-  { "inst", "general", (fluid_cmd_func_t) fluid_handle_inst, NULL,
+  { "inst", "general", (fluid_cmd_func_t) fluid_handle_inst,
     "inst font                  Print out the available instruments for the font" },
-  { "channels", "general", (fluid_cmd_func_t) fluid_handle_channels, NULL,
+  { "channels", "general", (fluid_cmd_func_t) fluid_handle_channels,
     "channels [-verbose]        Print out preset of all channels" },
-  { "interp", "general", (fluid_cmd_func_t) fluid_handle_interp, NULL,
+  { "interp", "general", (fluid_cmd_func_t) fluid_handle_interp,
     "interp num                 Choose interpolation method for all channels" },
-  { "interpc", "general", (fluid_cmd_func_t) fluid_handle_interpc, NULL,
+  { "interpc", "general", (fluid_cmd_func_t) fluid_handle_interpc,
     "interpc chan num           Choose interpolation method for one channel" },
-  { "rev_preset", "reverb", (fluid_cmd_func_t) fluid_handle_reverbpreset, NULL,
+  { "rev_preset", "reverb", (fluid_cmd_func_t) fluid_handle_reverbpreset,
     "rev_preset num             Load preset num into the reverb unit" },
-  { "rev_setroomsize", "reverb", (fluid_cmd_func_t) fluid_handle_reverbsetroomsize, NULL,
+  { "rev_setroomsize", "reverb", (fluid_cmd_func_t) fluid_handle_reverbsetroomsize,
     "rev_setroomsize num        Change reverb room size" },
-  { "rev_setdamp", "reverb", (fluid_cmd_func_t) fluid_handle_reverbsetdamp, NULL,
+  { "rev_setdamp", "reverb", (fluid_cmd_func_t) fluid_handle_reverbsetdamp,
     "rev_setdamp num            Change reverb damping" },
-  { "rev_setwidth", "reverb", (fluid_cmd_func_t) fluid_handle_reverbsetwidth, NULL,
+  { "rev_setwidth", "reverb", (fluid_cmd_func_t) fluid_handle_reverbsetwidth,
     "rev_setwidth num           Change reverb width" },
-  { "rev_setlevel", "reverb", (fluid_cmd_func_t) fluid_handle_reverbsetlevel, NULL,
+  { "rev_setlevel", "reverb", (fluid_cmd_func_t) fluid_handle_reverbsetlevel,
     "rev_setlevel num           Change reverb level" },
-  { "reverb", "reverb", (fluid_cmd_func_t) fluid_handle_reverb, NULL,
+  { "reverb", "reverb", (fluid_cmd_func_t) fluid_handle_reverb,
     "reverb [0|1|on|off]        Turn the reverb on or off" },
-  { "cho_set_nr", "chorus", (fluid_cmd_func_t) fluid_handle_chorusnr, NULL,
+  { "cho_set_nr", "chorus", (fluid_cmd_func_t) fluid_handle_chorusnr,
     "cho_set_nr n               Use n delay lines (default 3)" },
-  { "cho_set_level", "chorus", (fluid_cmd_func_t) fluid_handle_choruslevel, NULL,
+  { "cho_set_level", "chorus", (fluid_cmd_func_t) fluid_handle_choruslevel,
     "cho_set_level num          Set output level of each chorus line to num" },
-  { "cho_set_speed", "chorus", (fluid_cmd_func_t) fluid_handle_chorusspeed, NULL,
+  { "cho_set_speed", "chorus", (fluid_cmd_func_t) fluid_handle_chorusspeed,
     "cho_set_speed num          Set mod speed of chorus to num (Hz)" },
-  { "cho_set_depth", "chorus", (fluid_cmd_func_t) fluid_handle_chorusdepth, NULL,
+  { "cho_set_depth", "chorus", (fluid_cmd_func_t) fluid_handle_chorusdepth,
     "cho_set_depth num          Set chorus modulation depth to num (ms)" },
-  { "chorus", "chorus", (fluid_cmd_func_t) fluid_handle_chorus, NULL,
+  { "chorus", "chorus", (fluid_cmd_func_t) fluid_handle_chorus,
     "chorus [0|1|on|off]        Turn the chorus on or off" },
-  { "gain", "general", (fluid_cmd_func_t) fluid_handle_gain, NULL,
+  { "gain", "general", (fluid_cmd_func_t) fluid_handle_gain,
     "gain value                 Set the master gain (0 < gain < 5)" },
-  { "voice_count", "general", (fluid_cmd_func_t) fluid_handle_voice_count, NULL,
+  { "voice_count", "general", (fluid_cmd_func_t) fluid_handle_voice_count,
     "voice_count                Get number of active synthesis voices" },
-  { "tuning", "tuning", (fluid_cmd_func_t) fluid_handle_tuning, NULL,
+  { "tuning", "tuning", (fluid_cmd_func_t) fluid_handle_tuning,
     "tuning name bank prog      Create a tuning with name, bank number, \n"
     "                           and program number (0 <= bank,prog <= 127)" },
-  { "tune", "tuning", (fluid_cmd_func_t) fluid_handle_tune, NULL,
+  { "tune", "tuning", (fluid_cmd_func_t) fluid_handle_tune,
     "tune bank prog key pitch   Tune a key" },
-  { "settuning", "tuning", (fluid_cmd_func_t) fluid_handle_settuning, NULL,
+  { "settuning", "tuning", (fluid_cmd_func_t) fluid_handle_settuning,
     "settuning chan bank prog   Set the tuning for a MIDI channel" },
-  { "resettuning", "tuning", (fluid_cmd_func_t) fluid_handle_resettuning, NULL,
+  { "resettuning", "tuning", (fluid_cmd_func_t) fluid_handle_resettuning,
     "resettuning chan           Restore the default tuning of a MIDI channel" },
-  { "tunings", "tuning", (fluid_cmd_func_t) fluid_handle_tunings, NULL,
+  { "tunings", "tuning", (fluid_cmd_func_t) fluid_handle_tunings,
     "tunings                    Print the list of available tunings" },
-  { "dumptuning", "tuning", (fluid_cmd_func_t) fluid_handle_dumptuning, NULL,
+  { "dumptuning", "tuning", (fluid_cmd_func_t) fluid_handle_dumptuning,
     "dumptuning bank prog       Print the pitch details of the tuning" },
-  { "reset", "general", (fluid_cmd_func_t) fluid_handle_reset, NULL,
+  { "reset", "general", (fluid_cmd_func_t) fluid_handle_reset,
     "reset                      System reset (all notes off, reset controllers)" },
-  { "set", "settings", (fluid_cmd_func_t) fluid_handle_set, NULL,
+  { "set", "settings", (fluid_cmd_func_t) fluid_handle_set,
     "set name value             Set the value of a controller or settings" },
-  { "get", "settings", (fluid_cmd_func_t) fluid_handle_get, NULL,
+  { "get", "settings", (fluid_cmd_func_t) fluid_handle_get,
     "get name                   Get the value of a controller or settings" },
-  { "info", "settings", (fluid_cmd_func_t) fluid_handle_info, NULL,
+  { "info", "settings", (fluid_cmd_func_t) fluid_handle_info,
     "info name                  Get information about a controller or settings" },
-  { "settings", "settings", (fluid_cmd_func_t) fluid_handle_settings, NULL,
+  { "settings", "settings", (fluid_cmd_func_t) fluid_handle_settings,
     "settings                   Print out all settings" },
-  { "echo", "general", (fluid_cmd_func_t) fluid_handle_echo, NULL,
+  { "echo", "general", (fluid_cmd_func_t) fluid_handle_echo,
     "echo arg                   Print arg" },
   /* LADSPA-related commands */
 #ifdef LADSPA
-  { "ladspa_clear", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_clear, NULL,
+  { "ladspa_clear", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_clear,
     "ladspa_clear               Resets LADSPA effect unit to bypass state"},
-  { "ladspa_add", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_add, NULL,
+  { "ladspa_add", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_add,
     "ladspa_add lib plugin n1 <- p1 n2 -> p2 ... Loads and connects LADSPA plugin"},
-  { "ladspa_start", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_start, NULL,
+  { "ladspa_start", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_start,
     "ladspa_start               Starts LADSPA effect unit"},
-  { "ladspa_declnode", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_declnode, NULL,
+  { "ladspa_declnode", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_declnode,
     "ladspa_declnode node value Declares control node `node' with value `value'"},
-  { "ladspa_setnode", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_setnode, NULL,
+  { "ladspa_setnode", "ladspa", (fluid_cmd_func_t) fluid_LADSPA_handle_setnode,
     "ladspa_setnode node value  Assigns `value' to `node'"},
 #endif
-  { "router_clear", "router", (fluid_cmd_func_t) fluid_handle_router_clear, NULL,
+  { "router_clear", "router", (fluid_cmd_func_t) fluid_handle_router_clear,
     "router_clear               Clears all routing rules from the midi router"},
-  { "router_default", "router", (fluid_cmd_func_t) fluid_handle_router_default, NULL,
+  { "router_default", "router", (fluid_cmd_func_t) fluid_handle_router_default,
     "router_default             Resets the midi router to default state"},
-  { "router_begin", "router", (fluid_cmd_func_t) fluid_handle_router_begin, NULL,
+  { "router_begin", "router", (fluid_cmd_func_t) fluid_handle_router_begin,
     "router_begin [note|cc|prog|pbend|cpress|kpress]: Starts a new routing rule"},
-  { "router_chan", "router", (fluid_cmd_func_t) fluid_handle_router_chan, NULL,
+  { "router_chan", "router", (fluid_cmd_func_t) fluid_handle_router_chan,
     "router_chan min max mul add      filters and maps midi channels on current rule"},
-  { "router_par1", "router", (fluid_cmd_func_t) fluid_handle_router_par1, NULL,
+  { "router_par1", "router", (fluid_cmd_func_t) fluid_handle_router_par1,
     "router_par1 min max mul add      filters and maps parameter 1 (key/ctrl nr)"},
-  { "router_par2", "router", (fluid_cmd_func_t) fluid_handle_router_par2, NULL,
+  { "router_par2", "router", (fluid_cmd_func_t) fluid_handle_router_par2,
     "router_par2 min max mul add      filters and maps parameter 2 (vel/cc val)"},
-  { "router_end", "router", (fluid_cmd_func_t) fluid_handle_router_end, NULL,
-    "router_end                 closes and commits the current routing rule"},
-  { NULL, NULL, NULL, NULL, NULL }
+  { "router_end", "router", (fluid_cmd_func_t) fluid_handle_router_end,
+    "router_end                 closes and commits the current routing rule"}
 };
 
 /**
@@ -1598,7 +1608,7 @@ fluid_handle_help(fluid_cmd_handler_t* handler, int ac, char** av, fluid_ostream
 
   char* topic = "help"; /* default, if no topic is given */
   int count = 0;
-  int i;
+  unsigned int i;
 
   fluid_ostream_printf(out, "\n");
   /* 1st argument (optional): help topic */
@@ -1610,9 +1620,9 @@ fluid_handle_help(fluid_cmd_handler_t* handler, int ac, char** av, fluid_ostream
     fluid_ostream_printf(out,
 			"*** Help topics:***\n"
 			"help all (prints all topics)\n");
-    for (i = 0; fluid_commands[i].name != NULL; i++) {
+    for (i = 0; i < FLUID_N_ELEMENTS(fluid_commands); i++) {
       int listed_first_time = 1;
-      int ii;
+      unsigned int ii;
       for (ii = 0; ii < i; ii++){
 	if (strcmp(fluid_commands[i].topic, fluid_commands[ii].topic) == 0){
 	  listed_first_time = 0;
@@ -1624,10 +1634,9 @@ fluid_handle_help(fluid_cmd_handler_t* handler, int ac, char** av, fluid_ostream
     }; /* for all topics (outer loop) */
   } else {
     /* help (arbitrary topic or "all") */
-    for (i = 0; fluid_commands[i].name != NULL; i++) {
-      fluid_cmd_t cmd = fluid_commands[i];
-      if (cmd.help != NULL) {
-	if (strcmp(topic,"all") == 0 || strcmp(topic,cmd.topic) == 0){
+    for (i = 0; FLUID_N_ELEMENTS(fluid_commands); i++) {
+      if (fluid_commands[i].help != NULL) {
+	if (strcmp(topic,"all") == 0 || strcmp(topic,fluid_commands[i].topic) == 0){
 	  fluid_ostream_printf(out, "%s\n", fluid_commands[i].help);
 	  count++;
 	}; /* if it matches the topic */
@@ -1917,7 +1926,7 @@ fluid_cmd_handler_destroy_hash_value (void *value)
  */
 fluid_cmd_handler_t* new_fluid_cmd_handler(fluid_synth_t* synth, fluid_midi_router_t* router)
 {
-  int i;
+  unsigned int i;
   fluid_cmd_handler_t* handler;
 
   handler = FLUID_NEW(fluid_cmd_handler_t);
@@ -1935,11 +1944,17 @@ fluid_cmd_handler_t* new_fluid_cmd_handler(fluid_synth_t* synth, fluid_midi_rout
   handler->router = router;
   
   if (synth != NULL) {
-    for (i = 0; fluid_commands[i].name != NULL; i++)
+    for (i = 0; i < FLUID_N_ELEMENTS(fluid_commands); i++)
     {
-        fluid_commands[i].data = handler;
-        fluid_cmd_handler_register(handler, &fluid_commands[i]);
-        fluid_commands[i].data = NULL;
+        fluid_cmd_t cmd = {
+            (char *)fluid_commands[i].name,
+            (char *)fluid_commands[i].topic,
+            fluid_commands[i].handler,
+            handler,
+            (char *)fluid_commands[i].help
+        };
+
+        fluid_cmd_handler_register(handler, &cmd);
     }
   }
 

--- a/src/bindings/fluid_filerenderer.c
+++ b/src/bindings/fluid_filerenderer.c
@@ -54,21 +54,20 @@ struct _fluid_file_renderer_t {
 
 /* File audio format names.
  * !! Keep in sync with format_ids[] */
-const char *format_names[] = {
+static const char * const format_names[] = {
   "s8",
   "s16",
   "s24",
   "s32",
   "u8",
   "float",
-  "double",
-  NULL          /* Terminator */
+  "double"
 };
   
 
 /* File audio format IDs.
  * !! Keep in sync with format_names[] */
-const int format_ids[] = {
+static const int format_ids[] = {
   SF_FORMAT_PCM_S8,
   SF_FORMAT_PCM_16,
   SF_FORMAT_PCM_24,
@@ -80,17 +79,16 @@ const int format_ids[] = {
 
 /* File endian byte order names.
  * !! Keep in sync with endian_ids[] */
-const char *endian_names[] = {
+static const char * const endian_names[] = {
   "auto",
   "little",
   "big",
-  "cpu",
-  NULL
+  "cpu"
 };
 
 /* File endian byte order ids.
  * !! Keep in sync with endian_names[] */
-const int endian_ids[] = {
+static const int endian_ids[] = {
   SF_ENDIAN_FILE,
   SF_ENDIAN_LITTLE,
   SF_ENDIAN_BIG,
@@ -107,21 +105,18 @@ static int fluid_file_renderer_find_valid_format (SF_INFO *info);
 
 
 /* File type names. */
-const char *type_names[] = {
-  "raw",
-  NULL          /* Terminator */
+static const char * const type_names[] = {
+  "raw"
 };
 
 /* File audio format names. */
-const char *format_names[] = {
-  "s16",
-  NULL          /* Terminator */
+static const char * const format_names[] = {
+  "s16"
 };
 
 /* File endian byte order names. */
-const char *endian_names[] = {
-  "cpu",
-  NULL
+static const char * const endian_names[] = {
+  "cpu"
 };
 
 #endif
@@ -134,7 +129,7 @@ fluid_file_renderer_settings (fluid_settings_t* settings)
   SF_FORMAT_INFO finfo, cmpinfo;
   int major_count;
   int i, i2;
-  const char **np;
+  unsigned int n;
 
   fluid_settings_register_str(settings, "audio.file.name", "fluidsynth.wav",
                               FLUID_HINT_FILENAME, NULL, NULL);
@@ -165,11 +160,11 @@ fluid_file_renderer_settings (fluid_settings_t* settings)
       fluid_settings_add_option (settings, "audio.file.type", finfo.extension);
   }
 
-  for (np = format_names; *np; np++)
-    fluid_settings_add_option (settings, "audio.file.format", *np);
+  for (n = 0; n < FLUID_N_ELEMENTS(format_names); n++)
+    fluid_settings_add_option (settings, "audio.file.format", format_names[n]);
 
-  for (np = endian_names; *np; np++)
-    fluid_settings_add_option (settings, "audio.file.endian", *np);
+  for (n = 0; n < FLUID_N_ELEMENTS(endian_names); n++)
+    fluid_settings_add_option (settings, "audio.file.endian", endian_names[n]);
 
 #else
 
@@ -417,7 +412,7 @@ fluid_file_renderer_parse_options (char *filetype, char *format, char *endian,
 {
   int type = -1;        /* -1 indicates "auto" type */
   char *s;
-  int i;
+  unsigned int i;
 
   /* If "auto" type, then use extension to search for a match */
   if (!filetype || FLUID_STRCMP (filetype, "auto") == 0)
@@ -443,11 +438,11 @@ fluid_file_renderer_parse_options (char *filetype, char *format, char *endian,
   /* Look for subtype */
   if (format)
   {
-    for (i = 0; format_names[i]; i++)
+    for (i = 0; i < FLUID_N_ELEMENTS(format_names); i++)
       if (FLUID_STRCMP (format, format_names[i]) == 0)
         break;
 
-    if (!format_names[i])
+    if (i >= FLUID_N_ELEMENTS(format_names))
     {
       FLUID_LOG (FLUID_ERR, "Invalid or unsupported file audio format '%s'", format);
       return FALSE;
@@ -466,11 +461,11 @@ fluid_file_renderer_parse_options (char *filetype, char *format, char *endian,
   /* Look for endian */
   if (endian)
   {
-    for (i = 0; endian_names[i]; i++)
+    for (i = 0; i < FLUID_N_ELEMENTS(endian_names); i++)
       if (FLUID_STRCMP (endian, endian_names[i]) == 0)
         break;
 
-    if (!endian_names[i])
+    if (i >= FLUID_N_ELEMENTS(endian_names))
     {
       FLUID_LOG (FLUID_ERR, "Invalid or unsupported endian byte order '%s'", endian);
       return FALSE;

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -27,7 +27,7 @@
 
 typedef struct _fluid_audriver_definition_t
 {
-  char* name;
+  const char* name;
   fluid_audio_driver_t* (*new)(fluid_settings_t* settings, fluid_synth_t* synth);
   fluid_audio_driver_t* (*new2)(fluid_settings_t* settings,
 				fluid_audio_func_t func,
@@ -119,7 +119,7 @@ int delete_fluid_file_audio_driver(fluid_audio_driver_t* p);
 #endif
 
 /* Available audio drivers, listed in order of preference */
-fluid_audriver_definition_t fluid_audio_drivers[] = {
+static const fluid_audriver_definition_t fluid_audio_drivers[] = {
 #if JACK_SUPPORT
   { "jack",
     new_fluid_jack_audio_driver,
@@ -190,7 +190,6 @@ fluid_audriver_definition_t fluid_audio_drivers[] = {
     delete_fluid_file_audio_driver,
     NULL },
 #endif
-  { NULL, NULL, NULL, NULL, NULL }
 };
 
 
@@ -198,7 +197,7 @@ fluid_audriver_definition_t fluid_audio_drivers[] = {
 
 void fluid_audio_driver_settings(fluid_settings_t* settings)
 {
-  int i;
+  unsigned int i;
 
   fluid_settings_register_str(settings, "audio.sample-format", "16bits", 0, NULL, NULL);
   fluid_settings_add_option(settings, "audio.sample-format", "16bits");
@@ -275,7 +274,7 @@ void fluid_audio_driver_settings(fluid_settings_t* settings)
   fluid_settings_add_option(settings, "audio.driver", "file");
 #endif
 
-  for (i = 0; fluid_audio_drivers[i].name != NULL; i++) {
+  for (i = 0; i < FLUID_N_ELEMENTS(fluid_audio_drivers); i++) {
     if (fluid_audio_drivers[i].settings != NULL) {
       fluid_audio_drivers[i].settings(settings);
     }
@@ -295,12 +294,12 @@ void fluid_audio_driver_settings(fluid_settings_t* settings)
 fluid_audio_driver_t*
 new_fluid_audio_driver(fluid_settings_t* settings, fluid_synth_t* synth)
 {
-  int i;
+  unsigned int i;
   fluid_audio_driver_t* driver = NULL;
   char* name;
   char *allnames;
 
-  for (i = 0; fluid_audio_drivers[i].name != NULL; i++) {
+  for (i = 0; i < FLUID_N_ELEMENTS(fluid_audio_drivers); i++) {
     if (fluid_settings_str_equal(settings, "audio.driver", fluid_audio_drivers[i].name)) {
       FLUID_LOG(FLUID_DBG, "Using '%s' audio driver", fluid_audio_drivers[i].name);
       driver = (*fluid_audio_drivers[i].new)(settings, synth);

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -336,11 +336,11 @@ new_fluid_audio_driver(fluid_settings_t* settings, fluid_synth_t* synth)
 fluid_audio_driver_t*
 new_fluid_audio_driver2(fluid_settings_t* settings, fluid_audio_func_t func, void* data)
 {
-  int i;
+  unsigned int i;
   fluid_audio_driver_t* driver = NULL;
   char* name;
 
-  for (i = 0; fluid_audio_drivers[i].name != NULL; i++) {
+  for (i = 0; i < FLUID_N_ELEMENTS(fluid_audio_drivers); i++) {
     if (fluid_settings_str_equal(settings, "audio.driver", fluid_audio_drivers[i].name) &&
 	(fluid_audio_drivers[i].new2 != NULL)) {
       FLUID_LOG(FLUID_DBG, "Using '%s' audio driver", fluid_audio_drivers[i].name);
@@ -368,9 +368,9 @@ new_fluid_audio_driver2(fluid_settings_t* settings, fluid_audio_func_t func, voi
 void
 delete_fluid_audio_driver(fluid_audio_driver_t* driver)
 {
-  int i;
+  unsigned int i;
 
-  for (i = 0; fluid_audio_drivers[i].name != NULL; i++) {
+  for (i = 0; i < FLUID_N_ELEMENTS(fluid_audio_drivers); i++) {
     if (fluid_audio_drivers[i].name == driver->name) {
       fluid_audio_drivers[i].free(driver);
       return;

--- a/src/drivers/fluid_adriver.h
+++ b/src/drivers/fluid_adriver.h
@@ -21,7 +21,7 @@
 #ifndef _FLUID_AUDRIVER_H
 #define _FLUID_AUDRIVER_H
 
-#include "fluidsynth_priv.h"
+#include "fluid_sys.h"
 
 void fluid_audio_driver_settings(fluid_settings_t* settings);
 
@@ -32,7 +32,7 @@ void fluid_audio_driver_settings(fluid_settings_t* settings);
 
 struct _fluid_audio_driver_t
 {
-  char* name;
+  const char* name;
 };
 
 

--- a/src/drivers/fluid_mdriver.c
+++ b/src/drivers/fluid_mdriver.c
@@ -204,9 +204,9 @@ fluid_midi_driver_t* new_fluid_midi_driver(fluid_settings_t* settings, handle_mi
 {
   fluid_midi_driver_t* driver = NULL;
   char *allnames;
-  int i;
+  unsigned int i;
 
-  for (i = 0; fluid_midi_drivers[i].name != NULL; i++) {
+  for (i = 0; i < FLUID_N_ELEMENTS(fluid_midi_drivers); i++) {
     if (fluid_settings_str_equal(settings, "midi.driver", fluid_midi_drivers[i].name)) {
       FLUID_LOG(FLUID_DBG, "Using '%s' midi driver", fluid_midi_drivers[i].name);
       driver = fluid_midi_drivers[i].new(settings, handler, event_handler_data);
@@ -231,9 +231,9 @@ fluid_midi_driver_t* new_fluid_midi_driver(fluid_settings_t* settings, handle_mi
  */
 void delete_fluid_midi_driver(fluid_midi_driver_t* driver)
 {
-  int i;
+  unsigned int i;
 
-  for (i = 0; fluid_midi_drivers[i].name != NULL; i++) {
+  for (i = 0; i < FLUID_N_ELEMENTS(fluid_midi_drivers); i++) {
     if (fluid_midi_drivers[i].name == driver->name) {
       fluid_midi_drivers[i].free(driver);
       return;

--- a/src/drivers/fluid_mdriver.c
+++ b/src/drivers/fluid_mdriver.c
@@ -86,7 +86,7 @@ void fluid_coremidi_driver_settings(fluid_settings_t* settings);
  * fluid_mdriver_definition
  */
 struct fluid_mdriver_definition_t {
-  char* name;
+  const char* name;
   fluid_midi_driver_t* (*new)(fluid_settings_t* settings,
 			     handle_midi_event_func_t event_handler,
 			     void* event_handler_data);
@@ -95,7 +95,7 @@ struct fluid_mdriver_definition_t {
 };
 
 
-struct fluid_mdriver_definition_t fluid_midi_drivers[] = {
+static const struct fluid_mdriver_definition_t fluid_midi_drivers[] = {
 #if JACK_SUPPORT
   { "jack",
     new_fluid_jack_midi_driver,
@@ -136,14 +136,13 @@ struct fluid_mdriver_definition_t fluid_midi_drivers[] = {
     delete_fluid_coremidi_driver,
     fluid_coremidi_driver_settings },
 #endif
-  { NULL, NULL, NULL, NULL }
 };
 
 
 
 void fluid_midi_driver_settings(fluid_settings_t* settings)
 {
-  int i;
+  unsigned int i;
 
   fluid_settings_register_int (settings, "midi.realtime-prio",
                                FLUID_DEFAULT_MIDI_RT_PRIO, 0, 99, 0, NULL, NULL);
@@ -186,7 +185,7 @@ void fluid_midi_driver_settings(fluid_settings_t* settings)
   fluid_settings_add_option(settings, "midi.driver", "coremidi");
 #endif
 
-  for (i = 0; fluid_midi_drivers[i].name != NULL; i++) {
+  for (i = 0; i < FLUID_N_ELEMENTS(fluid_midi_drivers); i++) {
     if (fluid_midi_drivers[i].settings != NULL) {
       fluid_midi_drivers[i].settings(settings);
     }

--- a/src/drivers/fluid_mdriver.h
+++ b/src/drivers/fluid_mdriver.h
@@ -21,7 +21,7 @@
 #ifndef _FLUID_MDRIVER_H
 #define _FLUID_MDRIVER_H
 
-#include "fluidsynth_priv.h"
+#include "fluid_sys.h"
 
 void fluid_midi_driver_settings(fluid_settings_t* settings);
 
@@ -32,7 +32,7 @@ void fluid_midi_driver_settings(fluid_settings_t* settings);
 
 struct _fluid_midi_driver_t
 {
-  char* name;
+  const char* name;
   handle_midi_event_func_t handler;
   void* data;
 };

--- a/src/rvoice/fluid_rev.h
+++ b/src/rvoice/fluid_rev.h
@@ -46,7 +46,7 @@ typedef enum
  * reverb preset
  */
 typedef struct _fluid_revmodel_presets_t {
-  char* name;
+  const char* name;
   fluid_real_t roomsize;
   fluid_real_t damp;
   fluid_real_t width;

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -2132,7 +2132,7 @@ static int fixup_pgen (SFData * sf);
 static int fixup_igen (SFData * sf);
 static int fixup_sample (SFData * sf);
 
-char idlist[] = {
+static const char idlist[] = {
   "RIFFLISTsfbkINFOsdtapdtaifilisngINAMiromiverICRDIENGIPRD"
     "ICOPICMTISFTsnamsmplphdrpbagpmodpgeninstibagimodigenshdr"
 };
@@ -2421,7 +2421,7 @@ pdtahelper (unsigned int expid, unsigned int reclen, SFChunk * chunk,
   int * size, FILE * fd)
 {
   unsigned int id;
-  char *expstr;
+  const char *expstr;
 
   expstr = CHNKIDSTR (expid);	/* in case we need it */
 
@@ -3429,11 +3429,13 @@ fixup_sample (SFData * sf)
 #define MOD_CHUNK_OPTIMUM_AREA		256
 #define GEN_CHUNK_OPTIMUM_AREA		256
 
-unsigned short badgen[] = { Gen_Unused1, Gen_Unused2, Gen_Unused3, Gen_Unused4,
+static const unsigned short badgen[] = {
+  Gen_Unused1, Gen_Unused2, Gen_Unused3, Gen_Unused4,
   Gen_Reserved1, Gen_Reserved2, Gen_Reserved3, 0
 };
 
-unsigned short badpgen[] = { Gen_StartAddrOfs, Gen_EndAddrOfs, Gen_StartLoopAddrOfs,
+static const unsigned short badpgen[] = {
+  Gen_StartAddrOfs, Gen_EndAddrOfs, Gen_StartLoopAddrOfs,
   Gen_EndLoopAddrOfs, Gen_StartAddrCoarseOfs, Gen_EndAddrCoarseOfs,
   Gen_StartLoopAddrCoarseOfs, Gen_Keynum, Gen_Velocity,
   Gen_EndLoopAddrCoarseOfs, Gen_SampleModes, Gen_ExclusiveClass,

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -212,11 +212,6 @@ typedef enum
 }
 Gen_Unit;
 
-/* global data */
-
-extern unsigned short badgen[]; 	/* list of bad generators */
-extern unsigned short badpgen[]; 	/* list of bad preset generators */
-
 /* functions */
 void sfont_init_chunks (void);
 
@@ -294,9 +289,6 @@ typedef struct _SFShdr
   unsigned short sampletype;		/* 1 mono,2 right,4 left,linked 8,0x8000=ROM */
 }
 SFShdr;
-
-/* data */
-extern char idlist[];
 
 /* functions */
 SFData *sfload_file (const char * fname);

--- a/src/synth/fluid_gen.c
+++ b/src/synth/fluid_gen.c
@@ -24,7 +24,7 @@
 
 
 /* See SFSpec21 $8.1.3 */
-fluid_gen_info_t fluid_gen_info[] = {
+const fluid_gen_info_t fluid_gen_info[] = {
         /* number/name             init  scale         min        max         def */
         { GEN_STARTADDROFS,           1,     1,       0.0f,     1e10f,       0.0f },
         { GEN_ENDADDROFS,             1,     1,     -1e10f,      0.0f,       0.0f },

--- a/src/synth/fluid_gen.c
+++ b/src/synth/fluid_gen.c
@@ -24,7 +24,7 @@
 
 
 /* See SFSpec21 $8.1.3 */
-const fluid_gen_info_t fluid_gen_info[] = {
+static const fluid_gen_info_t fluid_gen_info[] = {
         /* number/name             init  scale         min        max         def */
         { GEN_STARTADDROFS,           1,     1,       0.0f,     1e10f,       0.0f },
         { GEN_ENDADDROFS,             1,     1,     -1e10f,      0.0f,       0.0f },

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3895,10 +3895,10 @@ fluid_synth_set_reverb_on(fluid_synth_t* synth, int on)
  * @note Currently private to libfluidsynth.
  */
 int
-fluid_synth_set_reverb_preset(fluid_synth_t* synth, int num)
+fluid_synth_set_reverb_preset(fluid_synth_t* synth, unsigned int num)
 {
   fluid_return_val_if_fail (
-    num < 0 || num >= (int)FLUID_N_ELEMENTS(revmodel_preset),
+    num < FLUID_N_ELEMENTS(revmodel_preset),
     FLUID_FAILED
   );
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -1738,7 +1738,6 @@ fluid_synth_system_reset(fluid_synth_t* synth)
 static int
 fluid_synth_system_reset_LOCAL(fluid_synth_t* synth)
 {
-  fluid_voice_t* voice;
   int i;
 
   fluid_synth_all_sounds_off_LOCAL(synth, -1);

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3895,10 +3895,12 @@ fluid_synth_set_reverb_on(fluid_synth_t* synth, int on)
  * @note Currently private to libfluidsynth.
  */
 int
-fluid_synth_set_reverb_preset(fluid_synth_t* synth, unsigned int num)
+fluid_synth_set_reverb_preset(fluid_synth_t* synth, int num)
 {
-  if (num >= FLUID_N_ELEMENTS(revmodel_preset))
-    return FLUID_FAILED;
+  fluid_return_val_if_fail (
+    num < 0 || num >= (int)FLUID_N_ELEMENTS(revmodel_preset),
+    FLUID_FAILED
+  );
 
   fluid_synth_set_reverb (synth, revmodel_preset[num].roomsize,
                           revmodel_preset[num].damp, revmodel_preset[num].width,

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -139,14 +139,13 @@ fluid_mod_t default_chorus_mod;         /* SF2.01 section 8.4.9  */
 fluid_mod_t default_pitch_bend_mod;     /* SF2.01 section 8.4.10 */
 
 /* reverb presets */
-static fluid_revmodel_presets_t revmodel_preset[] = {
+static const fluid_revmodel_presets_t revmodel_preset[] = {
   /* name */    /* roomsize */ /* damp */ /* width */ /* level */
   { "Test 1",          0.2f,      0.0f,       0.5f,       0.9f },
   { "Test 2",          0.4f,      0.2f,       0.5f,       0.8f },
   { "Test 3",          0.6f,      0.4f,       0.5f,       0.7f },
   { "Test 4",          0.8f,      0.7f,       0.5f,       0.6f },
   { "Test 5",          0.8f,      1.0f,       0.5f,       0.5f },
-  { NULL, 0.0f, 0.0f, 0.0f, 0.0f }
 };
 
 
@@ -3799,7 +3798,7 @@ fluid_synth_get_channel_info (fluid_synth_t *synth, int chan,
 {
   fluid_channel_t *channel;
   fluid_preset_t *preset;
-  char *name;
+  const char *name;
 
   if (info)
   {
@@ -3897,19 +3896,15 @@ fluid_synth_set_reverb_on(fluid_synth_t* synth, int on)
  * @note Currently private to libfluidsynth.
  */
 int
-fluid_synth_set_reverb_preset(fluid_synth_t* synth, int num)
+fluid_synth_set_reverb_preset(fluid_synth_t* synth, unsigned int num)
 {
-  int i = 0;
-  while (revmodel_preset[i].name != NULL) {
-    if (i == num) {
-      fluid_synth_set_reverb (synth, revmodel_preset[i].roomsize,
-                              revmodel_preset[i].damp, revmodel_preset[i].width,
-                              revmodel_preset[i].level);
-      return FLUID_OK;
-    }
-    i++;
-  }
-  return FLUID_FAILED;
+  if (num >= FLUID_N_ELEMENTS(revmodel_preset))
+    return FLUID_FAILED;
+
+  fluid_synth_set_reverb (synth, revmodel_preset[num].roomsize,
+                          revmodel_preset[num].damp, revmodel_preset[num].width,
+                          revmodel_preset[num].level);
+  return FLUID_OK;
 }
 
 /**

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -191,7 +191,7 @@ void fluid_synth_dither_s16(int *dither_index, int len, float* lin, float* rin,
 			    void* rout, int roff, int rincr);
 
 int fluid_synth_reset_reverb(fluid_synth_t* synth);
-int fluid_synth_set_reverb_preset(fluid_synth_t* synth, int num);
+int fluid_synth_set_reverb_preset(fluid_synth_t* synth, unsigned int num);
 int fluid_synth_set_reverb_full(fluid_synth_t* synth, int set, double roomsize,
                                 double damping, double width, double level);
 

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -191,7 +191,7 @@ void fluid_synth_dither_s16(int *dither_index, int len, float* lin, float* rin,
 			    void* rout, int roff, int rincr);
 
 int fluid_synth_reset_reverb(fluid_synth_t* synth);
-int fluid_synth_set_reverb_preset(fluid_synth_t* synth, unsigned int num);
+int fluid_synth_set_reverb_preset(fluid_synth_t* synth, int num);
 int fluid_synth_set_reverb_full(fluid_synth_t* synth, int set, double roomsize,
                                 double damping, double width, double level);
 

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -86,7 +86,7 @@ fluid_conversion_config(void)
      implemented according to the pictures on SF2.01 page 73. */
 
   for (i = 1; i < 127; i++) {
-    x = -20.0 / 96.0 * log((i * i) / (127.0 * 127.0)) / log(10.0);
+    x = -20.0 / 96.0 * log((i * i) / (127.0 * 127.0)) / M_LN10;
     fluid_convex_tab[i] = (fluid_real_t) (1.0 - x);
     fluid_concave_tab[127 - i] = (fluid_real_t) x;
   }
@@ -281,7 +281,7 @@ fluid_act2hz(fluid_real_t c)
 fluid_real_t
 fluid_hz2ct(fluid_real_t f)
 {
-  return (fluid_real_t) (6900 + 1200 * log(f / 440.0) / log(2.0));
+  return (fluid_real_t) (6900 + 1200 * log(f / 440.0) / M_LN2);
 }
 
 /*

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -92,7 +92,7 @@ fluid_conversion_config(void)
   }
 
   /* initialize the pan conversion table */
-  x = PI / 2.0 / (FLUID_PAN_SIZE - 1.0);
+  x = M_PI / 2.0 / (FLUID_PAN_SIZE - 1.0);
   for (i = 0; i < FLUID_PAN_SIZE; i++) {
     fluid_pan_tab[i] = (fluid_real_t) sin(i * x);
   }

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -74,7 +74,7 @@ static fluid_log_function_t fluid_log_function[LAST_LOG_LEVEL];
 static void* fluid_log_user_data[LAST_LOG_LEVEL];
 static int fluid_log_initialized = 0;
 
-static char* fluid_libname = "fluidsynth";
+static const char fluid_libname[] = "fluidsynth";
 
 
 void fluid_sys_config()

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -206,10 +206,6 @@ typedef struct _fluid_sample_timer_t fluid_sample_timer_t;
 #define FLUID_DEFAULT_AUDIO_RT_PRIO  60         /**< Default setting for audio.realtime-prio */
 #define FLUID_DEFAULT_MIDI_RT_PRIO   50         /**< Default setting for midi.realtime-prio */
 
-#ifndef PI
-#define PI                          3.141592654
-#endif
-
 /***************************************************************
  *
  *                      SYSTEM INTERFACE
@@ -280,6 +276,13 @@ typedef FILE*  fluid_file;
 #define M_PI 3.1415926535897932384626433832795
 #endif
 
+#ifndef M_LN2
+#define M_LN2 0.69314718055994530941723212145818
+#endif
+
+#ifndef M_LN10
+#define M_LN10 2.3025850929940456840179914546844
+#endif
 
 #define FLUID_ASSERT(a,b)
 #define FLUID_ASSERT_P(a,b)


### PR DESCRIPTION
This is the first set of fixes that I made for running Fluidsynth on my embedded platform.

bindings/fluidmax/fluidmax.c
src/synth/fluid_gen.c

- The array fluid_gen_info[] is declared as const, by looking the location where it is used, it seems good to be a read-only object.

src/bindings/fluid_cmd.c

- The array of commands could be a const object. Strings inside this array could be constant too. In my opinion, it would be a good idea to declare a fluid_cmd_int_t typedef, which is similar to the fluid_cmd_t but without the 'data' member, to avoid useless waste of space and it also simplify the next changes.
- I remove the sentinel with all NULL pointers. The number of elements in the list is known, thanks to the FLUID_N_ELEMENTS() macro.
- To avoid the warning of signed/unsigned comparison mismatch, the integer variables used with the FLUID_N_ELEMENTS() macro should be an unsigned type.
- In line #1628, in the code for handling the help, there is a copy of the current fluid_commands[i] item in RAM. It seems to me that there is not an explanation for doing this, at least with the current code, so I replaced that into the if() statement and the strcmp() function with direct access to the structure.
- In functions new_fluid_cmd_handler(), instead of setting the 'data' member and then resetting it back to NULL, it just makes a fluid_cmd_t structure, filled with the values inside fluid_commands[i]. Required because fluid_commands[i] is now constant and declared with reduced, space-saving structure and now also thread-safe.

src/bindings/fluid_filerenderer.c

- Actually, objects like format_names[] are made of 2 parts, the array of pointers and the strings to be addressed. For having a fully constant object, both the array and the strings should be declared constant, by writing "const char * const" in the declaration. They have been also declared as static since they are used only locally.
- I removed the sentinel used of detecting the end of the lists type_names[], format_names[] and endian_names[]. Their length is known by using FLUID_N_ELEMENTS() macro.

src/drivers/fluid_adriver.c

- 'name' field has been declared as const into struct fluid_audriver_definition_t.
- fluid_audio_drivers[] is declared as static const object.
- The sentinel used of detecting the end of fluid_audio_drivers[] has been removed. Its length is known by using FLUID_N_ELEMENTS() macro.
- By using FLUID_N_ELEMENTS() macro, the integer variable for parsing fluid_audio_drivers[] has been declared as unsigned type, to avoid warnings of signed/unsigned comparison mismatches.

src/drivers/fluid_adriver.h

- "fluid_sys.h" is included instead of "fluidsynth_priv.h", required for using FLUID_N_ELEMENTS() macro.
- 'name' field has been declared as const into struct fluid_audio_driver_t.

src/drivers/fluid_mdriver.c

- 'name' field has been declared as const into struct fluid_mdriver_definition_t.
- fluid_midi_drivers[] is declared as static const object.
- The sentinel used of detecting the end of fluid_midi_drivers[] has been removed. Its length is known by using FLUID_N_ELEMENTS() macro.
- By using FLUID_N_ELEMENTS() macro, the integer variable for parsing fluid_midi_drivers[] has been declared as unsigned type, to avoid warnings of signed/unsigned comparison mismatches.

src/drivers/fluid_mdriver.h

- "fluid_sys.h" is included instead of "fluidsynth_priv.h", required for using FLUID_N_ELEMENTS() macro.
- 'name' field has been declared as const into struct fluid_midi_driver_t.

src/synth/fluid_synth.c
src/synth/fluid_synth.h

- The revmodel_preset[] has been declared as const and the sentinel at the end has been removed.
- The fluid_synth_set_reverb_preset() function can be implemented much simpler, by using FLUID_N_ELEMENTS() macro to test the effective number of elements. For this reasons, the 'num' parameterhas been changed to unsigned type.
- 'name' field has been declared as pointer to const strings.

src/utils/fluid_sys.c

- fluid_libname[] can be a constant string, rather than a RAM pointer to RAM string.

src/rvoice/fluid_rev.h

- The 'name' field of structure fluid_revmodel_presets_t has been declared as const.

src/sfloader/fluid_defsfont.c

- The arrays idlist[], badgen[] and badpgen[] can be static const objects.

src/sfloader/fluid_defsfont.h

- Since the arrays idlist[], badgen[] and badpgen[] has been redeclared as static, I removed their declaration as 'extern'.

src/utils/fluid_conv.c
- To simplify calculations, log(10.0) and log(2.0) can be replaced by M_LN10 and M_LN2 macros.

src/utils/fluidsynth_priv.h
- If M_LN10 and M_LN2 macros do not exists, declare them, like it had been already done for M_PI.
