### PR TITLE
Disable network at compile time (option)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ option ( enable-dbus "compile DBUS support (if it is available)" on )
 option ( BUILD_SHARED_LIBS "Build a shared object or DLL" on )
 option ( enable-ladspa "enable LADSPA effect units" on )
 option ( enable-ipv6  "enable ipv6 support " on )
+option ( enable-network "enable network support (requires BSD sockets) " on )
 
 # Platform specific options
 if ( CMAKE_SYSTEM MATCHES "Linux" )
@@ -81,6 +82,7 @@ if ( CMAKE_SYSTEM MATCHES "Darwin" )
     option ( enable-coreaudio "compile CoreAudio support (if it is available)" on )
     option ( enable-coremidi "compile CoreMIDI support (if it is available)" on )
     option ( enable-framework "create a Mac OSX style FluidSynth.framework" on )
+    set ( enable-network off )
 endif ( CMAKE_SYSTEM MATCHES "Darwin" )
 
 if ( CMAKE_SYSTEM MATCHES "OS2" )
@@ -249,6 +251,11 @@ if ( enable-ipv6 )
     set ( IPV6_SUPPORT 1 )
   endif ( HAVE_INETNTOP )
 endif ( enable-ipv6 )
+
+unset ( NETWORK_SUPPORT )
+if ( enable-network )
+    set ( NETWORK_SUPPORT 1 )
+endif ( enable-network )
 
 unset ( WITH_FLOAT CACHE )
 if ( enable-floats )

--- a/cmake_admin/report.cmake
+++ b/cmake_admin/report.cmake
@@ -97,6 +97,12 @@ else ( AUFILE_SUPPORT )
   message ( "Audio to file driver:  no" )
 endif ( AUFILE_SUPPORT )
 
+if ( NETWORK_SUPPORT )
+  message ( "NETWORK Support :      yes" )
+else ( NETWORK_SUPPORT )
+  message ( "NETWORK Support :      no" )
+endif ( NETWORK_SUPPORT )
+
 if ( IPV6_SUPPORT )
   message ( "IPV6 Support :         yes" )
 else ( IPV6_SUPPORT )

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -2347,8 +2347,7 @@ fluid_cmd_handler_handle(void* data, int ac, char** av, fluid_ostream_t out)
 }
 
 
