### PR TITLE
New feature for overflow calculation: important channels

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -128,6 +128,30 @@ https://stackoverflow.com/a/6251757
             </desc>
         </setting>
         <setting>
+            <name>overflow.important</name>
+            <type>num</type>
+            <def>5000</def>
+            <min>-50000</min>
+            <max>50000</max>
+            <desc>
+                This score is added to voices on channels marked with the
+                synth.overflow.important-channels setting.
+            </desc>
+        </setting>
+        <setting>
+            <name>overflow.important-channels</name>
+            <type>str</type>
+            <def>""</def>
+            <desc>
+                This setting is a comma-separated list of MIDI channel numbers that should
+                be treated as "important" by the overflow calculation, adding the score
+                set by synth.overflow.important to each voice on those channels. It can
+                be used to make voices on particular MIDI channels
+                less likely (synth.overflow.important &gt; 0) or more likely
+                (synth.overflow.important &lt; 0) to be killed in an overflow situation.
+            </desc>
+        </setting>
+        <setting>
             <name>overflow.percussion</name>
             <type>num</type>
             <def>4000</def>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -115,6 +115,71 @@ https://stackoverflow.com/a/6251757
                 Sets the minimum note duration in milliseconds. This ensures that really short duration note events, such as percussion notes, have a better chance of sounding as intended. Set to 0 to disable this feature.</desc>
         </setting>
         <setting>
+            <name>overflow.age</name>
+            <type>num</type>
+            <def>1000</def>
+            <min>-10000</min>
+            <max>10000</max>
+            <desc>
+                This score is divided by the number of seconds this voice has been
+                active and is added to the overflow priority. It is usually a positive
+                value and gives voices which have just been started a higher priority,
+                making them less likely to be killed in an overflow situation.
+            </desc>
+        </setting>
+        <setting>
+            <name>overflow.percussion</name>
+            <type>num</type>
+            <def>4000</def>
+            <min>-10000</min>
+            <max>10000</max>
+            <desc>
+                Sets the overflow priority score added to voices on a percussion
+                channel. This is usually a positive score, to give percussion voices
+                a higher priority and less chance of being killed in an overflow
+                situation.
+            </desc>
+        </setting>
+        <setting>
+            <name>overflow.released</name>
+            <type>num</type>
+            <def>-2000</def>
+            <min>-10000</min>
+            <max>10000</max>
+            <desc>
+                Sets the overflow priority score added to voices that have already
+                received a note-off event. This is usually a negative score, to give released
+                voices a lower priority so that they are killed first in an overflow
+                situation.
+            </desc>
+        </setting>
+        <setting>
+            <name>overflow.sustained</name>
+            <type>num</type>
+            <def>-1000</def>
+            <min>-10000</min>
+            <max>10000</max>
+            <desc>
+                Sets the overflow priority score added to voices that are currently
+                sustained. With the default value, sustained voices are considered less
+                important and are more likely to be killed in an overflow situation.
+            </desc>
+        </setting>
+        <setting>
+            <name>overflow.volume</name>
+            <type>num</type>
+            <def>500</def>
+            <min>-10000</min>
+            <max>10000</max>
+            <desc>
+                Sets the overflow priority score added to voices based on their current
+                volume. The voice volume is normalized to a value between 0 and 1 and
+                multiplied with this setting. So voices with maximum volume get added
+                the full score, voices with only half that volume get added half of this
+                score.
+            </desc>
+        </setting>
+        <setting>
             <name>parallel-render</name>
             <type>bool</type>
             <def>1 (TRUE)</def>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -148,7 +148,8 @@ https://stackoverflow.com/a/6251757
                 set by synth.overflow.important to each voice on those channels. It can
                 be used to make voices on particular MIDI channels
                 less likely (synth.overflow.important &gt; 0) or more likely
-                (synth.overflow.important &lt; 0) to be killed in an overflow situation.
+                (synth.overflow.important &lt; 0) to be killed in an overflow situation. Channel
+                numbers are 1-based, so the first MIDI channel is number 1.
             </desc>
         </setting>
         <setting>

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -5339,10 +5339,8 @@ static int fluid_synth_set_important_channels(fluid_synth_t *synth, const char *
         scores->num_important_channels = synth->midi_channels;
     }
 
