### PR TITLE
Don't assume the paths are relative.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,8 +458,16 @@ add_subdirectory ( doc )
 # pkg-config support
 set ( prefix "${CMAKE_INSTALL_PREFIX}" )
 set ( exec_prefix "\${prefix}" )
-set ( libdir "\${exec_prefix}/${LIB_INSTALL_DIR}" )
-set ( includedir "\${prefix}/${INCLUDE_INSTALL_DIR}" )
+if ( IS_ABSOLUTE "${LIB_INSTALL_DIR}" )
+  set ( libdir "${LIB_INSTALL_DIR}" )
+else ()
+  set ( libdir "\${exec_prefix}/${LIB_INSTALL_DIR}" )
+endif ()
+if ( IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}" )
+  set ( includedir "${INCLUDE_INSTALL_DIR}" )
+else ()
+  set ( includedir "\${prefix}/${INCLUDE_INSTALL_DIR}" )
+endif ()
 configure_file ( fluidsynth.pc.in
 	${CMAKE_BINARY_DIR}/fluidsynth.pc IMMEDIATE @ONLY )
 install ( FILES ${CMAKE_BINARY_DIR}/fluidsynth.pc


### PR DESCRIPTION
When building fluidsynth, we can use relative or absolute paths for
LIB_INSTALL_DIR or INCLUDE_INSTALL_DIR (or let the build system decide).

Let's check whether one of these two vars was defined before writing
fluidsynth.pc.

Fixes https://bugzilla.opensuse.org/1084081