### PR TITLE
fix library file names when building with MinGW and CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,6 +268,15 @@ elseif ( OS2 )
         VERSION ${LIB_VERSION_INFO}
         SOVERSION ${LIB_VERSION_CURRENT}
     )
+elseif ( WIN32 )
+  set_target_properties ( libfluidsynth
+    PROPERTIES
+      ARCHIVE_OUTPUT_NAME "fluidsynth"
+      PREFIX "lib"
+      OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
+      VERSION ${LIB_VERSION_INFO}
+      SOVERSION ${LIB_VERSION_CURRENT}
+    )
 else ( MACOSX_FRAMEWORK )
   set_target_properties ( libfluidsynth
     PROPERTIES


### PR DESCRIPTION
We have applied this patch to the mingw-w64-fluidsynth package [1] in
MSYS2 to recieve the same library file names when building with CMake
as we got when building with Autotools.

[1] https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-fluidsynth