### PR TITLE
Add in-place rendering to LADSPA

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -82,6 +82,13 @@ https://stackoverflow.com/a/6251757
                 When set to "yes" the LADSPA subsystem will be enabled. This subsystem allows to load and interconnect LADSPA plug-ins. The output of the synthesizer is processed by the LADSPA subsystem. Note that the synthesizer has to be compiled with LADSPA support. More information about the LADSPA subsystem later.</desc>
         </setting>
         <setting>
+            <name>ladspa.in-place</name>
+            <type>bool</type>
+            <def>0 (FALSE)</def>
+            <desc>
+                (Only supported if FluidSynth has been compiled to use floats instead of doubles). When set to "yes" the LADSPA subsystem will enable plugins to render audio in-place, without the overhead of copying input and output buffers.</desc>
+        </setting>
+        <setting>
             <name>midi-channels</name>
             <type>int</type>
             <def>16</def>

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -502,7 +502,7 @@ static FLUID_INLINE int ladspa_run_start(fluid_ladspa_fx_t *fx)
     /* Somebody wants to deactivate the engine, so let's give them a chance to do that.
      * And check that there is at least one plugin loaded, to avoid the overhead of the
      * atomic compare and exchange on an unconfigured LADSPA engine. */
-    if (fluid_atomic_int_get(&fx->pending_deactivation) || fx->num_plugins == 0)
+    if (fx->pending_deactivation || fx->num_plugins == 0)
     {
         return FLUID_FAILED;
     }

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -430,18 +430,23 @@ static int create_input_output_nodes(fluid_ladspa_fx_t *fx)
 {
     char name[99];
     int i;
+    int buf_size;
+
+    /* If this LADSPA fx is set to work on the buffers passed into fluid_ladspa_run in-place,
+     * then don't allocate space on the nodes. */
+    buf_size = (fx->in_place) ?  0 : FLUID_BUFSIZE;
 
     /* Create left and right input nodes for each audio group. */
     for (i = 0; i < fx->audio_groups; i++)
     {
         FLUID_SNPRINTF(name, sizeof(name), "in%i_L", (i + 1));
-        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, FLUID_BUFSIZE) == NULL)
+        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, buf_size) == NULL)
         {
             return FLUID_FAILED;
         }
 
         FLUID_SNPRINTF(name, sizeof(name), "in%i_R", (i + 1));
-        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, FLUID_BUFSIZE) == NULL)
+        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, buf_size) == NULL)
         {
             return FLUID_FAILED;
         }
@@ -451,13 +456,13 @@ static int create_input_output_nodes(fluid_ladspa_fx_t *fx)
     for (i = 0; i < fx->effects_channels; i++)
     {
         FLUID_SNPRINTF(name, sizeof(name), "send%i_L", (i + 1));
-        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, FLUID_BUFSIZE) == NULL)
+        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, buf_size) == NULL)
         {
             return FLUID_FAILED;
         }
 
         FLUID_SNPRINTF(name, sizeof(name), "send%i_R", (i + 1));
-        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, FLUID_BUFSIZE) == NULL)
+        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, buf_size) == NULL)
         {
             return FLUID_FAILED;
         }
@@ -467,13 +472,13 @@ static int create_input_output_nodes(fluid_ladspa_fx_t *fx)
     for (i = 0; i < fx->audio_channels; i++)
     {
         FLUID_SNPRINTF(name, sizeof(name), "out%i_L", (i + 1));
-        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, FLUID_BUFSIZE) == NULL)
+        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, buf_size) == NULL)
         {
             return FLUID_FAILED;
         }
 
         FLUID_SNPRINTF(name, sizeof(name), "out%i_R", (i + 1));
-        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, FLUID_BUFSIZE) == NULL)
+        if (new_fluid_ladspa_node(fx, name, FLUID_LADSPA_NODE_AUDIO, buf_size) == NULL)
         {
             return FLUID_FAILED;
         }
