### PR TITLE
 introduce separate type for client IDs

### DIFF
--- a/include/fluidsynth/event.h
+++ b/include/fluidsynth/event.h
@@ -67,8 +67,8 @@ FLUIDSYNTH_API fluid_event_t* new_fluid_event(void);
 FLUIDSYNTH_API void delete_fluid_event(fluid_event_t* evt);
 
 /* Initializing events */
-FLUIDSYNTH_API void fluid_event_set_source(fluid_event_t* evt, short src);
-FLUIDSYNTH_API void fluid_event_set_dest(fluid_event_t* evt, short dest);
+FLUIDSYNTH_API void fluid_event_set_source(fluid_event_t* evt, fluid_seq_id_t src);
+FLUIDSYNTH_API void fluid_event_set_dest(fluid_event_t* evt, fluid_seq_id_t dest);
 
 /* Timer events */
 FLUIDSYNTH_API void fluid_event_timer(fluid_event_t* evt, void* data);
@@ -115,8 +115,8 @@ FLUIDSYNTH_API void fluid_event_unregistering(fluid_event_t* evt);
 
 /* Accessing event data */
 FLUIDSYNTH_API int fluid_event_get_type(fluid_event_t* evt);
-FLUIDSYNTH_API short fluid_event_get_source(fluid_event_t* evt);
-FLUIDSYNTH_API short fluid_event_get_dest(fluid_event_t* evt);
+FLUIDSYNTH_API fluid_seq_id_t fluid_event_get_source(fluid_event_t* evt);
+FLUIDSYNTH_API fluid_seq_id_t fluid_event_get_dest(fluid_event_t* evt);
 FLUIDSYNTH_API int fluid_event_get_channel(fluid_event_t* evt);
 FLUIDSYNTH_API short fluid_event_get_key(fluid_event_t* evt);
 FLUIDSYNTH_API short fluid_event_get_velocity(fluid_event_t* evt);

