### PR TITLE
Settings cleanup and refactor

### DIFF
--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -80,8 +80,8 @@ static int fluid_handle_voice_count (void* data, int ac, char **av,
 
 void fluid_shell_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "shell.prompt", "", 0, NULL, NULL);
-  fluid_settings_register_int(settings, "shell.port", 9800, 1, 65535, 0, NULL, NULL);
+  fluid_settings_register_str(settings, "shell.prompt", "", 0);
+  fluid_settings_register_int(settings, "shell.port", 9800, 1, 65535, 0);
 }
 
 

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -1363,9 +1363,9 @@ fluid_handle_set(void* data, int ac, char** av, fluid_ostream_t out)
       if (fluid_settings_get_hints (handler->synth->settings, av[0], &hints) == FLUID_OK
           && hints & FLUID_HINT_TOGGLED)
       {
-          if (FLUID_STRCMP (av[1], "yes") == 0 || FLUID_STRCMP (av[1], "True") == 0
-              || FLUID_STRCMP (av[1], "TRUE") == 0 || FLUID_STRCMP (av[1], "true") == 0
-              || FLUID_STRCMP (av[1], "T") == 0)
+          if (FLUID_STRCASECMP (av[1], "yes") == 0
+              || FLUID_STRCASECMP (av[1], "true") == 0
+              || FLUID_STRCASECMP (av[1], "t") == 0)
           ival = 1;
           else ival = atoi (av[1]);
       }

--- a/src/bindings/fluid_filerenderer.c
+++ b/src/bindings/fluid_filerenderer.c
@@ -113,10 +113,10 @@ fluid_file_renderer_settings (fluid_settings_t* settings)
   unsigned int n;
 
   fluid_settings_register_str(settings, "audio.file.name", "fluidsynth.wav",
-                              FLUID_HINT_FILENAME, NULL, NULL);
-  fluid_settings_register_str(settings, "audio.file.type", "auto", 0, NULL, NULL);
-  fluid_settings_register_str(settings, "audio.file.format", "s16", 0, NULL, NULL);
-  fluid_settings_register_str(settings, "audio.file.endian", "auto", 0, NULL, NULL);
+                              FLUID_HINT_FILENAME);
+  fluid_settings_register_str(settings, "audio.file.type", "auto", 0);
+  fluid_settings_register_str(settings, "audio.file.format", "s16", 0);
+  fluid_settings_register_str(settings, "audio.file.endian", "auto", 0);
 
   fluid_settings_add_option (settings, "audio.file.type", "auto");
 
@@ -149,12 +149,12 @@ fluid_file_renderer_settings (fluid_settings_t* settings)
 
 #else
 
