### PR TITLE
remove glib.h import from fluid_defsfont.h

### DIFF
--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -301,27 +301,6 @@ SFData *sfload_file (const char * fname);
 /********************************************************************************/
 /********************************************************************************/
 
-/* GLIB - Library of useful routines for C programming
- * Copyright (C) 1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02110-1301, USA.
- */
-
-#include <glib.h>
-
 
 /*-----------------------------------util.h----------------------------*/
 /*


### PR DESCRIPTION
not needed anymore since the glib macro is now wrapped in a custom FLUID macro