--- a/include/fluidsynth/seq.h
+++ b/include/fluidsynth/seq.h
@@ -51,8 +51,8 @@ fluid_seq_id_t fluid_sequencer_register_client(fluid_sequencer_t* seq, const cha
 FLUIDSYNTH_API void fluid_sequencer_unregister_client(fluid_sequencer_t* seq, fluid_seq_id_t id);
 FLUIDSYNTH_API int fluid_sequencer_count_clients(fluid_sequencer_t* seq);
 FLUIDSYNTH_API fluid_seq_id_t fluid_sequencer_get_client_id(fluid_sequencer_t* seq, int index);
-FLUIDSYNTH_API char* fluid_sequencer_get_client_name(fluid_sequencer_t* seq, int id);
-FLUIDSYNTH_API int fluid_sequencer_client_is_dest(fluid_sequencer_t* seq, int id);
+FLUIDSYNTH_API char* fluid_sequencer_get_client_name(fluid_sequencer_t* seq, fluid_seq_id_t id);
+FLUIDSYNTH_API int fluid_sequencer_client_is_dest(fluid_sequencer_t* seq, fluid_seq_id_t id);
 FLUIDSYNTH_API void fluid_sequencer_process(fluid_sequencer_t* seq, unsigned int msec);
 FLUIDSYNTH_API void fluid_sequencer_send_now(fluid_sequencer_t* seq, fluid_event_t* evt);
 FLUIDSYNTH_API 

--- a/include/fluidsynth/seq.h
+++ b/include/fluidsynth/seq.h
@@ -46,11 +46,11 @@ FLUIDSYNTH_API fluid_sequencer_t* new_fluid_sequencer2(int use_system_timer);
 FLUIDSYNTH_API void delete_fluid_sequencer(fluid_sequencer_t* seq);
 FLUIDSYNTH_API int fluid_sequencer_get_use_system_timer(fluid_sequencer_t* seq);
 FLUIDSYNTH_API 
-short fluid_sequencer_register_client(fluid_sequencer_t* seq, const char *name, 
+fluid_seq_id_t fluid_sequencer_register_client(fluid_sequencer_t* seq, const char *name, 
 				     fluid_event_callback_t callback, void* data);
-FLUIDSYNTH_API void fluid_sequencer_unregister_client(fluid_sequencer_t* seq, short id);
+FLUIDSYNTH_API void fluid_sequencer_unregister_client(fluid_sequencer_t* seq, fluid_seq_id_t id);
 FLUIDSYNTH_API int fluid_sequencer_count_clients(fluid_sequencer_t* seq);
-FLUIDSYNTH_API short fluid_sequencer_get_client_id(fluid_sequencer_t* seq, int index);
+FLUIDSYNTH_API fluid_seq_id_t fluid_sequencer_get_client_id(fluid_sequencer_t* seq, int index);
 FLUIDSYNTH_API char* fluid_sequencer_get_client_name(fluid_sequencer_t* seq, int id);
 FLUIDSYNTH_API int fluid_sequencer_client_is_dest(fluid_sequencer_t* seq, int id);
 FLUIDSYNTH_API void fluid_sequencer_process(fluid_sequencer_t* seq, unsigned int msec);
@@ -59,7 +59,7 @@ FLUIDSYNTH_API
 int fluid_sequencer_send_at(fluid_sequencer_t* seq, fluid_event_t* evt, 
 			   unsigned int time, int absolute);
 FLUIDSYNTH_API 
-void fluid_sequencer_remove_events(fluid_sequencer_t* seq, short source, short dest, int type);
+void fluid_sequencer_remove_events(fluid_sequencer_t* seq, fluid_seq_id_t source, fluid_seq_id_t dest, int type);
 FLUIDSYNTH_API unsigned int fluid_sequencer_get_tick(fluid_sequencer_t* seq);
 FLUIDSYNTH_API void fluid_sequencer_set_time_scale(fluid_sequencer_t* seq, double scale);
 FLUIDSYNTH_API double fluid_sequencer_get_time_scale(fluid_sequencer_t* seq);

--- a/include/fluidsynth/seqbind.h
+++ b/include/fluidsynth/seqbind.h
@@ -33,7 +33,7 @@ extern "C" {
  */
 
 FLUIDSYNTH_API 
-short fluid_sequencer_register_fluidsynth(fluid_sequencer_t* seq, fluid_synth_t* synth);
+fluid_seq_id_t fluid_sequencer_register_fluidsynth(fluid_sequencer_t* seq, fluid_synth_t* synth);
 FLUIDSYNTH_API int
 fluid_sequencer_add_midi_event_to_buffer(void* data, fluid_midi_event_t* event);
 

--- a/include/fluidsynth/types.h
+++ b/include/fluidsynth/types.h
@@ -61,7 +61,7 @@ typedef struct _fluid_cmd_handler_t fluid_cmd_handler_t;        /**< Shell Comma
 typedef int fluid_istream_t;    /**< Input stream descriptor */
 typedef int fluid_ostream_t;    /**< Output stream descriptor */
 
-typedef short fluid_seq_id_t; /**< Type used for unique client IDs by the sequencer and #fluid_event_t */
+typedef short fluid_seq_id_t; /**< Unique client IDs use by the sequencer and #fluid_event_t, obtained by fluid_sequencer_register_client() and fluid_sequencer_register_fluidsynth() */
 
 #ifdef __cplusplus
 }

--- a/include/fluidsynth/types.h
+++ b/include/fluidsynth/types.h
@@ -61,6 +61,7 @@ typedef struct _fluid_cmd_handler_t fluid_cmd_handler_t;        /**< Shell Comma
 typedef int fluid_istream_t;    /**< Input stream descriptor */
 typedef int fluid_ostream_t;    /**< Output stream descriptor */
 
+typedef short fluid_seq_id_t; /**< Type used for unique client IDs by the sequencer and #fluid_event_t */
 
 #ifdef __cplusplus
 }

--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -46,7 +46,7 @@ struct _fluid_sequencer_t {
 	int useSystemTimer;
 	double scale; // ticks per second
 	fluid_list_t* clients;
-	short clientsID;
+	fluid_seq_id_t clientsID;
 	/* for queue + heap */
 	fluid_evt_entry* preQueue;
 	fluid_evt_entry* preQueueLast;
@@ -67,7 +67,7 @@ struct _fluid_sequencer_t {
 
 /* Private data for clients */
 typedef struct _fluid_sequencer_client_t {
-	short id;
+	fluid_seq_id_t id;
 	char* name;
 	fluid_event_callback_t callback;
 	void* data;
@@ -77,7 +77,7 @@ typedef struct _fluid_sequencer_client_t {
 static short _fluid_seq_queue_init(fluid_sequencer_t* seq, int nbEvents);
 static void _fluid_seq_queue_end(fluid_sequencer_t* seq);
 static short _fluid_seq_queue_pre_insert(fluid_sequencer_t* seq, fluid_event_t * evt);
-static void _fluid_seq_queue_pre_remove(fluid_sequencer_t* seq, short src, short dest, int type);
+static void _fluid_seq_queue_pre_remove(fluid_sequencer_t* seq, fluid_seq_id_t src, fluid_seq_id_t dest, int type);
 static int _fluid_seq_queue_process(void* data, unsigned int msec); // callback from timer
 static void _fluid_seq_queue_insert_entry(fluid_sequencer_t* seq, fluid_evt_entry * evtentry);
 static void _fluid_seq_queue_remove_entries_matching(fluid_sequencer_t* seq, fluid_evt_entry* temp);
@@ -262,7 +262,7 @@ void fluid_seq_dotrace(fluid_sequencer_t* seq, char *fmt, ...) {}
  * Clients can be sources or destinations of events.  Sources don't need to
  * register a callback.
  */
-short
+fluid_seq_id_t
 fluid_sequencer_register_client (fluid_sequencer_t* seq, const char *name,
                                  fluid_event_callback_t callback, void* data)
 {
@@ -300,7 +300,7 @@ fluid_sequencer_register_client (fluid_sequencer_t* seq, const char *name,
  * @param id Client ID as returned by fluid_sequencer_register_client().
  */
 void
-fluid_sequencer_unregister_client (fluid_sequencer_t* seq, short id)
+fluid_sequencer_unregister_client (fluid_sequencer_t* seq, fluid_seq_id_t id)
 {
 	fluid_list_t *tmp;
 	fluid_event_t* evt;
@@ -355,7 +355,7 @@ fluid_sequencer_count_clients(fluid_sequencer_t* seq)
  * @param index Index of register client
  * @return Client ID or #FLUID_FAILED if not found
  */
-short fluid_sequencer_get_client_id (fluid_sequencer_t* seq, int index)
+fluid_seq_id_t fluid_sequencer_get_client_id (fluid_sequencer_t* seq, int index)
 {
 	fluid_list_t *tmp = fluid_list_nth(seq->clients, index);
 	if (tmp == NULL) {
@@ -427,7 +427,7 @@ fluid_sequencer_client_is_dest(fluid_sequencer_t* seq, int id)
 void
 fluid_sequencer_send_now(fluid_sequencer_t* seq, fluid_event_t* evt)
 {
-	short destID = fluid_event_get_dest(evt);
+	fluid_seq_id_t destID = fluid_event_get_dest(evt);
 
 	/* find callback */
 	fluid_list_t *tmp = seq->clients;
@@ -478,8 +478,8 @@ fluid_sequencer_send_at (fluid_sequencer_t* seq, fluid_event_t* evt,
  * @param type Event type to match or -1 for wildcard (#fluid_seq_event_type)
  */
 void
-fluid_sequencer_remove_events (fluid_sequencer_t* seq, short source,
-                               short dest, int type)
+fluid_sequencer_remove_events (fluid_sequencer_t* seq, fluid_seq_id_t source,
+                               fluid_seq_id_t dest, int type)
 {
 	_fluid_seq_queue_pre_remove(seq, source, dest, type);
 }
@@ -747,7 +747,7 @@ _fluid_seq_queue_pre_insert(fluid_sequencer_t* seq, fluid_event_t * evt)
  * May be called from the main thread (usually) but also recursively
  * from the queue thread, when a callback itself does an insert... */
 static void
-_fluid_seq_queue_pre_remove(fluid_sequencer_t* seq, short src, short dest, int type)
+_fluid_seq_queue_pre_remove(fluid_sequencer_t* seq, fluid_seq_id_t src, fluid_seq_id_t dest, int type)
 {
 	fluid_evt_entry * evtentry = _fluid_seq_heap_get_free(seq->heap);
 	if (evtentry == NULL) {
@@ -979,7 +979,7 @@ _fluid_seq_queue_insert_entry(fluid_sequencer_t* seq, fluid_evt_entry * evtentry
 }
 
 static int
-_fluid_seq_queue_matchevent(fluid_event_t* evt, int templType, short templSrc, short templDest)
+_fluid_seq_queue_matchevent(fluid_event_t* evt, int templType, fluid_seq_id_t templSrc, fluid_seq_id_t templDest)
 {
 	int eventType;
 
@@ -1016,7 +1016,7 @@ _fluid_seq_queue_remove_entries_matching(fluid_sequencer_t* seq, fluid_evt_entry
 {
 	/* we walk everything : this is slow, but that is life */
 	int i, type;
-	short src, dest;
+	fluid_seq_id_t src, dest;
 
 	src = templ->evt.src;
 	dest = templ->evt.dest;

--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -374,7 +374,7 @@ fluid_seq_id_t fluid_sequencer_get_client_id (fluid_sequencer_t* seq, int index)
  *   be modified or freed.
  */
 char *
-fluid_sequencer_get_client_name(fluid_sequencer_t* seq, int id)
+fluid_sequencer_get_client_name(fluid_sequencer_t* seq, fluid_seq_id_t id)
 {
 	fluid_list_t *tmp;
 
@@ -400,7 +400,7 @@ fluid_sequencer_get_client_name(fluid_sequencer_t* seq, int id)
  * @return TRUE if client is a destination client, FALSE otherwise or if not found
  */
 int
-fluid_sequencer_client_is_dest(fluid_sequencer_t* seq, int id)
+fluid_sequencer_client_is_dest(fluid_sequencer_t* seq, fluid_seq_id_t id)
 {
 	fluid_list_t *tmp;
 

--- a/src/midi/fluid_seqbind.c
+++ b/src/midi/fluid_seqbind.c
@@ -41,7 +41,7 @@ struct _fluid_seqbind_t {
 	fluid_synth_t* synth;
 	fluid_sequencer_t* seq;
 	fluid_sample_timer_t* sample_timer;
-	short client_id;
+	fluid_seq_id_t client_id;
 };
 typedef struct _fluid_seqbind_t fluid_seqbind_t;
 
@@ -75,7 +75,7 @@ delete_fluid_seqbind(fluid_seqbind_t* seqbind)
  * @param synth Synthesizer instance
  * @returns Sequencer client ID, or #FLUID_FAILED on error.
  */
-short 
+fluid_seq_id_t 
 fluid_sequencer_register_fluidsynth (fluid_sequencer_t* seq, fluid_synth_t* synth)
 {
 	fluid_seqbind_t* seqbind;
@@ -243,9 +243,10 @@ fluid_seq_fluidsynth_callback(unsigned int time, fluid_event_t* evt, fluid_seque
 	}
 }
 
-static int get_fluidsynth_dest(fluid_sequencer_t* seq) 
+static fluid_seq_id_t get_fluidsynth_dest(fluid_sequencer_t* seq) 
 {
-	int i, id;
+	int i;
+	fluid_seq_id_t id;
 	char* name;
 	int j = fluid_sequencer_count_clients(seq);
 	for (i = 0; i < j; i++) {

--- a/src/synth/fluid_event.c
+++ b/src/synth/fluid_event.c
@@ -93,23 +93,23 @@ fluid_event_set_time(fluid_event_t* evt, unsigned int time)
 }
 
 /**
- * Set source of a sequencer event (DOCME).
+ * Set source of a sequencer event. \c src must be a unique sequencer ID or -1 if not set.
  * @param evt Sequencer event structure
- * @param src DOCME
+ * @param src Unique sequencer ID
  */
 void
-fluid_event_set_source(fluid_event_t* evt, short src)
+fluid_event_set_source(fluid_event_t* evt, fluid_seq_id_t src)
 {
 	evt->src = src;
 }
 
 /**
- * Set destination of a sequencer event (DOCME).
+ * Set destination of this sequencer event, i.e. the sequencer client this event will be sent to. \c dest must be a unique sequencer ID.
  * @param evt Sequencer event structure
- * @param dest DOCME
+ * @param dest The destination unique sequencer ID
  */
 void
-fluid_event_set_dest(fluid_event_t* evt, short dest)
+fluid_event_set_dest(fluid_event_t* evt, fluid_seq_id_t dest)
 {
 	evt->dest = dest;
 }
@@ -488,21 +488,21 @@ unsigned int fluid_event_get_time(fluid_event_t* evt)
 }
 
 /**
- * Get the source field from a sequencer event structure.
+ * Get the source sequencer client from a sequencer event structure.
  * @param evt Sequencer event structure
- * @return DOCME
+ * @return source field of the sequencer event
  */
-short fluid_event_get_source(fluid_event_t* evt)
+fluid_seq_id_t fluid_event_get_source(fluid_event_t* evt)
 {
 	return evt->src;
 }
 
 /**
- * Get the dest field from a sequencer event structure.
+ * Get the dest sequencer client from a sequencer event structure.
  * @param evt Sequencer event structure
- * @return DOCME
+ * @return dest field of the sequencer event
  */
-short fluid_event_get_dest(fluid_event_t* evt)
+fluid_seq_id_t fluid_event_get_dest(fluid_event_t* evt)
 {
 	return evt->dest;
 }

--- a/src/synth/fluid_event_priv.h
+++ b/src/synth/fluid_event_priv.h
@@ -30,8 +30,8 @@
 struct _fluid_event_t {
 	unsigned int time;
 	int type;
-	short src;
-	short dest;
+	fluid_seq_id_t src;
+	fluid_seq_id_t dest;
 	int channel;
 	short key;
 	short vel;


### PR DESCRIPTION
typedef the unique client ID returned by `fluid_sequencer_register_client()` and `fluid_sequencer_register_fluidsynth()`