### PR TITLE
return FLUID_FAIL when sampletype is OGG but not compiled with LIBSND…

### DIFF
--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -1976,6 +1976,8 @@ fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defs
     {
         FLUID_LOG (FLUID_WARN, _("Vorbis sample '%s' has invalid loop points"), sample->name);
     }
+#else
+    return FLUID_FAILED;
 #endif
   }
 


### PR DESCRIPTION
…FILE_SUPPORT