### PR TITLE
Fix sample check and SF3 soundfont loading

### DIFF
--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -1861,6 +1861,7 @@ fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defs
     int ret = uncompress_vorbis_sample(sample);
     if (sample->data == NULL || ret == FLUID_FAILED)
     {
+      sample->valid = 0;
       return ret;
     }
   }
@@ -1869,12 +1870,14 @@ fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defs
     sample->valid = 0;
     FLUID_LOG(FLUID_WARN, "Ignoring sample '%s': can't use ROM samples", sample->name);
   }
-  if (sample->end - sample->start < 8) {
+  else if (sample->end - sample->start < 8) {
     sample->valid = 0;
     FLUID_LOG(FLUID_WARN, "Ignoring sample '%s': too few sample data points", sample->name);
   }
+  else {
+    sample->valid = TRUE;
+  }
 
-  sample->valid = TRUE;
   return FLUID_OK;
 }
 

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -3373,11 +3373,13 @@ fixup_sample (SFData * sf)
   p = sf->sample;
   while (p)
     {
-      /* Standard SoundFont files (SF2) use sample word indices for sample start and end pointers,
-       * but SF3 files with Ogg Vorbis compression use byte indices for start and end. */
-      unsigned int max_end = (sam->sampletype & FLUID_SAMPLETYPE_OGG_VORBIS) ? total_bytes : total_samples;
+      unsigned int max_end;
 
       sam = (SFSample *) (p->data);
+
+      /* Standard SoundFont files (SF2) use sample word indices for sample start and end pointers,
+       * but SF3 files with Ogg Vorbis compression use byte indices for start and end. */
+      max_end = (sam->sampletype & FLUID_SAMPLETYPE_OGG_VORBIS) ? total_bytes : total_samples;
 
       /* ROM samples are unusable for us by definition, so simply ignore them. */
       if (sam->sampletype & FLUID_SAMPLETYPE_ROM)

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -1827,6 +1827,7 @@ fluid_zone_inside_range(fluid_zone_range_t* range, int key, int vel)
  *
  *                           SAMPLE
  */
+static int uncompress_vorbis_sample(fluid_sample_t *sample);
 
 /*
  * fluid_sample_in_rom
@@ -1840,6 +1841,52 @@ fluid_sample_in_rom(fluid_sample_t* sample)
 /*
  * fluid_sample_import_sfont
  */
+int
+fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defsfont_t* sfont)
+{
+  FLUID_STRCPY(sample->name, sfsample->name);
+  sample->data = sfont->sampledata;
+  sample->data24 = sfont->sample24data;
+  sample->start = sfsample->start;
+  sample->end = sfsample->start + sfsample->end;
+  sample->loopstart = sfsample->start + sfsample->loopstart;
+  sample->loopend = sfsample->start + sfsample->loopend;
+  sample->samplerate = sfsample->samplerate;
+  sample->origpitch = sfsample->origpitch;
+  sample->pitchadj = sfsample->pitchadj;
+  sample->sampletype = sfsample->sampletype;
+
+  if (sample->sampletype & FLUID_SAMPLETYPE_OGG_VORBIS)
+  {
+    int ret = uncompress_vorbis_sample(sample);
+    if (sample->data == NULL || ret == FLUID_FAILED)
+    {
+      return ret;
+    }
+  }
+
+  if (sample->sampletype & FLUID_SAMPLETYPE_ROM) {
+    sample->valid = 0;
+    FLUID_LOG(FLUID_WARN, "Ignoring sample '%s': can't use ROM samples", sample->name);
+  }
+  if (sample->end - sample->start < 8) {
+    sample->valid = 0;
+    FLUID_LOG(FLUID_WARN, "Ignoring sample '%s': too few sample data points", sample->name);
+  } else {
+/*      if (sample->loopstart < sample->start + 8) { */
+/*        FLUID_LOG(FLUID_WARN, "Fixing sample %s: at least 8 data points required before loop start", sample->name);     */
+/*        sample->loopstart = sample->start + 8; */
+/*      } */
+/*      if (sample->loopend > sample->end - 8) { */
+/*        FLUID_LOG(FLUID_WARN, "Fixing sample %s: at least 8 data points required after loop end", sample->name);     */
+/*        sample->loopend = sample->end - 8; */
+/*      } */
+  }
+  
+  sample->valid = TRUE;
+  return FLUID_OK;
+}
+
 #if LIBSNDFILE_SUPPORT
 // virtual file access rountines to allow for handling
 // samples as virtual files in memory
@@ -1894,26 +1941,9 @@ sfvio_tell (void* user_data)
 
   return (sf_count_t)sample->userdata;
 }
-#endif
 
