### PR TITLE
fix wrong index of 'for' statement in (fluid_rvoice.c)

### DIFF
--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -467,8 +467,8 @@ fluid_rvoice_buffers_check_bufnum(fluid_rvoice_buffers_t* buffers, unsigned int 
   if (bufnum >= FLUID_RVOICE_MAX_BUFS) return FLUID_FAILED;
 
   for (i = buffers->count; i <= bufnum; i++) {
-    buffers->bufs[bufnum].amp = 0.0f;  
-    buffers->bufs[bufnum].mapping = i;  
+    buffers->bufs[i].amp = 0.0f;  
+    buffers->bufs[i].mapping = i;  
   }
   buffers->count = bufnum+1;
   return FLUID_OK;


### PR DESCRIPTION
469   for (i = buffers->count; i <= bufnum; i++) {
470     buffers->bufs[bufnum].amp = 0.0f;     
471     buffers->bufs[bufnum].mapping = i;     
472   }

change to 

469   for (i = buffers->count; i <= bufnum; i++) {
470     buffers->bufs[i].amp = 0.0f;     
471     buffers->bufs[i].mapping = i;     
472   }

Is it right?