-#if !defined(WITHOUT_SERVER)
-
+#ifdef NETWORK_SUPPORT
 
 struct _fluid_server_t {
   fluid_server_socket_t* socket;
@@ -2358,65 +2357,6 @@ struct _fluid_server_t {
   fluid_list_t* clients;
   fluid_mutex_t mutex;
 };
-
-static int fluid_server_handle_connection(fluid_server_t* server,
-					  fluid_socket_t client_socket,
-					  char* addr);
-static void fluid_server_close(fluid_server_t* server);
-
-/**
- * Create a new TCP/IP command shell server.
- * @param settings Settings instance to use for the shell
- * @param synth If not NULL, the synth instance for the command handler to be used by the client
- * @param router If not NULL, the midi_router instance for the command handler to be used by the client
- * @return New shell server instance or NULL on error
- */
-fluid_server_t*
-new_fluid_server(fluid_settings_t* settings,
-		fluid_synth_t* synth, fluid_midi_router_t* router)
-{
-  fluid_server_t* server;
-  int port;
-
-  server = FLUID_NEW(fluid_server_t);
-  if (server == NULL) {
-    FLUID_LOG(FLUID_ERR, "Out of memory");
-    return NULL;
-  }
-
-  server->settings = settings;
-  server->clients = NULL;
-  server->synth = synth;
-  server->router = router;
-
-  fluid_mutex_init(server->mutex);
-
-  fluid_settings_getint(settings, "shell.port", &port);
-
-  server->socket = new_fluid_server_socket(port,
-					  (fluid_server_func_t) fluid_server_handle_connection,
-					  server);
-  if (server->socket == NULL) {
-    FLUID_FREE(server);
-    return NULL;
-  }
-
-  return server;
-}
-
-/**
- * Delete a TCP/IP shell server.
- * @param server Shell server instance
- */
-void
-delete_fluid_server(fluid_server_t* server)
-{
-  fluid_return_if_fail(server != NULL);
-
-  fluid_server_close(server);
-
-  FLUID_FREE(server);
-}
 
 static void fluid_server_close(fluid_server_t* server)
 {
@@ -2474,17 +2414,6 @@ void fluid_server_remove_client(fluid_server_t* server, fluid_client_t* client)
   server->clients = fluid_list_remove(server->clients, client);
   fluid_mutex_unlock(server->mutex);
 }
-
-/**
- * Join a shell server thread (wait until it quits).
- * @param server Shell server instance
- * @return #FLUID_OK on success, #FLUID_FAILED otherwise
- */
-int fluid_server_join(fluid_server_t* server)
-{
-  return fluid_server_socket_join(server->socket);
-}
-
 
 struct _fluid_client_t {
   fluid_server_t* server;
@@ -2564,5 +2493,82 @@ void delete_fluid_client(fluid_client_t* client)
   FLUID_FREE(client);
 }
 
+#endif /* NETWORK_SUPPORT */
 
-#endif /* WITHOUT_SERVER */
+/**
+ * Create a new TCP/IP command shell server.
+ * @param settings Settings instance to use for the shell
+ * @param synth If not NULL, the synth instance for the command handler to be used by the client
+ * @param router If not NULL, the midi_router instance for the command handler to be used by the client
+ * @return New shell server instance or NULL on error
+ */
+fluid_server_t*
+new_fluid_server(fluid_settings_t* settings,
+		fluid_synth_t* synth, fluid_midi_router_t* router)
+{
+#ifdef NETWORK_SUPPORT
+  fluid_server_t* server;
+  int port;
+
+  server = FLUID_NEW(fluid_server_t);
+  if (server == NULL) {
+    FLUID_LOG(FLUID_ERR, "Out of memory");
+    return NULL;
+  }
+
+  server->settings = settings;
+  server->clients = NULL;
+  server->synth = synth;
+  server->router = router;
+
+  fluid_mutex_init(server->mutex);
+
+  fluid_settings_getint(settings, "shell.port", &port);
+
+  server->socket = new_fluid_server_socket(port,
+					  (fluid_server_func_t) fluid_server_handle_connection,
+					  server);
+  if (server->socket == NULL) {
+    FLUID_FREE(server);
+    return NULL;
+  }
+
+  return server;
+#else
+  FLUID_LOG(FLUID_WARN, "Network support disabled on this platform.");
+  return NULL;
+#endif
+}
+
+/**
+ * Delete a TCP/IP shell server.
+ * @param server Shell server instance
+ */
+void
+delete_fluid_server(fluid_server_t* server)
+{
+#ifdef NETWORK_SUPPORT
+  fluid_return_if_fail(server != NULL);
+
+  fluid_server_close(server);
+
+  FLUID_FREE(server);
+#else
+  FLUID_LOG(FLUID_WARN, "Network support disabled on this platform.");
+#endif
+}
+
+/**
+ * Join a shell server thread (wait until it quits).
+ * @param server Shell server instance
+ * @return #FLUID_OK on success, #FLUID_FAILED otherwise
+ */
+int fluid_server_join(fluid_server_t* server)
+{
+#ifdef NETWORK_SUPPORT
+  return fluid_server_socket_join(server->socket);
+#else
+  FLUID_LOG(FLUID_WARN, "Network support disabled on this platform.");
+  return FLUID_OK;
+#endif
+}

--- a/src/config.cmake
+++ b/src/config.cmake
@@ -142,6 +142,9 @@
 /* Define to enable IPV6 support */
 #cmakedefine IPV6_SUPPORT @IPV6_SUPPORT@
 
+/* Define to enable network support */
+#cmakedefine NETWORK_SUPPORT @NETWORK_SUPPORT@
+
 /* libsndfile has ogg vorbis support */
 #cmakedefine LIBSNDFILE_HASVORBIS @LIBSNDFILE_HASVORBIS@
 

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -261,7 +261,7 @@ int main(int argc, char** argv)
   fluid_midi_driver_t* mdriver = NULL;
   fluid_audio_driver_t* adriver = NULL;
   fluid_synth_t* synth = NULL;
-#if !defined(MACINTOSH)
+#ifdef NETWORK_SUPPORT
   fluid_server_t* server = NULL;
 #endif
   char* config_file = NULL;
@@ -270,11 +270,9 @@ int main(int argc, char** argv)
   int with_server = 0;
   int dump = 0;
   int fast_render = 0;
+  static const char optchars[] = "a:C:c:dE:f:F:G:g:hijK:L:lm:nO:o:p:R:r:sT:Vvz:";
 #ifdef LASH_ENABLED
   int connect_lash = 1;
-#endif
-  char *optchars = "a:C:c:dE:f:F:G:g:hijK:L:lm:nO:o:p:R:r:sT:Vvz:";
-#ifdef LASH_ENABLED
   int enabled_lash = 0;		/* set to TRUE if lash gets enabled */
   fluid_lash_args_t *lash_args;
 
@@ -691,7 +689,7 @@ int main(int argc, char** argv)
   }
   
   /* run the server, if requested */
-#if !defined(MACINTOSH)
+#ifdef NETWORK_SUPPORT
   if (with_server) {
     server = new_fluid_server(settings, synth, router);
     if (server == NULL) {
@@ -736,7 +734,7 @@ int main(int argc, char** argv)
 
  cleanup:
 
-#if !defined(MACINTOSH)
+#ifdef NETWORK_SUPPORT
   if (server != NULL) {
     /* if the user typed 'quit' in the shell, kill the server */
     if (!interactive) {

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -940,6 +940,8 @@ fluid_ostream_printf (fluid_ostream_t out, char* format, ...)
 #endif
 }
 
+#ifdef NETWORK_SUPPORT
+
 int fluid_server_socket_join(fluid_server_socket_t *server_socket)
 {
   return fluid_thread_join (server_socket->thread);
@@ -1171,3 +1173,5 @@ void delete_fluid_server_socket(fluid_server_socket_t *server_socket)
   // Should be called the same number of times as fluid_socket_init()
   fluid_socket_cleanup();
 }
+
+#endif // NETWORK_SUPPORT

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -148,9 +148,8 @@ typedef guint64  uint64_t;
 
 /* Darwin special defines (taken from config_macosx.h) */
 #ifdef DARWIN
-#define MACINTOSH
-#define __Types__
-#define WITHOUT_SERVER 1
+# define MACINTOSH
+# define __Types__
 #endif
 
 


### PR DESCRIPTION
I disabled by default network support for Darwin in CMakeLists.txt, for getting the same results as it was before into src/utils/fluidsynth_priv.h. I don't know why it had been done, but I decided to reproduce the same behavior.