-    for (i = 0; i < scores->num_important_channels; i++)
-    {
-        scores->important_channels[i] = FALSE;
-    }
+    FLUID_MEMSET(scores->important_channels, FALSE,
+            sizeof(*scores->important_channels) * scores->num_important_channels);
 
     if (channels != NULL)
     {

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -515,8 +515,6 @@ new_fluid_synth(fluid_settings_t *settings)
 {
   fluid_synth_t* synth;
   fluid_sfloader_t* loader;
-  double gain;
-  double num_val;
   int i, nbuf;
   int with_ladspa = 0;
   
@@ -569,21 +567,15 @@ new_fluid_synth(fluid_settings_t *settings)
   fluid_settings_getint(settings, "synth.audio-channels", &synth->audio_channels);
   fluid_settings_getint(settings, "synth.audio-groups", &synth->audio_groups);
   fluid_settings_getint(settings, "synth.effects-channels", &synth->effects_channels);
-  fluid_settings_getnum(settings, "synth.gain", &gain);
-  synth->gain = gain;
+  fluid_settings_getnum_float(settings, "synth.gain", &synth->gain);
   fluid_settings_getint(settings, "synth.device-id", &synth->device_id);
   fluid_settings_getint(settings, "synth.cpu-cores", &synth->cores);
 
-  fluid_settings_getnum(settings, "synth.overflow.percussion", &num_val);
-  synth->overflow.percussion = num_val;
-  fluid_settings_getnum(settings, "synth.overflow.released", &num_val);
-  synth->overflow.released = num_val;
-  fluid_settings_getnum(settings, "synth.overflow.sustained", &num_val);
-  synth->overflow.sustained = num_val;
-  fluid_settings_getnum(settings, "synth.overflow.volume", &num_val);
-  synth->overflow.volume = num_val;
-  fluid_settings_getnum(settings, "synth.overflow.age", &num_val);
-  synth->overflow.age = num_val;
+  fluid_settings_getnum_float(settings, "synth.overflow.percussion", &synth->overflow.percussion);
+  fluid_settings_getnum_float(settings, "synth.overflow.released", &synth->overflow.released);
+  fluid_settings_getnum_float(settings, "synth.overflow.sustained", &synth->overflow.sustained);
+  fluid_settings_getnum_float(settings, "synth.overflow.volume", &synth->overflow.volume);
+  fluid_settings_getnum_float(settings, "synth.overflow.age", &synth->overflow.age);
 
   /* register the callbacks */
   fluid_settings_callback_num(settings, "synth.sample-rate",

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3168,8 +3168,8 @@ static fluid_voice_t*
 fluid_synth_free_voice_by_kill_LOCAL(fluid_synth_t* synth)
 {
   int i;
-  fluid_real_t best_prio = OVERFLOW_PRIO_CANNOT_KILL-1;
-  fluid_real_t this_voice_prio;
+  float best_prio = OVERFLOW_PRIO_CANNOT_KILL-1;
+  float this_voice_prio;
   fluid_voice_t* voice;
   int best_voice_index=-1;
   unsigned int ticks = fluid_synth_get_ticks(synth);

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -1687,6 +1687,7 @@ fluid_voice_get_overflow_prio(fluid_voice_t* voice,
 			       unsigned int cur_time)
 {
   float this_voice_prio = 0;
+  int channel;
 
   /* Are we already overflowing? */
   if (!voice->can_access_overflow_rvoice) {
@@ -1733,6 +1734,13 @@ fluid_voice_get_overflow_prio(fluid_voice_t* voice,
       a = 0.1; // Avoid div by zero
     }
     this_voice_prio += score->volume / a;
+  }
+
+  /* Check if this voice is on an important channel. If so, then add the
+   * score for important channels */
+  channel = fluid_voice_get_channel(voice);
+  if (channel < score->num_important_channels && score->important_channels[channel]) {
+      this_voice_prio += score->important;
   }
     
   return this_voice_prio;

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -1681,12 +1681,12 @@ fluid_voice_optimize_sample(fluid_sample_t* s)
   return FLUID_OK;
 }
 
-fluid_real_t 
+float
 fluid_voice_get_overflow_prio(fluid_voice_t* voice, 
 			       fluid_overflow_prio_t* score,
 			       unsigned int cur_time)
 {
-  fluid_real_t this_voice_prio = 0;
+  float this_voice_prio = 0;
 
   /* Are we already overflowing? */
   if (!voice->can_access_overflow_rvoice) {

--- a/src/synth/fluid_voice.h
+++ b/src/synth/fluid_voice.h
@@ -42,6 +42,9 @@ struct _fluid_overflow_prio_t
   float sustained; /**< Is this voice sustained? Then add this score (usually negative) */
   float volume; /**< Multiply current (or future) volume (a value between 0 and 1) */
   float age; /**< This score will be divided by the number of seconds the voice has lasted */
+  float important; /**< This score will be added to all important channels */
+  char *important_channels; /**< "important" flags indexed by MIDI channel number */
+  int num_important_channels; /**< Number of elements in the important_channels array */
 };
 
 enum fluid_voice_status

--- a/src/synth/fluid_voice.h
+++ b/src/synth/fluid_voice.h
@@ -37,11 +37,11 @@ typedef struct _fluid_overflow_prio_t fluid_overflow_prio_t;
 
 struct _fluid_overflow_prio_t 
 {
-  fluid_real_t percussion; /**< Is this voice on the drum channel? Then add this score */
-  fluid_real_t released; /**< Is this voice in release stage? Then add this score (usually negative) */ 
-  fluid_real_t sustained; /**< Is this voice sustained? Then add this score (usually negative) */
-  fluid_real_t volume; /**< Multiply current (or future) volume (a value between 0 and 1) */
-  fluid_real_t age; /**< This score will be divided by the number of seconds the voice has lasted */
+  float percussion; /**< Is this voice on the drum channel? Then add this score */
+  float released; /**< Is this voice in release stage? Then add this score (usually negative) */
+  float sustained; /**< Is this voice sustained? Then add this score (usually negative) */
+  float volume; /**< Multiply current (or future) volume (a value between 0 and 1) */
+  float age; /**< This score will be divided by the number of seconds the voice has lasted */
 };
 
 enum fluid_voice_status
@@ -148,7 +148,7 @@ void fluid_voice_stop(fluid_voice_t* voice);
 void fluid_voice_overflow_rvoice_finished(fluid_voice_t* voice);
 
 int fluid_voice_kill_excl(fluid_voice_t* voice);
-fluid_real_t fluid_voice_get_overflow_prio(fluid_voice_t* voice, 
+float fluid_voice_get_overflow_prio(fluid_voice_t* voice,
 					    fluid_overflow_prio_t* score,
 					    unsigned int cur_time);
 

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -1250,6 +1250,27 @@ fluid_settings_getnum(fluid_settings_t* settings, const char *name, double* val)
 }
 
 /**
+ * float-typed wrapper for fluid_settings_getnum
+ *
+ * @param settings a settings object
+ * @param name a setting's name
+ * @param val variable pointer to receive the setting's float value
+ * @return #FLUID_OK if the value exists, #FLUID_FAILED otherwise
+ */
+int fluid_settings_getnum_float(fluid_settings_t *settings, const char *name, float *val)
+{
+    double tmp;
+
+    if (fluid_settings_getnum(settings, name, &tmp) == FLUID_OK)
+    {
+        *val = tmp;
+        return FLUID_OK;
+    }
+
+    return FLUID_FAILED;
+}
+
+/**
  * Get the range of values of a numeric setting
  *
  * @param settings a settings object

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -1738,3 +1738,36 @@ fluid_settings_foreach (fluid_settings_t* settings, void* data,
 
   delete_fluid_list (bag.names);        /* -- Free names list */
 }
+
+/**
+ * Split a comma-separated list of integers and fill the passed
+ * in buffer with the parsed values.
+ *
+ * @param str the comma-separated string to split
+ * @param buf user-supplied buffer to hold the parsed numbers
+ * @param buf_len length of user-supplied buffer
+ * @return number of parsed values or -1 on failure
+ */
+int fluid_settings_split_csv(const char *str, int *buf, int buf_len)
+{
+  char *s;
+  char *tok;
+  char *tokstr;
+  int n = 0;
+
+  s = tokstr = FLUID_STRDUP(str);
+  if (s == NULL)
+  {
+      FLUID_LOG(FLUID_ERR, "Out of memory");
+      return -1;
+  }
+
+  while ((tok = fluid_strtok(&tokstr, ",")) && n < buf_len)
+  {
+      buf[n++] = atoi(tok);
+  }
+
+  FLUID_FREE(s);
+
+  return n;
+}

--- a/src/utils/fluid_settings.h
+++ b/src/utils/fluid_settings.h
@@ -50,4 +50,6 @@ int fluid_settings_register_int(fluid_settings_t* settings, const char* name, in
 int fluid_settings_callback_int(fluid_settings_t* settings, const char* name,
                                 fluid_int_update_t fun, void* data);
 
+int fluid_settings_split_csv(const char *str, int *buf, int buf_len);
+
 #endif /* _FLUID_SETTINGS_H */

--- a/src/utils/fluid_settings.h
+++ b/src/utils/fluid_settings.h
@@ -40,6 +40,9 @@ int fluid_settings_register_num(fluid_settings_t* settings, const char* name, do
 int fluid_settings_callback_num(fluid_settings_t* settings, const char* name,
                                 fluid_num_update_t fun, void* data);
 
+/* Type specific wrapper for fluid_settings_getnum */
+int fluid_settings_getnum_float(fluid_settings_t *settings, const char *name, float *val);
+
 
 typedef void (*fluid_int_update_t)(void* data, const char* name, int value);
 int fluid_settings_register_int(fluid_settings_t* settings, const char* name, int def,


### PR DESCRIPTION
The FluidSynth overflow priority calculation determines which voice to kill in an overflow situation, i.e. when the polyphony limit has been exceeded and FluidSynth tries to kill an active voice in order to service a note-on event.

This PR adds a new feature to the overflow priority calculation, making it possible to mark a number of MIDI channels as "important" and add a user-defined value to their score. The use-case for this is to protect long running notes on separate MIDI channels from being killed by the overflow handling.

In my particular use-case there are a number of MIDI channels which play "drone" notes (i.e. notes that get started once and always sound white the instrument is playing) and another MIDI channels that plays a melody. I want those drone notes protected from killing, as it is very noticeable if one of them goes away.

Please consider this as an RFC. It works very well for my use-case, but maybe there is better approach for this?

The other three commits are just cleanup/refactor and documentation.