### PR TITLE
remove unused API functions

### DIFF
--- a/doc/fluidsynth-v11-devdoc.txt
+++ b/doc/fluidsynth-v11-devdoc.txt
@@ -84,6 +84,7 @@ Changes in FluidSynth 2.0.0 concerning developers:
 - remove deprecated fluid_synth_reset_tuning(), use fluid_synth_deactivate_tuning(synth, chan, FALSE) instead
 - remove deprecated FLUID_HINT_INTEGER
 - remove deprecated fluid_synth_set_gen2() as there doesnt seem to be a use case for absolute generator values
+- remove fluid_cmd_handler_register() and fluid_cmd_handler_unregister() from public API, as they seem to be unused downstream
 - remove misspelled FLUID_SEQ_PITCHWHHELSENS macro
 - remove obsolete "audio.[out|in]put-channels" settings
 - remove unimplemented "synth.dump" setting

--- a/doc/fluidsynth-v11-devdoc.txt
+++ b/doc/fluidsynth-v11-devdoc.txt
@@ -83,6 +83,7 @@ Changes in FluidSynth 2.0.0 concerning developers:
 - remove deprecated fluid_synth_select_tuning(), use fluid_synth_activate_tuning(synth, chan, bank, prog, FALSE) instead
 - remove deprecated fluid_synth_reset_tuning(), use fluid_synth_deactivate_tuning(synth, chan, FALSE) instead
 - remove deprecated FLUID_HINT_INTEGER
+- remove deprecated fluid_synth_set_gen2() as there doesnt seem to be a use case for absolute generator values
 - remove misspelled FLUID_SEQ_PITCHWHHELSENS macro
 - remove obsolete "audio.[out|in]put-channels" settings
 - remove unimplemented "synth.dump" setting

--- a/include/fluidsynth/shell.h
+++ b/include/fluidsynth/shell.h
@@ -42,26 +42,6 @@ FLUIDSYNTH_API fluid_ostream_t fluid_get_stdout(void);
 FLUIDSYNTH_API char* fluid_get_userconf(char* buf, int len);
 FLUIDSYNTH_API char* fluid_get_sysconf(char* buf, int len);
 
-/**
- * Command handler function prototype.
- * @param data User defined data
- * @param ac Argument count
- * @param av Array of string arguments
- * @param out Output stream to send response to
- * @return Should return #FLUID_OK on success, #FLUID_FAILED otherwise
- */
-typedef int (*fluid_cmd_func_t)(void* data, int ac, char** av, fluid_ostream_t out);  
-
-/**
- * Shell command information structure.
- */
-typedef struct {
-  char* name;                           /**< The name of the command, as typed in the shell */
-  char* topic;                          /**< The help topic group of this command */ 
-  fluid_cmd_func_t handler;             /**< Pointer to the handler for this command */
-  void* data;                           /**< User data passed to the handler */
-  char* help;                           /**< A help string */
-} fluid_cmd_t;
 
 /* The command handler */
 
@@ -74,11 +54,6 @@ void delete_fluid_cmd_handler(fluid_cmd_handler_t* handler);
 FLUIDSYNTH_API 
 void fluid_cmd_handler_set_synth(fluid_cmd_handler_t* handler, fluid_synth_t* synth);
 
-FLUIDSYNTH_API 
-int fluid_cmd_handler_register(fluid_cmd_handler_t* handler, fluid_cmd_t* cmd);
-
-FLUIDSYNTH_API 
-int fluid_cmd_handler_unregister(fluid_cmd_handler_t* handler, const char *cmd);
 
 
 /* Command function */

--- a/include/fluidsynth/synth.h
+++ b/include/fluidsynth/synth.h
@@ -219,9 +219,6 @@ enum fluid_interp {
 
 FLUIDSYNTH_API int fluid_synth_set_gen (fluid_synth_t* synth, int chan,
                                          int param, float value);
-FLUIDSYNTH_API int fluid_synth_set_gen2 (fluid_synth_t* synth, int chan,
-                                         int param, float value,
-                                         int absolute, int normalized);
 FLUIDSYNTH_API float fluid_synth_get_gen(fluid_synth_t* synth, int chan, int param);
 
 

--- a/src/bindings/fluid_cmd.h
+++ b/src/bindings/fluid_cmd.h
@@ -95,13 +95,35 @@ int fluid_handle_ladspa_stop(void *data, int ac, char **av, fluid_ostream_t out)
 int fluid_handle_ladspa_reset(void *data, int ac, char **av, fluid_ostream_t out);
 #endif
 
-fluid_cmd_t* fluid_cmd_copy(fluid_cmd_t* cmd);
+/**
+ * Command handler function prototype.
+ * @param data User defined data
+ * @param ac Argument count
+ * @param av Array of string arguments
+ * @param out Output stream to send response to
+ * @return Should return #FLUID_OK on success, #FLUID_FAILED otherwise
+ */
+typedef int (*fluid_cmd_func_t)(void* data, int ac, char** av, fluid_ostream_t out);
+
+/**
+ * Shell command information structure.
+ */
+typedef struct {
+  char* name;                           /**< The name of the command, as typed in the shell */
+  char* topic;                          /**< The help topic group of this command */
+  fluid_cmd_func_t handler;             /**< Pointer to the handler for this command */
+  char* help;                           /**< A help string */
+} fluid_cmd_t;
+
+fluid_cmd_t* fluid_cmd_copy(const fluid_cmd_t* cmd);
 void delete_fluid_cmd(fluid_cmd_t* cmd);
 
 int fluid_cmd_handler_handle(void* data,
 			    int ac, char** av,
 			    fluid_ostream_t out);
 
+int fluid_cmd_handler_register(fluid_cmd_handler_t* handler, const fluid_cmd_t* cmd);
+int fluid_cmd_handler_unregister(fluid_cmd_handler_t* handler, const char *cmd);
 
 
 void fluid_server_remove_client(fluid_server_t* server, fluid_client_t* client);

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -201,6 +201,9 @@ void fluid_synth_api_exit(fluid_synth_t* synth);
 
 void fluid_synth_process_event_queue(fluid_synth_t* synth);
 
+int fluid_synth_set_gen2 (fluid_synth_t* synth, int chan,
+                                         int param, float value,
+                                         int absolute, int normalized);
 /*
  * misc
  */


### PR DESCRIPTION
This removes

* fluid_synth_set_gen2()
* fluid_cmd_handler_register()
* fluid_cmd_handler_unregister()
* fluid_cmd_t

from public API. Related discussions:
* https://lists.nongnu.org/archive/html/fluid-dev/2018-01/msg00047.html
* https://lists.nongnu.org/archive/html/fluid-dev/2017-12/msg00004.html

Closes #325.