### PR TITLE
add cmake toolchain files

### DIFF
--- a/cmake_admin/cross/i686-w64-mingw32.cmake
+++ b/cmake_admin/cross/i686-w64-mingw32.cmake
@@ -1,0 +1,23 @@
+# Cross compile toolchain configuration based on:
+# http://www.cmake.org/Wiki/CMake_Cross_Compiling
+
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+# 32 bit mingw-w64
+SET(TOOLCHAIN_PREFIX "i686-w64-mingw32")
+
+# compilers to use for C and C++
+FIND_PROGRAM(CMAKE_C_COMPILER NAMES ${TOOLCHAIN_PREFIX}-gcc)
+FIND_PROGRAM(CMAKE_CXX_COMPILER NAMES ${TOOLCHAIN_PREFIX}-g++)
+FIND_PROGRAM(CMAKE_RC_COMPILER NAMES ${TOOLCHAIN_PREFIX}-windres)
+FIND_PROGRAM(PKG_CONFIG_EXECUTABLE ${TOOLCHAIN_PREFIX}-pkg-config)
+
+# path to the target environment
+SET(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX}/sys-root/mingw)
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/cmake_admin/cross/x86_64-w64-mingw32.cmake
+++ b/cmake_admin/cross/x86_64-w64-mingw32.cmake
@@ -1,0 +1,23 @@
+# Cross compile toolchain configuration based on:
+# http://www.cmake.org/Wiki/CMake_Cross_Compiling
+
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+# 64 bit mingw-w64
+SET(TOOLCHAIN_PREFIX "x86_64-w64-mingw32")
+
+# compilers to use for C and C++
+FIND_PROGRAM(CMAKE_C_COMPILER NAMES ${TOOLCHAIN_PREFIX}-gcc)
+FIND_PROGRAM(CMAKE_CXX_COMPILER NAMES ${TOOLCHAIN_PREFIX}-g++)
+FIND_PROGRAM(CMAKE_RC_COMPILER NAMES ${TOOLCHAIN_PREFIX}-windres)
+FIND_PROGRAM(PKG_CONFIG_EXECUTABLE ${TOOLCHAIN_PREFIX}-pkg-config)
+
+# path to the target environment
+SET(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX}/sys-root/mingw)
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
...as provided by Carlo in #275. Since there was no input from the mailing list yet, I propose to create a subdir `/cmake_admin/cross/` where we place any toolchain files. As naming convention I suggest using the target system this file is dedicated for (i.e. as indicated by the `TOOLCHAIN_PREFIX`). Although I'm not sure if the host system matters for these files. So this can be seen as RFC.

@carlo-bramini @jjceresa @mawe42 @ensonic Any opinions?