@@ -1222,7 +1227,7 @@ static fluid_ladspa_node_t *new_fluid_ladspa_node(fluid_ladspa_fx_t *fx, const c
 
 static void delete_fluid_ladspa_node(fluid_ladspa_node_t *node)
 {
-    if (node->buf != NULL)
+    if (node->buf != NULL && !node->buf_is_shared)
     {
         FLUID_FREE(node->buf);
     }

--- a/src/bindings/fluid_ladspa.h
+++ b/src/bindings/fluid_ladspa.h
@@ -106,6 +106,7 @@ typedef struct _fluid_ladspa_fx_t
     int audio_groups;
     int effects_channels;
     int audio_channels;
+    int buffer_size;
 
     int in_place;
 
@@ -133,7 +134,7 @@ typedef struct _fluid_ladspa_fx_t
 } fluid_ladspa_fx_t;
 
 
-fluid_ladspa_fx_t *new_fluid_ladspa_fx(fluid_real_t sample_rate, int audio_groups, int effects_channels, int audio_channels);
+fluid_ladspa_fx_t *new_fluid_ladspa_fx(fluid_real_t sample_rate, int audio_groups, int effects_channels, int audio_channels, int buffer_size);
 void delete_fluid_ladspa_fx(fluid_ladspa_fx_t *fx);
 int fluid_ladspa_set_sample_rate(fluid_ladspa_fx_t *fx, fluid_real_t sample_rate);
 
@@ -143,7 +144,7 @@ int fluid_ladspa_deactivate(fluid_ladspa_fx_t *fx);
 int fluid_ladspa_reset(fluid_ladspa_fx_t *fx);
 
 void fluid_ladspa_run(fluid_ladspa_fx_t *fx, fluid_real_t *left_buf[], fluid_real_t *right_buf[],
-                      fluid_real_t *fx_left_buf[], fluid_real_t *fx_right_buf[]);
+                      fluid_real_t *fx_left_buf[], fluid_real_t *fx_right_buf[], int block, int block_size);
 
 int fluid_ladspa_add_plugin(fluid_ladspa_fx_t *fx, const char *lib_name, const char *plugin_name);
 int fluid_ladspa_port_exists(fluid_ladspa_fx_t *fx, int plugin_id, const char *name);

--- a/src/bindings/fluid_ladspa.h
+++ b/src/bindings/fluid_ladspa.h
@@ -91,6 +91,9 @@ typedef struct _fluid_ladspa_node_t
     fluid_ladspa_node_type_t type;
     LADSPA_Data *buf;
 
+    /* used to indicate that buf was not allocated by the LADSPA fx, but is supplied externally */
+    int buf_is_shared;
+
     int num_inputs;
     int num_outputs;
 
@@ -103,6 +106,8 @@ typedef struct _fluid_ladspa_fx_t
     int audio_groups;
     int effects_channels;
     int audio_channels;
+
+    int in_place;
 
     fluid_ladspa_lib_t *libs[FLUID_LADSPA_MAX_LIBS];
     int num_libs;

--- a/src/bindings/fluid_ladspa.h
+++ b/src/bindings/fluid_ladspa.h
@@ -137,6 +137,8 @@ typedef struct _fluid_ladspa_fx_t
 fluid_ladspa_fx_t *new_fluid_ladspa_fx(fluid_real_t sample_rate, int audio_groups, int effects_channels, int audio_channels, int buffer_size);
 void delete_fluid_ladspa_fx(fluid_ladspa_fx_t *fx);
 int fluid_ladspa_set_sample_rate(fluid_ladspa_fx_t *fx, fluid_real_t sample_rate);
+int fluid_ladspa_set_in_place_buffers(fluid_ladspa_fx_t *fx, fluid_real_t *left_buf[],
+        fluid_real_t *right_buf[], fluid_real_t *fx_left_buf[], fluid_real_t *fx_right_buf[]);
 
 int fluid_ladspa_is_active(fluid_ladspa_fx_t *fx);
 int fluid_ladspa_activate(fluid_ladspa_fx_t *fx);
