### PR TITLE
Fix crash to TCP server (WIN32).

### DIFF
--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -736,7 +736,7 @@ int main(int argc, char** argv)
 
  cleanup:
 
-#if !defined(MACINTOSH) && !defined(WIN32)
+#if !defined(MACINTOSH)
   if (server != NULL) {
     /* if the user typed 'quit' in the shell, kill the server */
     if (!interactive) {

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -1161,8 +1161,10 @@ void delete_fluid_server_socket(fluid_server_socket_t *server_socket)
   if (server_socket->socket != INVALID_SOCKET)
     fluid_socket_close (server_socket->socket);
 
-  if (server_socket->thread)
+  if (server_socket->thread) {
+    fluid_thread_join(server_socket->thread);
     delete_fluid_thread (server_socket->thread);
+  }
 
   FLUID_FREE (server_socket);
 


### PR DESCRIPTION
This is the fix for the bug that I signaled in the mailing list.
I have not removed the join into fluidsynth.c because, as I have written in the mailing list, I have not understood what it is its purpose.