-int
-fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defsfont_t* sfont)
+static int uncompress_vorbis_sample(fluid_sample_t *sample)
 {
-  FLUID_STRCPY(sample->name, sfsample->name);
-  sample->data = sfont->sampledata;
-  sample->data24 = sfont->sample24data;
-  sample->start = sfsample->start;
-  sample->end = sfsample->start + sfsample->end;
-  sample->loopstart = sfsample->start + sfsample->loopstart;
-  sample->loopend = sfsample->start + sfsample->loopend;
-  sample->samplerate = sfsample->samplerate;
-  sample->origpitch = sfsample->origpitch;
-  sample->pitchadj = sfsample->pitchadj;
-  sample->sampletype = sfsample->sampletype;
-
-  if (sample->sampletype & FLUID_SAMPLETYPE_OGG_VORBIS)
-  {
-#if LIBSNDFILE_SUPPORT
     SNDFILE *sndfile;
     SF_INFO sfinfo;
     SF_VIRTUAL_IO sfvio = {
@@ -2000,32 +2030,15 @@ fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defs
     {
         FLUID_LOG (FLUID_WARN, _("Vorbis sample '%s' has invalid loop points"), sample->name);
     }
-#else
-    return FLUID_FAILED;
-#endif
-  }
 
-  if (sample->sampletype & FLUID_SAMPLETYPE_ROM) {
-    sample->valid = 0;
-    FLUID_LOG(FLUID_WARN, "Ignoring sample '%s': can't use ROM samples", sample->name);
-  }
-  if (sample->end - sample->start < 8) {
-    sample->valid = 0;
-    FLUID_LOG(FLUID_WARN, "Ignoring sample '%s': too few sample data points", sample->name);
-  } else {
-/*      if (sample->loopstart < sample->start + 8) { */
-/*        FLUID_LOG(FLUID_WARN, "Fixing sample %s: at least 8 data points required before loop start", sample->name);     */
-/*        sample->loopstart = sample->start + 8; */
-/*      } */
-/*      if (sample->loopend > sample->end - 8) { */
-/*        FLUID_LOG(FLUID_WARN, "Fixing sample %s: at least 8 data points required after loop end", sample->name);     */
-/*        sample->loopend = sample->end - 8; */
-/*      } */
-  }
-  
-  sample->valid = TRUE;
-  return FLUID_OK;
+    return FLUID_OK;
 }
+#else
+static int uncompress_vorbis_sample(fluid_sample_t *sample)
+{
+    return FLUID_FAILED;
+}
+#endif
 
 
 

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -1872,17 +1872,8 @@ fluid_sample_import_sfont(fluid_sample_t* sample, SFSample* sfsample, fluid_defs
   if (sample->end - sample->start < 8) {
     sample->valid = 0;
     FLUID_LOG(FLUID_WARN, "Ignoring sample '%s': too few sample data points", sample->name);
-  } else {
-/*      if (sample->loopstart < sample->start + 8) { */
-/*        FLUID_LOG(FLUID_WARN, "Fixing sample %s: at least 8 data points required before loop start", sample->name);     */
-/*        sample->loopstart = sample->start + 8; */
-/*      } */
-/*      if (sample->loopend > sample->end - 8) { */
-/*        FLUID_LOG(FLUID_WARN, "Fixing sample %s: at least 8 data points required after loop end", sample->name);     */
-/*        sample->loopend = sample->end - 8; */
-/*      } */
   }
-  
+
   sample->valid = TRUE;
   return FLUID_OK;
 }

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -3389,9 +3389,11 @@ fixup_sample (SFData * sf)
 	        /* disable sample by setting all sample markers to 0 */
 	        sam->start = sam->end = sam->loopstart = sam->loopend = 0;
 
-	        return (OK);
+          p = fluid_list_next (p);
+          continue;
 	    }
-      else if (sam->sampletype & FLUID_SAMPLETYPE_OGG_VORBIS)
+
+      if (sam->sampletype & FLUID_SAMPLETYPE_OGG_VORBIS)
 	    {
             /*
              * compressed samples get fixed up after decompression

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -3385,8 +3385,7 @@ fixup_sample (SFData * sf)
       if (sam->sampletype & FLUID_SAMPLETYPE_ROM)
       {
         sam->start = sam->end = sam->loopstart = sam->loopend = 0;
-        p = fluid_list_next (p);
-        continue;
+        goto next_sample;
       }
 
       /* If end is over the sample data chunk or sam start is greater than 4
@@ -3399,8 +3398,7 @@ fixup_sample (SFData * sf)
         FLUID_LOG (FLUID_WARN, _("Sample '%s' start/end file positions are invalid,"
                    " disabling and will not be saved"), sam->name);
         sam->start = sam->end = sam->loopstart = sam->loopend = 0;
-        p = fluid_list_next (p);
-        continue;
+        goto next_sample;
       }
       
       /* The SoundFont 2.4 spec defines the loopstart index as the first sample point of the loop */
@@ -3457,6 +3455,7 @@ fixup_sample (SFData * sf)
       sam->loopstart -= sam->start;
       sam->loopend -= sam->start;
 
+next_sample:
       p = fluid_list_next (p);
     }
 


### PR DESCRIPTION
While trying to refactor the SoundFont loading I noticed a few smaller bugs in the sample fixup code and a larger one that prevented SF3 files from being loaded properly. This pull requests adresses the following problems:

- when a sample has an invalid start or end pointer, the sample check returns OK immediately and therefore doesn't check any of the samples located further down in the file
- fluid_sample_import_sfont set sample->valid = TRUE unconditionally at the end of the function. Regardless if it had been set to FALSE previously
- Fix loading of SF3 (Ogg Vorbis compressed) SoundFonts. SF3 specifies the start and end pointers for each sample in byte offsets, not sample word offsets as specified in the SF2 spec. So we need to check the sample type and use the correct maximum end index. 