@@ -144,7 +146,8 @@ int fluid_ladspa_deactivate(fluid_ladspa_fx_t *fx);
 int fluid_ladspa_reset(fluid_ladspa_fx_t *fx);
 
 void fluid_ladspa_run(fluid_ladspa_fx_t *fx, fluid_real_t *left_buf[], fluid_real_t *right_buf[],
-                      fluid_real_t *fx_left_buf[], fluid_real_t *fx_right_buf[], int block, int block_size);
+                      fluid_real_t *fx_left_buf[], fluid_real_t *fx_right_buf[], int block_count, int block_size);
+void fluid_ladspa_run_in_place(fluid_ladspa_fx_t *fx, int block_count, int block_size);
 
 int fluid_ladspa_add_plugin(fluid_ladspa_fx_t *fx, const char *lib_name, const char *plugin_name);
 int fluid_ladspa_port_exists(fluid_ladspa_fx_t *fx, int plugin_id, const char *name);

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -648,7 +648,7 @@ void delete_fluid_rvoice_mixer(fluid_rvoice_mixer_t* mixer)
 
 
 #ifdef LADSPA				    
-void fluid_rvoice_mixer_set_ladspa(fluid_rvoice_mixer_t* mixer, fluid_ladspa_fx_t *ladspa_fx)
+void fluid_rvoice_mixer_set_ladspa(fluid_rvoice_mixer_t* mixer, fluid_ladspa_fx_t *ladspa_fx, int in_place)
 {
   mixer->ladspa_fx = ladspa_fx;
 }

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -82,6 +82,7 @@ struct _fluid_rvoice_mixer_t {
 
 #ifdef LADSPA
   fluid_ladspa_fx_t* ladspa_fx; /**< Used by mixer only: Effects unit for LADSPA support. Never created or freed */
+  int ladspa_in_place;          /**< flag to enable in-place rendering on the mixer buffers */
 #endif
 
 #ifdef ENABLE_MIXER_THREADS
@@ -143,13 +144,19 @@ fluid_rvoice_mixer_process_fx(fluid_rvoice_mixer_t* mixer)
 #ifdef LADSPA
   /* Run the signal through the LADSPA Fx unit */
   if (mixer->ladspa_fx) {
-    for (i=0; i < mixer->current_blockcount; i++) {
-      fluid_ladspa_run(mixer->ladspa_fx,
-              mixer->buffers.left_buf, mixer->buffers.right_buf,
-              mixer->buffers.fx_left_buf, mixer->buffers.fx_right_buf,
-              i, FLUID_BUFSIZE);
-    }
-    fluid_check_fpe("LADSPA");
+      /* If in-place rendering is requested, run the LADSPA engine on the previously set
+       * buffers (set in fluid_rvoice_mixer_set_ladspa) */
+      if (mixer->ladspa_in_place)
+      {
+        fluid_ladspa_run_in_place(mixer->ladspa_fx, mixer->current_blockcount, FLUID_BUFSIZE);
+      }
+      else {
+        fluid_ladspa_run(mixer->ladspa_fx,
+                mixer->buffers.left_buf, mixer->buffers.right_buf,
+                mixer->buffers.fx_left_buf, mixer->buffers.fx_right_buf,
+                mixer->current_blockcount, FLUID_BUFSIZE);
+      }
+      fluid_check_fpe("LADSPA");
   }
 #endif
 }
@@ -632,6 +639,18 @@ void delete_fluid_rvoice_mixer(fluid_rvoice_mixer_t* mixer)
 void fluid_rvoice_mixer_set_ladspa(fluid_rvoice_mixer_t* mixer, fluid_ladspa_fx_t *ladspa_fx, int in_place)
 {
   mixer->ladspa_fx = ladspa_fx;
+  mixer->ladspa_in_place = in_place;
+
+  /* Connect the mixer buffers to LADSPA for in-place rendering */
+  if (mixer->ladspa_in_place)
+  {
+      if (fluid_ladspa_set_in_place_buffers(ladspa_fx, mixer->buffers.left_buf, mixer->buffers.right_buf,
+              mixer->buffers.fx_left_buf, mixer->buffers.fx_right_buf) != FLUID_OK)
+      {
+          FLUID_LOG(FLUID_WARN, "Failed to set up LADSPA in-place buffers, disabling in-place rendering");
+          mixer->ladspa_in_place = 0;
+      }
+  }
 }
 #endif
 

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -142,7 +142,7 @@ fluid_rvoice_mixer_process_fx(fluid_rvoice_mixer_t* mixer)
   
 #ifdef LADSPA
   /* Run the signal through the LADSPA Fx unit */
