### PR TITLE
Fixed nasty loop test

### DIFF
--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -1647,7 +1647,7 @@ fluid_handle_help(fluid_cmd_handler_t* handler, int ac, char** av, fluid_ostream
     }; /* for all topics (outer loop) */
   } else {
     /* help (arbitrary topic or "all") */
-    for (i = 0; FLUID_N_ELEMENTS(fluid_commands); i++) {
+    for (i = 0; i < FLUID_N_ELEMENTS(fluid_commands); i++) {
       if (fluid_commands[i].help != NULL) {
 	if (strcmp(topic,"all") == 0 || strcmp(topic,fluid_commands[i].topic) == 0){
 	  fluid_ostream_printf(out, "%s\n", fluid_commands[i].help);


### PR DESCRIPTION
There's a nasty bug introduced in fluid_cmd.c that lead to a segfault when the shell command ```help all``` is used.  ```FLUID_N_ELEMENTS(fluid_commands)``` is a int >= 0 so will always be true, hence the loop over all commands never terminates.