-  fluid_settings_register_str(settings, "audio.file.name", "fluidsynth.raw", 0, NULL, NULL);
-  fluid_settings_register_str(settings, "audio.file.type", "raw", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.file.name", "fluidsynth.raw", 0);
+  fluid_settings_register_str(settings, "audio.file.type", "raw", 0);
   fluid_settings_add_option (settings, "audio.file.type", "raw");
-  fluid_settings_register_str(settings, "audio.file.format", "s16", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.file.format", "s16", 0);
   fluid_settings_add_option (settings, "audio.file.format", "s16");
-  fluid_settings_register_str(settings, "audio.file.endian", "cpu", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.file.endian", "cpu", 0);
   fluid_settings_add_option (settings, "audio.file.endian", "cpu");
 #endif
 }

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -268,47 +268,47 @@ void fluid_audio_driver_settings(fluid_settings_t* settings)
 {
   unsigned int i;
 
-  fluid_settings_register_str(settings, "audio.sample-format", "16bits", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.sample-format", "16bits", 0);
   fluid_settings_add_option(settings, "audio.sample-format", "16bits");
   fluid_settings_add_option(settings, "audio.sample-format", "float");
 
 #if defined(WIN32)
-  fluid_settings_register_int(settings, "audio.period-size", 512, 64, 8192, 0, NULL, NULL);
-  fluid_settings_register_int(settings, "audio.periods", 8, 2, 64, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "audio.period-size", 512, 64, 8192, 0);
+  fluid_settings_register_int(settings, "audio.periods", 8, 2, 64, 0);
 #elif defined(MACOS9)
-  fluid_settings_register_int(settings, "audio.period-size", 64, 64, 8192, 0, NULL, NULL);
-  fluid_settings_register_int(settings, "audio.periods", 8, 2, 64, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "audio.period-size", 64, 64, 8192, 0);
+  fluid_settings_register_int(settings, "audio.periods", 8, 2, 64, 0);
 #else
-  fluid_settings_register_int(settings, "audio.period-size", 64, 64, 8192, 0, NULL, NULL);
-  fluid_settings_register_int(settings, "audio.periods", 16, 2, 64, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "audio.period-size", 64, 64, 8192, 0);
+  fluid_settings_register_int(settings, "audio.periods", 16, 2, 64, 0);
 #endif
 
   fluid_settings_register_int (settings, "audio.realtime-prio",
-                               FLUID_DEFAULT_AUDIO_RT_PRIO, 0, 99, 0, NULL, NULL);
+                               FLUID_DEFAULT_AUDIO_RT_PRIO, 0, 99, 0);
 
   /* Set the default driver */
 #if JACK_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "jack", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "jack", 0);
 #elif ALSA_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "alsa", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "alsa", 0);
 #elif PULSE_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "pulseaudio", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "pulseaudio", 0);
 #elif OSS_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "oss", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "oss", 0);
 #elif COREAUDIO_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "coreaudio", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "coreaudio", 0);
 #elif DSOUND_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "dsound", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "dsound", 0);
 #elif SNDMAN_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "sndman", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "sndman", 0);
 #elif PORTAUDIO_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "portaudio", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "portaudio", 0);
 #elif DART_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "dart", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "dart", 0);
 #elif AUFILE_SUPPORT
-  fluid_settings_register_str(settings, "audio.driver", "file", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "file", 0);
 #else
-  fluid_settings_register_str(settings, "audio.driver", "", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.driver", "", 0);
 #endif
 
   /* Add all drivers to the list of options */

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -151,7 +151,7 @@ static fluid_thread_return_t fluid_alsa_seq_run(void* d);
 
 void fluid_alsa_audio_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "audio.alsa.device", "default", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.alsa.device", "default", 0);
 }
 
 
@@ -548,7 +548,7 @@ static fluid_thread_return_t fluid_alsa_audio_run_s16 (void *d)
 
 void fluid_alsa_rawmidi_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "midi.alsa.device", "default", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.alsa.device", "default", 0);
 }
 
 /*
@@ -715,8 +715,8 @@ fluid_alsa_midi_run(void* d)
 
 void fluid_alsa_seq_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "midi.alsa_seq.device", "default", 0, NULL, NULL);
-  fluid_settings_register_str(settings, "midi.alsa_seq.id", "pid", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.alsa_seq.device", "default", 0);
+  fluid_settings_register_str(settings, "midi.alsa_seq.id", "pid", 0);
 }
 
 

--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -111,7 +111,7 @@ fluid_core_audio_driver_settings(fluid_settings_t* settings)
   pa.mScope = kAudioObjectPropertyScopeWildcard;
   pa.mElement = kAudioObjectPropertyElementMaster;
 
-  fluid_settings_register_str (settings, "audio.coreaudio.device", "default", 0, NULL, NULL);
+  fluid_settings_register_str (settings, "audio.coreaudio.device", "default", 0);
   fluid_settings_add_option (settings, "audio.coreaudio.device", "default");
   if (OK (AudioObjectGetPropertyDataSize (kAudioObjectSystemObject, &pa, 0, 0, &size))) {
     int num = size / (int) sizeof (AudioDeviceID);

--- a/src/drivers/fluid_coremidi.c
+++ b/src/drivers/fluid_coremidi.c
@@ -66,7 +66,7 @@ void fluid_coremidi_callback(const MIDIPacketList *list, void *p, void *src);
 
 void fluid_coremidi_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "midi.coremidi.id", "pid", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.coremidi.id", "pid", 0);
 }
 
 /*

--- a/src/drivers/fluid_dart.c
+++ b/src/drivers/fluid_dart.c
@@ -75,7 +75,7 @@ static LONG APIENTRY fluid_dart_audio_run( ULONG ulStatus, PMCI_MIX_BUFFER pBuff
 
 void fluid_dart_audio_driver_settings(fluid_settings_t* settings)
 {
-    fluid_settings_register_str(settings, "audio.dart.device", "default", 0, NULL, NULL);
+    fluid_settings_register_str(settings, "audio.dart.device", "default", 0);
 }
 
 

--- a/src/drivers/fluid_dsound.c
+++ b/src/drivers/fluid_dsound.c
@@ -84,7 +84,7 @@ fluid_dsound_enum_callback2(LPGUID guid, LPCTSTR description, LPCTSTR module, LP
 
 void fluid_dsound_audio_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "audio.dsound.device", "default", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.dsound.device", "default", 0);
   fluid_settings_add_option(settings, "audio.dsound.device", "default");
   DirectSoundEnumerate((LPDSENUMCALLBACK) fluid_dsound_enum_callback, settings);
 }

--- a/src/drivers/fluid_jack.c
+++ b/src/drivers/fluid_jack.c
@@ -106,10 +106,10 @@ static fluid_jack_client_t *last_client = NULL;       /* Last unpaired client. F
 void
 fluid_jack_audio_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "audio.jack.id", "fluidsynth", 0, NULL, NULL);
-  fluid_settings_register_int(settings, "audio.jack.multi", 0, 0, 1, FLUID_HINT_TOGGLED, NULL, NULL);
-  fluid_settings_register_int(settings, "audio.jack.autoconnect", 0, 0, 1, FLUID_HINT_TOGGLED, NULL, NULL);
-  fluid_settings_register_str(settings, "audio.jack.server", "", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.jack.id", "fluidsynth", 0);
+  fluid_settings_register_int(settings, "audio.jack.multi", 0, 0, 1, FLUID_HINT_TOGGLED);
+  fluid_settings_register_int(settings, "audio.jack.autoconnect", 0, 0, 1, FLUID_HINT_TOGGLED);
+  fluid_settings_register_str(settings, "audio.jack.server", "", 0);
 }
 
 /*
@@ -614,8 +614,8 @@ fluid_jack_driver_shutdown(void *arg)
 
 void fluid_jack_midi_driver_settings (fluid_settings_t *settings)
 {
-  fluid_settings_register_str (settings, "midi.jack.id", "fluidsynth-midi", 0, NULL, NULL);
-  fluid_settings_register_str (settings, "midi.jack.server", "", 0, NULL, NULL);
+  fluid_settings_register_str (settings, "midi.jack.id", "fluidsynth-midi", 0);
+  fluid_settings_register_str (settings, "midi.jack.server", "", 0);
 }
 
 /*

--- a/src/drivers/fluid_mdriver.c
+++ b/src/drivers/fluid_mdriver.c
@@ -144,26 +144,26 @@ void fluid_midi_driver_settings(fluid_settings_t* settings)
 {
   unsigned int i;
 
-  fluid_settings_register_int (settings, "midi.autoconnect", 0, 0, 1, FLUID_HINT_TOGGLED, NULL, NULL);
+  fluid_settings_register_int (settings, "midi.autoconnect", 0, 0, 1, FLUID_HINT_TOGGLED);
   
   fluid_settings_register_int (settings, "midi.realtime-prio",
-                               FLUID_DEFAULT_MIDI_RT_PRIO, 0, 99, 0, NULL, NULL);
+                               FLUID_DEFAULT_MIDI_RT_PRIO, 0, 99, 0);
 
   /* Set the default driver */
 #if ALSA_SUPPORT
-  fluid_settings_register_str(settings, "midi.driver", "alsa_seq", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.driver", "alsa_seq", 0);
 #elif JACK_SUPPORT
-  fluid_settings_register_str(settings, "midi.driver", "jack", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.driver", "jack", 0);
 #elif OSS_SUPPORT
-  fluid_settings_register_str(settings, "midi.driver", "oss", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.driver", "oss", 0);
 #elif WINMIDI_SUPPORT
-  fluid_settings_register_str(settings, "midi.driver", "winmidi", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.driver", "winmidi", 0);
 #elif MIDISHARE_SUPPORT
-  fluid_settings_register_str(settings, "midi.driver", "midishare", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.driver", "midishare", 0);
 #elif COREMIDI_SUPPORT
-  fluid_settings_register_str(settings, "midi.driver", "coremidi", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.driver", "coremidi", 0);
 #else
-  fluid_settings_register_str(settings, "midi.driver", "", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.driver", "", 0);
 #endif
 
   /* Add all drivers to the list of options */

--- a/src/drivers/fluid_oss.c
+++ b/src/drivers/fluid_oss.c
@@ -101,7 +101,7 @@ static fluid_thread_return_t fluid_oss_midi_run(void* d);
 void
 fluid_oss_audio_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "audio.oss.device", "/dev/dsp", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.oss.device", "/dev/dsp", 0);
 }
 
 /*
@@ -502,7 +502,7 @@ fluid_oss_audio_run2(void* d)
 
 void fluid_oss_midi_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "midi.oss.device", "/dev/midi", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.oss.device", "/dev/midi", 0);
 }
 
 /*

--- a/src/drivers/fluid_portaudio.c
+++ b/src/drivers/fluid_portaudio.c
@@ -122,7 +122,7 @@ fluid_portaudio_driver_settings (fluid_settings_t *settings)
   PaError err;
   int i;
 
-  fluid_settings_register_str (settings, "audio.portaudio.device", PORTAUDIO_DEFAULT_DEVICE, 0, NULL, NULL);
+  fluid_settings_register_str (settings, "audio.portaudio.device", PORTAUDIO_DEFAULT_DEVICE, 0);
   fluid_settings_add_option (settings, "audio.portaudio.device", PORTAUDIO_DEFAULT_DEVICE);
 
   err = Pa_Initialize();

--- a/src/drivers/fluid_pulse.c
+++ b/src/drivers/fluid_pulse.c
@@ -63,11 +63,11 @@ static fluid_thread_return_t fluid_pulse_audio_run2(void* d);
 
 void fluid_pulse_audio_driver_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_str(settings, "audio.pulseaudio.server", "default", 0, NULL, NULL);
-  fluid_settings_register_str(settings, "audio.pulseaudio.device", "default", 0, NULL, NULL);
-  fluid_settings_register_str(settings, "audio.pulseaudio.media-role", "music", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "audio.pulseaudio.server", "default", 0);
+  fluid_settings_register_str(settings, "audio.pulseaudio.device", "default", 0);
+  fluid_settings_register_str(settings, "audio.pulseaudio.media-role", "music", 0);
   fluid_settings_register_int(settings, "audio.pulseaudio.adjust-latency", 1, 0, 1,
-                              FLUID_HINT_TOGGLED, NULL, NULL);
+                              FLUID_HINT_TOGGLED);
 }
 
 

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -86,7 +86,7 @@ void fluid_winmidi_midi_driver_settings(fluid_settings_t* settings)
   MMRESULT res;
   MIDIINCAPS in_caps;
   UINT i, num;	
-  fluid_settings_register_str(settings, "midi.winmidi.device", "default", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "midi.winmidi.device", "default", 0);
   num = midiInGetNumDevs();
   if (num > 0) {
     fluid_settings_add_option(settings, "midi.winmidi.device", "default");

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -94,9 +94,9 @@ void process_o_cmd_line_option(fluid_settings_t* settings, char* optarg)
     if (fluid_settings_get_hints (settings, optarg, &hints) == FLUID_OK
         && hints & FLUID_HINT_TOGGLED)
     {
-      if (FLUID_STRCMP (val, "yes") == 0 || FLUID_STRCMP (val, "True") == 0
-          || FLUID_STRCMP (val, "TRUE") == 0 || FLUID_STRCMP (val, "true") == 0
-          || FLUID_STRCMP (val, "T") == 0)
+      if (FLUID_STRCASECMP (val, "yes") == 0
+          || FLUID_STRCASECMP (val, "true") == 0
+          || FLUID_STRCASECMP (val, "t") == 0)
         ival = 1;
       else ival = atoi (val);
     }

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -1293,14 +1293,12 @@ fluid_player_settings(fluid_settings_t *settings)
 {
     /* player.timing-source can be either "system" (use system timer)
      or "sample" (use timer based on number of written samples) */
-    fluid_settings_register_str(settings, "player.timing-source", "sample", 0,
-            NULL, NULL);
+    fluid_settings_register_str(settings, "player.timing-source", "sample", 0);
     fluid_settings_add_option(settings, "player.timing-source", "sample");
     fluid_settings_add_option(settings, "player.timing-source", "system");
 
     /* Selects whether the player should reset the synth between songs, or not. */
-    fluid_settings_register_int(settings, "player.reset-synth", 1, 0, 1,
-            FLUID_HINT_TOGGLED, NULL, NULL);
+    fluid_settings_register_int(settings, "player.reset-synth", 1, 0, 1, FLUID_HINT_TOGGLED);
 }
 
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -612,18 +612,13 @@ new_fluid_synth(fluid_settings_t *settings)
   fluid_settings_getint(settings, "synth.cpu-cores", &synth->cores);
 
   /* register the callbacks */
-  fluid_settings_register_num(settings, "synth.sample-rate",
-			      44100.0f, 8000.0f, 96000.0f, 0,
+  fluid_settings_callback_num(settings, "synth.sample-rate",
 			      (fluid_num_update_t) fluid_synth_update_sample_rate, synth);
-  fluid_settings_register_num(settings, "synth.gain",
-			      0.2f, 0.0f, 10.0f, 0,
+  fluid_settings_callback_num(settings, "synth.gain",
 			      (fluid_num_update_t) fluid_synth_update_gain, synth);
-  fluid_settings_register_int(settings, "synth.polyphony",
-			      synth->polyphony, 1, 65535, 0,
-			      (fluid_int_update_t) fluid_synth_update_polyphony,
-                              synth);
-  fluid_settings_register_int(settings, "synth.device-id",
-			      synth->device_id, 126, 0, 0,
+  fluid_settings_callback_int(settings, "synth.polyphony",
+			      (fluid_int_update_t) fluid_synth_update_polyphony, synth);
+  fluid_settings_callback_int(settings, "synth.device-id",
                               (fluid_int_update_t) fluid_synth_update_device_id, synth);
 
   fluid_synth_register_overflow(settings, 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3132,22 +3132,26 @@ fluid_synth_render_blocks(fluid_synth_t* synth, int blockcount)
  */
 static void fluid_synth_handle_overflow (void *data, const char *name, double value)
 {
-  double d;
   fluid_synth_t *synth = (fluid_synth_t *)data;
   fluid_return_if_fail(synth != NULL);
 
   fluid_synth_api_enter(synth);
-  
-  fluid_settings_getnum(synth->settings, "synth.overflow.percussion", &d);
-  synth->overflow.percussion = d;
-  fluid_settings_getnum(synth->settings, "synth.overflow.released", &d);
-  synth->overflow.released = d;
-  fluid_settings_getnum(synth->settings, "synth.overflow.sustained", &d);
-  synth->overflow.sustained = d;
-  fluid_settings_getnum(synth->settings, "synth.overflow.volume", &d);
-  synth->overflow.volume = d;
-  fluid_settings_getnum(synth->settings, "synth.overflow.age", &d);
-  synth->overflow.age = d;
+
+  if (FLUID_STRCMP(name, "synth.overflow.percussion") == 0) {
+    synth->overflow.percussion = value;
+  }
+  else if (FLUID_STRCMP(name, "synth.overflow.released") == 0) {
+    synth->overflow.released = value;
+  }
+  else if (FLUID_STRCMP(name, "synth.overflow.sustained") == 0) {
+    synth->overflow.sustained = value;
+  }
+  else if (FLUID_STRCMP(name, "synth.overflow.volume") == 0) {
+    synth->overflow.volume = value;
+  }
+  else if (FLUID_STRCMP(name, "synth.overflow.age") == 0) {
+    synth->overflow.age = value;
+  }
   
   fluid_synth_api_exit(synth);
 }

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -516,6 +516,7 @@ new_fluid_synth(fluid_settings_t *settings)
   fluid_synth_t* synth;
   fluid_sfloader_t* loader;
   double gain;
+  double num_val;
   int i, nbuf;
   int with_ladspa = 0;
   int with_reverb = 0;
@@ -576,6 +577,17 @@ new_fluid_synth(fluid_settings_t *settings)
   synth->gain = gain;
   fluid_settings_getint(settings, "synth.device-id", &synth->device_id);
   fluid_settings_getint(settings, "synth.cpu-cores", &synth->cores);
+
+  fluid_settings_getnum(settings, "synth.overflow.percussion", &num_val);
+  synth->overflow.percussion = num_val;
+  fluid_settings_getnum(settings, "synth.overflow.released", &num_val);
+  synth->overflow.released = num_val;
+  fluid_settings_getnum(settings, "synth.overflow.sustained", &num_val);
+  synth->overflow.sustained = num_val;
+  fluid_settings_getnum(settings, "synth.overflow.volume", &num_val);
+  synth->overflow.volume = num_val;
+  fluid_settings_getnum(settings, "synth.overflow.age", &num_val);
+  synth->overflow.age = num_val;
 
   /* register the callbacks */
   fluid_settings_callback_num(settings, "synth.sample-rate",
@@ -729,7 +741,6 @@ new_fluid_synth(fluid_settings_t *settings)
 
   fluid_synth_set_sample_rate(synth, synth->sample_rate);
   
-  fluid_synth_handle_overflow(synth, "", 0.0f);
   fluid_synth_update_mixer(synth, fluid_rvoice_mixer_set_polyphony, 
 			   synth->polyphony, 0.0f);
   fluid_synth_set_reverb_on(synth, fluid_atomic_int_get(&synth->with_reverb));

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -43,9 +43,9 @@ static int fluid_synth_noteon_LOCAL(fluid_synth_t* synth, int chan, int key,
                                        int vel);
 static int fluid_synth_noteoff_LOCAL(fluid_synth_t* synth, int chan, int key);
 static int fluid_synth_cc_LOCAL(fluid_synth_t* synth, int channum, int num);
-static int fluid_synth_update_device_id (fluid_synth_t *synth, char *name,
+static void fluid_synth_update_device_id (fluid_synth_t *synth, char *name,
                                          int value);
-static int fluid_synth_update_overflow (fluid_synth_t *synth, char *name,
+static void fluid_synth_update_overflow (fluid_synth_t *synth, char *name,
                                          fluid_real_t value);
 static int fluid_synth_sysex_midi_tuning (fluid_synth_t *synth, const char *data,
                                           int len, char *response,
@@ -71,12 +71,12 @@ fluid_synth_get_preset_by_sfont_name(fluid_synth_t* synth, const char *sfontname
                                      unsigned int banknum, unsigned int prognum);
 
 static void fluid_synth_update_presets(fluid_synth_t* synth);
-static int fluid_synth_update_sample_rate(fluid_synth_t* synth,
+static void fluid_synth_update_sample_rate(fluid_synth_t* synth,
                                    char* name, double value);
-static int fluid_synth_update_gain(fluid_synth_t* synth,
+static void fluid_synth_update_gain(fluid_synth_t* synth,
                                    char* name, double value);
 static void fluid_synth_update_gain_LOCAL(fluid_synth_t* synth);
-static int fluid_synth_update_polyphony(fluid_synth_t* synth,
+static void fluid_synth_update_polyphony(fluid_synth_t* synth,
                                         char* name, int value);
 static int fluid_synth_update_polyphony_LOCAL(fluid_synth_t* synth, int new_polyphony);
 static void init_dither(void);
@@ -1331,13 +1331,12 @@ fluid_synth_get_cc(fluid_synth_t* synth, int chan, int num, int* pval)
 /*
  * Handler for synth.device-id setting.
  */
-static int
+static void
 fluid_synth_update_device_id (fluid_synth_t *synth, char *name, int value)
 {
   fluid_synth_api_enter(synth);
   synth->device_id = value;
   fluid_synth_api_exit(synth);
-  return 0;
 }
 
 /**
@@ -2345,11 +2344,10 @@ fluid_synth_update_presets(fluid_synth_t* synth)
 }
 
 /* Handler for synth.sample-rate setting. */
-static int
+static void
 fluid_synth_update_sample_rate(fluid_synth_t* synth, char* name, double value)
 {
   fluid_synth_set_sample_rate(synth, (float) value);
-  return 0;
 }
 
 /**
@@ -2381,11 +2379,10 @@ fluid_synth_set_sample_rate(fluid_synth_t* synth, float sample_rate)
 
 
 /* Handler for synth.gain setting. */
-static int
+static void
 fluid_synth_update_gain(fluid_synth_t* synth, char* name, double value)
 {
   fluid_synth_set_gain(synth, (float) value);
-  return 0;
 }
 
 /**
@@ -2442,11 +2439,10 @@ fluid_synth_get_gain(fluid_synth_t* synth)
 /*
  * Handler for synth.polyphony setting.
  */
-static int
+static void
 fluid_synth_update_polyphony(fluid_synth_t* synth, char* name, int value)
 {
   fluid_synth_set_polyphony(synth, value);
-  return 0;
 }
 
 /**
@@ -3129,7 +3125,7 @@ fluid_synth_render_blocks(fluid_synth_t* synth, int blockcount)
 }
 
 
-static int fluid_synth_update_overflow (fluid_synth_t *synth, char *name,
+static void fluid_synth_update_overflow (fluid_synth_t *synth, char *name,
                                          fluid_real_t value)
 {
   double d;
@@ -3146,7 +3142,7 @@ static int fluid_synth_update_overflow (fluid_synth_t *synth, char *name,
   fluid_settings_getnum(synth->settings, "synth.overflow.age", &d);
   synth->overflow.age = d;
   
-  FLUID_API_RETURN(0);
+  fluid_synth_api_exit(synth);
 }
 
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -155,77 +155,47 @@ static const fluid_revmodel_presets_t revmodel_preset[] = {
  *               INITIALIZATION & UTILITIES
  */
 
-static void fluid_synth_register_overflow(fluid_settings_t* settings,
-					  fluid_num_update_t update_func,
-					  void* update_data)
-{
-  fluid_settings_register_num(settings, "synth.overflow.percussion",
-			      4000, -10000, 10000, 0, update_func, update_data);
-  fluid_settings_register_num(settings, "synth.overflow.sustained",
-			      -1000, -10000, 10000, 0, update_func, update_data);
-  fluid_settings_register_num(settings, "synth.overflow.released",
-			      -2000, -10000, 10000, 0, update_func, update_data);
-  fluid_settings_register_num(settings, "synth.overflow.age",
-			      1000, -10000, 10000, 0, update_func, update_data);
-  fluid_settings_register_num(settings, "synth.overflow.volume",
-			      500, -10000, 10000, 0, update_func, update_data);  
-}
-
 void fluid_synth_settings(fluid_settings_t* settings)
 {
-  fluid_settings_register_int(settings, "synth.verbose", 0, 0, 1,
-                              FLUID_HINT_TOGGLED, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.reverb.active", 1, 0, 1,
-                              FLUID_HINT_TOGGLED, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.chorus.active", 1, 0, 1,
-                              FLUID_HINT_TOGGLED, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.ladspa.active", 0, 0, 1,
-                              FLUID_HINT_TOGGLED, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.lock-memory", 1, 0, 1,
-                              FLUID_HINT_TOGGLED, NULL, NULL);
-  fluid_settings_register_str(settings, "midi.portname", "", 0, NULL, NULL);
+  fluid_settings_register_int(settings, "synth.verbose", 0, 0, 1, FLUID_HINT_TOGGLED);
+  fluid_settings_register_int(settings, "synth.reverb.active", 1, 0, 1, FLUID_HINT_TOGGLED);
+  fluid_settings_register_int(settings, "synth.chorus.active", 1, 0, 1, FLUID_HINT_TOGGLED);
+  fluid_settings_register_int(settings, "synth.ladspa.active", 0, 0, 1, FLUID_HINT_TOGGLED);
+  fluid_settings_register_int(settings, "synth.lock-memory", 1, 0, 1, FLUID_HINT_TOGGLED);
+  fluid_settings_register_str(settings, "midi.portname", "", 0);
 
 #ifdef DEFAULT_SOUNDFONT
-  fluid_settings_register_str(settings, "synth.default-soundfont",
-            DEFAULT_SOUNDFONT, 0, NULL, NULL);
+  fluid_settings_register_str(settings, "synth.default-soundfont", DEFAULT_SOUNDFONT, 0);
 #endif
 
-  fluid_settings_register_int(settings, "synth.polyphony",
-			      256, 1, 65535, 0, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.midi-channels",
-			      16, 16, 256, 0, NULL, NULL);
-  fluid_settings_register_num(settings, "synth.gain",
-			      0.2f, 0.0f, 10.0f,
-			      0, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.audio-channels",
-			      1, 1, 128, 0, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.audio-groups",
-			      1, 1, 128, 0, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.effects-channels",
-			      2, 2, 2, 0, NULL, NULL);
-  fluid_settings_register_num(settings, "synth.sample-rate",
-			      44100.0f, 8000.0f, 96000.0f,
-			      0, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.device-id",
-			      0, 0, 126, 0, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.cpu-cores", 1, 1, 256, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "synth.polyphony", 256, 1, 65535, 0);
+  fluid_settings_register_int(settings, "synth.midi-channels", 16, 16, 256, 0);
+  fluid_settings_register_num(settings, "synth.gain", 0.2f, 0.0f, 10.0f, 0);
+  fluid_settings_register_int(settings, "synth.audio-channels", 1, 1, 128, 0);
+  fluid_settings_register_int(settings, "synth.audio-groups", 1, 1, 128, 0);
+  fluid_settings_register_int(settings, "synth.effects-channels", 2, 2, 2, 0);
+  fluid_settings_register_num(settings, "synth.sample-rate", 44100.0f, 8000.0f, 96000.0f, 0);
+  fluid_settings_register_int(settings, "synth.device-id", 0, 0, 126, 0);
+  fluid_settings_register_int(settings, "synth.cpu-cores", 1, 1, 256, 0);
 
-  fluid_settings_register_int(settings, "synth.min-note-length", 10, 0, 65535, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "synth.min-note-length", 10, 0, 65535, 0);
   
-  fluid_settings_register_int(settings, "synth.threadsafe-api", 1, 0, 1,
-                              FLUID_HINT_TOGGLED, NULL, NULL);
-  fluid_settings_register_int(settings, "synth.parallel-render", 1, 0, 1,
-                              FLUID_HINT_TOGGLED, NULL, NULL);
+  fluid_settings_register_int(settings, "synth.threadsafe-api", 1, 0, 1, FLUID_HINT_TOGGLED);
+  fluid_settings_register_int(settings, "synth.parallel-render", 1, 0, 1, FLUID_HINT_TOGGLED);
 
-  fluid_synth_register_overflow(settings, NULL, NULL);
+  fluid_settings_register_num(settings, "synth.overflow.percussion", 4000, -10000, 10000, 0);
+  fluid_settings_register_num(settings, "synth.overflow.sustained", -1000, -10000, 10000, 0);
+  fluid_settings_register_num(settings, "synth.overflow.released", -2000, -10000, 10000, 0);
+  fluid_settings_register_num(settings, "synth.overflow.age", 1000, -10000, 10000, 0);
+  fluid_settings_register_num(settings, "synth.overflow.volume", 500, -10000, 10000, 0);
 
-  fluid_settings_register_str(settings, "synth.midi-bank-select", "gs", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "synth.midi-bank-select", "gs", 0);
   fluid_settings_add_option(settings, "synth.midi-bank-select", "gm");
   fluid_settings_add_option(settings, "synth.midi-bank-select", "gs");
   fluid_settings_add_option(settings, "synth.midi-bank-select", "xg");
   fluid_settings_add_option(settings, "synth.midi-bank-select", "mma");
   
-  fluid_settings_register_str(settings, "synth.volenv", "emu", 0, NULL, NULL);
+  fluid_settings_register_str(settings, "synth.volenv", "emu", 0);
   fluid_settings_add_option(settings, "synth.volenv", "emu");
   fluid_settings_add_option(settings, "synth.volenv", "compliant");
 }
@@ -620,10 +590,17 @@ new_fluid_synth(fluid_settings_t *settings)
 			      (fluid_int_update_t) fluid_synth_update_polyphony, synth);
   fluid_settings_callback_int(settings, "synth.device-id",
                               (fluid_int_update_t) fluid_synth_update_device_id, synth);
+  fluid_settings_callback_num(settings, "synth.overflow.percussion",
+                              (fluid_num_update_t) fluid_synth_update_overflow, synth);
+  fluid_settings_callback_num(settings, "synth.overflow.sustained",
+                              (fluid_num_update_t) fluid_synth_update_overflow, synth);
+  fluid_settings_callback_num(settings, "synth.overflow.released",
+                              (fluid_num_update_t) fluid_synth_update_overflow, synth);
+  fluid_settings_callback_num(settings, "synth.overflow.age",
+                              (fluid_num_update_t) fluid_synth_update_overflow, synth);
+  fluid_settings_callback_num(settings, "synth.overflow.volume",
+                              (fluid_num_update_t) fluid_synth_update_overflow, synth);
 
-  fluid_synth_register_overflow(settings, 
-				(fluid_num_update_t) fluid_synth_update_overflow, synth);
-				
   /* do some basic sanity checking on the settings */
 
   if (synth->midi_channels % 16 != 0) {

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -113,8 +113,8 @@ struct _fluid_synth_t
   fluid_settings_t* settings;        /**< the synthesizer settings */
   int device_id;                     /**< Device ID used for SYSEX messages */
   int polyphony;                     /**< Maximum polyphony */
-  fluid_atomic_int_t with_reverb;    /**< Should the synth use the built-in reverb unit? */
-  fluid_atomic_int_t with_chorus;    /**< Should the synth use the built-in chorus unit? */
+  int with_reverb;                   /**< Should the synth use the built-in reverb unit? */
+  int with_chorus;                   /**< Should the synth use the built-in chorus unit? */
   int verbose;                       /**< Turn verbose mode on? */
   double sample_rate;                /**< The sample rate */
   int midi_channels;                 /**< the number of MIDI channels (>= 16) */

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -626,6 +626,114 @@ fluid_settings_register_int(fluid_settings_t* settings, const char* name, int de
 }
 
 /**
+ * Registers a callback for the specified string setting.
+ *
+ * @param settings a settings object
+ * @param name the setting's name
+ * @param callback an update function for the setting
+ * @param data user supplied data passed to the update function
+ * @return #FLUID_OK if the callback has been set, #FLUID_FAILED otherwise
+ */
+int fluid_settings_callback_str(fluid_settings_t* settings, const char* name,
+        fluid_str_update_t callback, void* data)
+{
+    fluid_setting_node_t *node;
+    fluid_str_setting_t *setting;
+
+    fluid_return_val_if_fail (settings != NULL, FLUID_FAILED);
+    fluid_return_val_if_fail (name != NULL, FLUID_FAILED);
+    fluid_return_val_if_fail (name[0] != '\0', FLUID_FAILED);
+
+    fluid_rec_mutex_lock (settings->mutex);
+
+    if ((fluid_settings_get(settings, name, &node) != FLUID_OK)
+        || node->type != FLUID_STR_TYPE)
+    {
+        fluid_rec_mutex_unlock(settings->mutex);
+        return FLUID_FAILED;
+    }
+
+    setting = &node->str;
+    setting->update = callback;
+    setting->data = data;
+
+    fluid_rec_mutex_unlock(settings->mutex);
+    return FLUID_OK;
+}
+
+/**
+ * Registers a callback for the specified numeric setting.
+ *
+ * @param settings a settings object
+ * @param name the setting's name
+ * @param callback an update function for the setting
+ * @param data user supplied data passed to the update function
+ * @return #FLUID_OK if the callback has been set, #FLUID_FAILED otherwise
+ */
+int fluid_settings_callback_num(fluid_settings_t* settings, const char* name,
+        fluid_num_update_t callback, void* data)
+{
+    fluid_setting_node_t *node;
+    fluid_num_setting_t *setting;
+
+    fluid_return_val_if_fail (settings != NULL, FLUID_FAILED);
+    fluid_return_val_if_fail (name != NULL, FLUID_FAILED);
+    fluid_return_val_if_fail (name[0] != '\0', FLUID_FAILED);
+
+    fluid_rec_mutex_lock (settings->mutex);
+
+    if ((fluid_settings_get(settings, name, &node) != FLUID_OK)
+        || node->type != FLUID_NUM_TYPE)
+    {
+        fluid_rec_mutex_unlock(settings->mutex);
+        return FLUID_FAILED;
+    }
+
+    setting = &node->num;
+    setting->update = callback;
+    setting->data = data;
+
+    fluid_rec_mutex_unlock(settings->mutex);
+    return FLUID_OK;
+}
+
+/**
+ * Registers a callback for the specified int setting.
+ *
+ * @param settings a settings object
+ * @param name the setting's name
+ * @param callback an update function for the setting
+ * @param data user supplied data passed to the update function
+ * @return #FLUID_OK if the callback has been set, #FLUID_FAILED otherwise
+ */
+int fluid_settings_callback_int(fluid_settings_t* settings, const char* name,
+        fluid_int_update_t callback, void* data)
+{
+    fluid_setting_node_t *node;
+    fluid_int_setting_t *setting;
+
+    fluid_return_val_if_fail (settings != NULL, FLUID_FAILED);
+    fluid_return_val_if_fail (name != NULL, FLUID_FAILED);
+    fluid_return_val_if_fail (name[0] != '\0', FLUID_FAILED);
+
+    fluid_rec_mutex_lock (settings->mutex);
+
+    if ((fluid_settings_get(settings, name, &node) != FLUID_OK)
+        || node->type != FLUID_INT_TYPE)
+    {
+        fluid_rec_mutex_unlock(settings->mutex);
+        return FLUID_FAILED;
+    }
+
+    setting = &node->i;
+    setting->update = callback;
+    setting->data = data;
+
+    fluid_rec_mutex_unlock(settings->mutex);
+    return FLUID_OK;
+}
+
+/**
  * Get the type of the setting with the given name
  *
  * @param settings a settings object

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -920,7 +920,6 @@ fluid_settings_copystr(fluid_settings_t* settings, const char *name,
       if (setting->value)
       {
         FLUID_STRNCPY (str, setting->value, len);
-        str[len - 1] = 0;   /* Force terminate, in case of truncation */
       }
 
       retval = FLUID_OK;
@@ -932,7 +931,6 @@ fluid_settings_copystr(fluid_settings_t* settings, const char *name,
       if (setting->hints & FLUID_HINT_TOGGLED)
       {
         FLUID_STRNCPY (str, setting->value ? "yes" : "no", len);
-        str[len - 1] = 0;   /* Force terminate, in case of truncation */
 
         retval = FLUID_OK;
       }

--- a/src/utils/fluid_settings.h
+++ b/src/utils/fluid_settings.h
@@ -26,14 +26,14 @@ int fluid_settings_add_option(fluid_settings_t* settings, const char* name, cons
 int fluid_settings_remove_option(fluid_settings_t* settings, const char* name, const char* s);
 
 
-typedef int (*fluid_str_update_t)(void* data, const char* name, const char* value);
+typedef void (*fluid_str_update_t)(void* data, const char* name, const char* value);
 
 int fluid_settings_register_str(fluid_settings_t* settings, const char* name, const char* def, int hints);
 int fluid_settings_callback_str(fluid_settings_t* settings, const char* name,
                                 fluid_str_update_t fun, void* data);
 
 
-typedef int (*fluid_num_update_t)(void* data, const char* name, double value);
+typedef void (*fluid_num_update_t)(void* data, const char* name, double value);
 
 int fluid_settings_register_num(fluid_settings_t* settings, const char* name, double def,
                                 double min, double max, int hints);
@@ -41,7 +41,7 @@ int fluid_settings_callback_num(fluid_settings_t* settings, const char* name,
                                 fluid_num_update_t fun, void* data);
 
 
-typedef int (*fluid_int_update_t)(void* data, const char* name, int value);
+typedef void (*fluid_int_update_t)(void* data, const char* name, int value);
 int fluid_settings_register_int(fluid_settings_t* settings, const char* name, int def,
                                 int min, int max, int hints);
 int fluid_settings_callback_int(fluid_settings_t* settings, const char* name,

--- a/src/utils/fluid_settings.h
+++ b/src/utils/fluid_settings.h
@@ -30,6 +30,8 @@ typedef int (*fluid_str_update_t)(void* data, const char* name, const char* valu
 
 int fluid_settings_register_str(fluid_settings_t* settings, const char* name, const char* def, int hints,
                                 fluid_str_update_t fun, void* data);
+int fluid_settings_callback_str(fluid_settings_t* settings, const char* name,
+                                fluid_str_update_t fun, void* data);
 
 
 typedef int (*fluid_num_update_t)(void* data, const char* name, double value);
@@ -37,11 +39,15 @@ typedef int (*fluid_num_update_t)(void* data, const char* name, double value);
 int fluid_settings_register_num(fluid_settings_t* settings, const char* name, double def,
                                 double min, double max, int hints,
                                 fluid_num_update_t fun, void* data);
+int fluid_settings_callback_num(fluid_settings_t* settings, const char* name,
+                                fluid_num_update_t fun, void* data);
 
 
 typedef int (*fluid_int_update_t)(void* data, const char* name, int value);
 int fluid_settings_register_int(fluid_settings_t* settings, const char* name, int def,
                                 int min, int max, int hints,
+                                fluid_int_update_t fun, void* data);
+int fluid_settings_callback_int(fluid_settings_t* settings, const char* name,
                                 fluid_int_update_t fun, void* data);
 
 #endif /* _FLUID_SETTINGS_H */

--- a/src/utils/fluid_settings.h
+++ b/src/utils/fluid_settings.h
@@ -28,8 +28,7 @@ int fluid_settings_remove_option(fluid_settings_t* settings, const char* name, c
 
 typedef int (*fluid_str_update_t)(void* data, const char* name, const char* value);
 
-int fluid_settings_register_str(fluid_settings_t* settings, const char* name, const char* def, int hints,
-                                fluid_str_update_t fun, void* data);
+int fluid_settings_register_str(fluid_settings_t* settings, const char* name, const char* def, int hints);
 int fluid_settings_callback_str(fluid_settings_t* settings, const char* name,
                                 fluid_str_update_t fun, void* data);
 
@@ -37,16 +36,14 @@ int fluid_settings_callback_str(fluid_settings_t* settings, const char* name,
 typedef int (*fluid_num_update_t)(void* data, const char* name, double value);
 
 int fluid_settings_register_num(fluid_settings_t* settings, const char* name, double def,
-                                double min, double max, int hints,
-                                fluid_num_update_t fun, void* data);
+                                double min, double max, int hints);
 int fluid_settings_callback_num(fluid_settings_t* settings, const char* name,
                                 fluid_num_update_t fun, void* data);
 
 
 typedef int (*fluid_int_update_t)(void* data, const char* name, int value);
 int fluid_settings_register_int(fluid_settings_t* settings, const char* name, int def,
-                                int min, int max, int hints,
-                                fluid_int_update_t fun, void* data);
+                                int min, int max, int hints);
 int fluid_settings_callback_int(fluid_settings_t* settings, const char* name,
                                 fluid_int_update_t fun, void* data);
 


### PR DESCRIPTION
Second attempt at cleaning up the settings, especially the callback handling.

As in the previous PR I have added dedicated functions to register setting callbacks. This enables the removal of the callback and data parameters to all settings_register_* functions.

The callback function signatures have been cleaned up, returning void now, as the callbacks return value wasn't used anyway. And the error-hiding casts have been removed from the callback registering, making the cast from void* to fluid_synth_t* explicit in the callback handlers.

The handlers have been renamed to clarify their purpose and distinguish them from the other _update* functions in fluid_synth.h.

The settings mutex is now released before calling the callbacks.

A little unrelated, but still touches settings code: with_reverb and with_chorus on fluid_settings_t don't need to be atomics. Setting those via fluid_synth_reverb_on and fluid_synth_chorus_on is (or should be) protected via the api mutex anyway. fluid_synth_reverb_on wasn't protected but is now. It's calling fluid_synth_update_mixer, and that definitely needs to be protected by the API lock.

Please also note two backwards-incompatible changes:
- fluid_settings_setstr was allowed to be called for integer settings, evaluating "yes" and "no" to TRUE and FALSE. This hack has been removed. The fluidsynth binary and the fluid shell still accept "yes", "true", "t" (all case-insensitive) and anything else but 0 as TRUE, as they handle it themselves. A programmer using the FluidSynth API should be able to use _setint for an int setting and not rely on "yes" and "no".
- All fluid_settings_set* functions silently registered a new setting if the specified setting didn't exist. This hack has also been removed. The fluidsynth binary and the fluid shell check if a setting exists and return an error if it does not. The API should be just as strict and not hide errors like that.