-  if (mixer->ladspa_fx && mixer->ladspa_fx->state == FLUID_LADSPA_ACTIVE) {
+  if (mixer->ladspa_fx) {
     for (i=0; i < mixer->current_blockcount; i++) {
       fluid_ladspa_run(mixer->ladspa_fx,
               mixer->buffers.left_buf, mixer->buffers.right_buf,

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -143,30 +143,11 @@ fluid_rvoice_mixer_process_fx(fluid_rvoice_mixer_t* mixer)
 #ifdef LADSPA
   /* Run the signal through the LADSPA Fx unit */
   if (mixer->ladspa_fx && mixer->ladspa_fx->state == FLUID_LADSPA_ACTIVE) {
-    int j;
-    FLUID_DECLARE_VLA(fluid_real_t*, left_buf, mixer->buffers.buf_count);
-    FLUID_DECLARE_VLA(fluid_real_t*, right_buf, mixer->buffers.buf_count);
-    FLUID_DECLARE_VLA(fluid_real_t*, fx_left_buf, mixer->buffers.fx_buf_count);
-    FLUID_DECLARE_VLA(fluid_real_t*, fx_right_buf, mixer->buffers.fx_buf_count);
-    for (j=0; j < mixer->buffers.buf_count; j++) {
-      left_buf[j] = mixer->buffers.left_buf[j];
-      right_buf[j] = mixer->buffers.right_buf[j];
-    }
-    for (j=0; j < mixer->buffers.fx_buf_count; j++) {
-      fx_left_buf[j] = mixer->buffers.fx_left_buf[j];
-      fx_right_buf[j] = mixer->buffers.fx_right_buf[j];
-    }
-    for (i=0; i < mixer->current_blockcount * FLUID_BUFSIZE; i += FLUID_BUFSIZE) {
-      fluid_ladspa_run(mixer->ladspa_fx, left_buf, right_buf, fx_left_buf,
-                      fx_right_buf);
-      for (j=0; j < mixer->buffers.buf_count; j++) {
-        left_buf[j] += FLUID_BUFSIZE;
-        right_buf[j] += FLUID_BUFSIZE;
-      }
-      for (j=0; j < mixer->buffers.fx_buf_count; j++) {
-        fx_left_buf[j] += FLUID_BUFSIZE;
-        fx_right_buf[j] += FLUID_BUFSIZE;
-      }
+    for (i=0; i < mixer->current_blockcount; i++) {
+      fluid_ladspa_run(mixer->ladspa_fx,
+              mixer->buffers.left_buf, mixer->buffers.right_buf,
+              mixer->buffers.fx_left_buf, mixer->buffers.fx_right_buf,
+              i, FLUID_BUFSIZE);
     }
     fluid_check_fpe("LADSPA");
   }

--- a/src/rvoice/fluid_rvoice_mixer.h
+++ b/src/rvoice/fluid_rvoice_mixer.h
@@ -69,7 +69,7 @@ void fluid_rvoice_mixer_set_threads(fluid_rvoice_mixer_t* mixer, int thread_coun
 				    int prio_level);
 				    
 #ifdef LADSPA				    
-void fluid_rvoice_mixer_set_ladspa(fluid_rvoice_mixer_t* mixer, fluid_ladspa_fx_t* ladspa_fx);
+void fluid_rvoice_mixer_set_ladspa(fluid_rvoice_mixer_t* mixer, fluid_ladspa_fx_t* ladspa_fx, int in_place);
 #endif
 
 #endif

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -724,7 +724,7 @@ new_fluid_synth(fluid_settings_t *settings)
 #endif /* WITH_FLOAT */
 
     synth->ladspa_fx = new_fluid_ladspa_fx(synth->sample_rate, synth->audio_groups,
-            synth->effects_channels, synth->audio_channels);
+            synth->effects_channels, synth->audio_channels, FLUID_BUFSIZE);
     if(synth->ladspa_fx == NULL) {
       FLUID_LOG(FLUID_ERR, "Out of memory");
       goto error_recovery;

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -180,6 +180,8 @@ void fluid_synth_settings(fluid_settings_t* settings)
                               FLUID_HINT_TOGGLED, NULL, NULL);
   fluid_settings_register_int(settings, "synth.ladspa.active", 0, 0, 1,
                               FLUID_HINT_TOGGLED, NULL, NULL);
+  fluid_settings_register_int(settings, "synth.ladspa.in-place", 0, 0, 1,
+                              FLUID_HINT_TOGGLED, NULL, NULL);
   fluid_settings_register_int(settings, "synth.lock-memory", 1, 0, 1,
                               FLUID_HINT_TOGGLED, NULL, NULL);
   fluid_settings_register_str(settings, "midi.portname", "", 0, NULL, NULL);
@@ -710,13 +712,24 @@ new_fluid_synth(fluid_settings_t *settings)
   fluid_settings_getint(settings, "synth.ladspa.active", &with_ladspa);
   if (with_ladspa) {
 #ifdef LADSPA
+    int ladspa_in_place = 0;
+    fluid_settings_getint(settings, "synth.ladspa.in-place", &ladspa_in_place);
+
+#ifndef WITH_FLOAT
+    if (ladspa_in_place) {
+      FLUID_LOG(FLUID_WARN, "In-place rendering for LADSPA is only available if "
+              "FluidSynth was compiled to use float instead of double");
+      ladspa_in_place = 0;
+    }
+#endif /* WITH_FLOAT */
+
     synth->ladspa_fx = new_fluid_ladspa_fx(synth->sample_rate, synth->audio_groups,
             synth->effects_channels, synth->audio_channels);
     if(synth->ladspa_fx == NULL) {
       FLUID_LOG(FLUID_ERR, "Out of memory");
       goto error_recovery;
     }
-    fluid_rvoice_mixer_set_ladspa(synth->eventhandler->mixer, synth->ladspa_fx);
+    fluid_rvoice_mixer_set_ladspa(synth->eventhandler->mixer, synth->ladspa_fx, ladspa_in_place);
 #else /* LADSPA */
     FLUID_LOG(FLUID_WARN, "FluidSynth has not been compiled with LADSPA support");
 #endif /* LADSPA */

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -724,7 +724,8 @@ new_fluid_synth(fluid_settings_t *settings)
 #endif /* WITH_FLOAT */
 
     synth->ladspa_fx = new_fluid_ladspa_fx(synth->sample_rate, synth->audio_groups,
-            synth->effects_channels, synth->audio_channels, FLUID_BUFSIZE);
+            synth->effects_channels, synth->audio_channels,
+            FLUID_MIXER_MAX_BUFFERS_DEFAULT * FLUID_BUFSIZE);
     if(synth->ladspa_fx == NULL) {
       FLUID_LOG(FLUID_ERR, "Out of memory");
       goto error_recovery;


### PR DESCRIPTION
This set of commits make some performance optimizations to the LADSPA system. It adds an in-place rendering mode, which is only available if FluidSynth has been compiled with `-Denable-floats=1`. To enable it, a new setting `synth.ladspa.in-place` has been introduced. In-place rendering means that the LADSPA plugins operate directly on the mixer buffers when reading or writing to the system nodes. This eliminates two memcpy operations per input and output channel.

This pull request also changes the "normal" (not in-place) rendering entry point fluid_ladspa_run, removing the need for VLAs, removing lots of for-loops in rvoice mixer and reducing the number of executed atomic compare and exchange operations. fluid_ladspa_run and the new fluid_ladspa_run_in_place methods process all blocks to be rendered as a single large block, calling each plugin only once.