### PR TITLE
Simplified code for modulation waveforms

### DIFF
--- a/src/rvoice/fluid_chorus.c
+++ b/src/rvoice/fluid_chorus.c
@@ -479,13 +479,22 @@ static void
 fluid_chorus_sine(int *buf, int len, int depth)
 {
   int i;
-  double val;
+  double angle, incr, mult;
 
+  /* Pre-calculate increment between angles. */
+  incr = (2. * M_PI) / (double)len;
+
+  /* Pre-calculate 'depth' multiplier. */
+  mult = (double) depth / 2.0 * (double) INTERPOLATION_SUBSAMPLES;
+
+  /* Initialize to zero degrees. */
+  angle = 0.;
+
+  /* Build sine modulation waveform */
   for (i = 0; i < len; i++) {
-    val = sin((double) i / (double)len * 2.0 * M_PI);
-    buf[i] = (int) ((1.0 + val) * (double) depth / 2.0 * (double) INTERPOLATION_SUBSAMPLES);
-    buf[i] -= 3* MAX_SAMPLES * INTERPOLATION_SUBSAMPLES;
-    //    printf("%i %i\n",i,buf[i]);
+    buf[i] = (int) ((1. + sin(angle)) * mult) - 3 * MAX_SAMPLES * INTERPOLATION_SUBSAMPLES;
+
+    angle += incr;
   }
 }
 
@@ -496,15 +505,24 @@ fluid_chorus_sine(int *buf, int len, int depth)
 static void
 fluid_chorus_triangle(int *buf, int len, int depth)
 {
-  int i=0;
-  int ii=len-1;
-  double val;
-  double val2;
+  int *il = buf;
+  int *ir = buf + len-1;
+  int ival;
+  double val, incr;
 
-  while (i <= ii){
-    val = i * 2.0 / len * (double)depth * (double) INTERPOLATION_SUBSAMPLES;
-    val2= (int) (val + 0.5) - 3 * MAX_SAMPLES * INTERPOLATION_SUBSAMPLES;
-    buf[i++] = (int) val2;
-    buf[ii--] = (int) val2;
+  /* Pre-calculate increment for the ramp. */
+  incr = 2.0 / len * (double)depth * (double) INTERPOLATION_SUBSAMPLES;
+
+  /* Initialize first value */
+  val = 0.;
+
+  /* Build triangular modulation waveform */
+  while (il <= ir) {
+    ival= (int)(val + 0.5) - 3 * MAX_SAMPLES * INTERPOLATION_SUBSAMPLES;
+
+    *il++ = ival;
+    *ir-- = ival;
+
+    val += incr;
   }
 }


### PR DESCRIPTION
When I finally run FluidSynth on an embedded ARM Cortex M3, I already expected not so good performance since it has not an hardware floating point unit. Surprisingly, it required more than 20 seconds to reaching the prompt on the console, too much if I think that, afterall, it is clocked at 120MHz.
After a bit of debugging, I discovered that the bottleneck is the calculation of the modulation waveform.
I simplified the code by extracting the calculations that never changed during the loop, this has improved the speed results a lot, by decreasing that time to 8 seconds. Evidently, the calculation of the sin() value is the most expensive one and it cannot be avoided. I applied the same rewrite also for the triangular waveform. Since the "depth" parameter cannot be bigger than MAX_SAMPLES, it could be possible to calculate fluid_chorus_triangle() with an integer implementation, but unlike the the fluid_chorus_sine(), it is calculate in a blink of eye, even with soft-float, the prompt appears immediately after poweron, so I think there are no problems to leave it as is.