### PR TITLE
Unify calling conventions for rvoice update functions 

### DIFF
--- a/src/rvoice/fluid_adsr_env.c
+++ b/src/rvoice/fluid_adsr_env.c
@@ -20,15 +20,16 @@
 
 #include "fluid_adsr_env.h"
 
-void 
-fluid_adsr_env_set_data(fluid_adsr_env_t* env,
-                        fluid_adsr_env_section_t section,
-                        unsigned int count,
-                        fluid_real_t coeff,
-                        fluid_real_t increment,
-                        fluid_real_t min,
-                        fluid_real_t max)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_adsr_env_set_data)
 {
+    fluid_adsr_env_t* env = obj;
+    fluid_adsr_env_section_t section = param[0].i;
+    unsigned int count = param[1].i;
+    fluid_real_t coeff = param[2].real;
+    fluid_real_t increment = param[3].real;
+    fluid_real_t min = param[4].real;
+    fluid_real_t max = param[5].real;
+    
   env->data[section].count = count;
   env->data[section].coeff = coeff;
   env->data[section].increment = increment;

--- a/src/rvoice/fluid_adsr_env.h
+++ b/src/rvoice/fluid_adsr_env.h
@@ -104,14 +104,7 @@ fluid_adsr_env_calc(fluid_adsr_env_t* env, int is_volenv)
 
 /* This one cannot be inlined since it is referenced in 
    the event queue */
-void 
-fluid_adsr_env_set_data(fluid_adsr_env_t* env,
-                        fluid_adsr_env_section_t section,
-                        unsigned int count,
-                        fluid_real_t coeff,
-                        fluid_real_t increment,
-                        fluid_real_t min,
-                        fluid_real_t max);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_adsr_env_set_data);
 
 static FLUID_INLINE void 
 fluid_adsr_env_reset(fluid_adsr_env_t* env)

--- a/src/rvoice/fluid_iir_filter.c
+++ b/src/rvoice/fluid_iir_filter.c
@@ -138,8 +138,12 @@ fluid_iir_filter_apply(fluid_iir_filter_t* iir_filter,
 }
 
 
-void fluid_iir_filter_init(fluid_iir_filter_t* iir_filter, enum fluid_iir_filter_type type, enum fluid_iir_filter_flags flags)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_init)
 {
+    fluid_iir_filter_t* iir_filter = obj;
+    enum fluid_iir_filter_type type = param[0].i;
+    enum fluid_iir_filter_flags flags = param[1].i;
+    
     iir_filter->type = type;
     iir_filter->flags = flags;
     if(type != FLUID_IIR_DISABLED)
@@ -158,10 +162,11 @@ fluid_iir_filter_reset(fluid_iir_filter_t* iir_filter)
   iir_filter->filter_startup = 1;
 }
 
-void 
-fluid_iir_filter_set_fres(fluid_iir_filter_t* iir_filter, 
-                          fluid_real_t fres)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_fres)
 {
+  fluid_iir_filter_t* iir_filter = obj;
+  fluid_real_t fres = param[0].real;
+  
   iir_filter->fres = fres;
   iir_filter->last_fres = -1.;
 }
@@ -197,9 +202,10 @@ static fluid_real_t fluid_iir_filter_q_from_dB(fluid_real_t q_dB)
     return pow(10.0f, q_dB / 20.0f);
 }
 
-void 
-fluid_iir_filter_set_q(fluid_iir_filter_t* iir_filter, fluid_real_t q)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_q)
 {
+    fluid_iir_filter_t* iir_filter = obj;
+    fluid_real_t q = param[0].real;
     int flags = iir_filter->flags;
     
     if(flags & FLUID_IIR_Q_ZERO_OFF && q<=0.0)

--- a/src/rvoice/fluid_iir_filter.h
+++ b/src/rvoice/fluid_iir_filter.h
@@ -25,18 +25,14 @@
 
 typedef struct _fluid_iir_filter_t fluid_iir_filter_t;
 
-
-void fluid_iir_filter_init(fluid_iir_filter_t* iir_filter, enum fluid_iir_filter_type, enum fluid_iir_filter_flags flags);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_init);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_fres);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_q);
 
 void fluid_iir_filter_apply(fluid_iir_filter_t* iir_filter,
                             fluid_real_t *dsp_buf, int dsp_buf_count);
 
 void fluid_iir_filter_reset(fluid_iir_filter_t* iir_filter);
-
-void fluid_iir_filter_set_q(fluid_iir_filter_t* iir_filter, fluid_real_t q);
-
-void fluid_iir_filter_set_fres(fluid_iir_filter_t* iir_filter, 
-                               fluid_real_t fres);
 
 void fluid_iir_filter_calc(fluid_iir_filter_t* iir_filter, 
                            fluid_real_t output_rate, 

--- a/src/rvoice/fluid_lfo.c
+++ b/src/rvoice/fluid_lfo.c
@@ -1,13 +1,17 @@
 #include "fluid_lfo.h"
 
-void
-fluid_lfo_set_incr(fluid_lfo_t* lfo, fluid_real_t increment)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_lfo_set_incr)
 {
-  lfo->increment = increment;
+    fluid_lfo_t* lfo = obj;
+    fluid_real_t increment = param[0].real;
+    
+    lfo->increment = increment;
 }
 
-void
-fluid_lfo_set_delay(fluid_lfo_t* lfo, unsigned int delay)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_lfo_set_delay)
 {
-  lfo->delay = delay;
+    fluid_lfo_t* lfo = obj;
+    unsigned int delay = param[0].i;
+    
+    lfo->delay = delay;
 }

--- a/src/rvoice/fluid_lfo.h
+++ b/src/rvoice/fluid_lfo.h
@@ -38,8 +38,8 @@ fluid_lfo_reset(fluid_lfo_t* lfo)
 }
 
 // These two cannot be inlined since they're used by event_dispatch
-void fluid_lfo_set_incr(fluid_lfo_t* lfo, fluid_real_t increment);
-void fluid_lfo_set_delay(fluid_lfo_t* lfo, unsigned int delay);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_lfo_set_incr);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_lfo_set_delay);
 
 static FLUID_INLINE fluid_real_t
 fluid_lfo_get_val(fluid_lfo_t* lfo)

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -167,40 +167,36 @@ int fluid_rvoice_write(fluid_rvoice_t* voice, fluid_real_t *dsp_buf);
 void fluid_rvoice_buffers_mix(fluid_rvoice_buffers_t* buffers, 
                               fluid_real_t* dsp_buf, int samplecount, 
                               fluid_real_t** dest_bufs, int dest_bufcount);
-void fluid_rvoice_buffers_set_amp(fluid_rvoice_buffers_t* buffers, 
-                                  unsigned int bufnum, fluid_real_t value);
-void fluid_rvoice_buffers_set_mapping(fluid_rvoice_buffers_t* buffers,
-                                      unsigned int bufnum, int mapping);
 
-/* Dynamic update functions */
-void fluid_rvoice_set_portamento(fluid_rvoice_t * voice, unsigned int countinc,
-								 fluid_real_t pitchoffset);
-void fluid_rvoice_multi_retrigger_attack(fluid_rvoice_t* voice);
-void fluid_rvoice_noteoff(fluid_rvoice_t* voice, unsigned int min_ticks);
-void fluid_rvoice_voiceoff(fluid_rvoice_t* voice);
-void fluid_rvoice_reset(fluid_rvoice_t* voice);
-void fluid_rvoice_set_output_rate(fluid_rvoice_t* voice, fluid_real_t output_rate);
-void fluid_rvoice_set_interp_method(fluid_rvoice_t* voice, int interp_method);
-void fluid_rvoice_set_root_pitch_hz(fluid_rvoice_t* voice, fluid_real_t root_pitch_hz);
-void fluid_rvoice_set_pitch(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_synth_gain(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_attenuation(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_min_attenuation_cB(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_viblfo_to_pitch(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_modlfo_to_pitch(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_modlfo_to_vol(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_modlfo_to_fc(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_modenv_to_fc(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_modenv_to_pitch(fluid_rvoice_t* voice, fluid_real_t value);
-void fluid_rvoice_set_start(fluid_rvoice_t* voice, int value);
-void fluid_rvoice_set_end(fluid_rvoice_t* voice, int value);
-void fluid_rvoice_set_loopstart(fluid_rvoice_t* voice, int value);
-void fluid_rvoice_set_loopend(fluid_rvoice_t* voice, int value);
-void fluid_rvoice_set_sample(fluid_rvoice_t* voice, fluid_sample_t* value);
-void fluid_rvoice_set_samplemode(fluid_rvoice_t* voice, enum fluid_loop value);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_buffers_set_amp);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_buffers_set_mapping);
+
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_noteoff);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_voiceoff);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_reset);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_multi_retrigger_attack);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_portamento);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_output_rate);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_interp_method);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_root_pitch_hz);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_pitch);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_attenuation);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_min_attenuation_cB);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_viblfo_to_pitch);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_modlfo_to_pitch);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_modlfo_to_vol);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_modlfo_to_fc);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_modenv_to_fc);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_modenv_to_pitch);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_synth_gain);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_start);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_end);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_loopstart);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_loopend);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_samplemode);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_sample);
 
 /* defined in fluid_rvoice_dsp.c */
-
 void fluid_rvoice_dsp_config (void);
 int fluid_rvoice_dsp_interpolate_none (fluid_rvoice_dsp_t *voice);
 int fluid_rvoice_dsp_interpolate_linear (fluid_rvoice_dsp_t *voice);

--- a/src/rvoice/fluid_rvoice_event.c
+++ b/src/rvoice/fluid_rvoice_event.c
@@ -39,7 +39,7 @@ fluid_rvoice_event_dispatch(fluid_rvoice_event_t* event)
  * use push for all events, then use flush to commit them to the 
  * queue. If threadsafe is false, all events are processed immediately. */
 int
-fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler, 
+fluid_rvoice_eventhandler_push_int_real(fluid_rvoice_eventhandler_t* handler, 
                                 fluid_rvoice_function_t method, void* object, int intparam, 
                                 fluid_real_t realparam)
 {
@@ -54,7 +54,7 @@ fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler,
 }
 
 int
-fluid_rvoice_eventhandler_push_param(fluid_rvoice_eventhandler_t* handler, fluid_rvoice_function_t method, void* object, fluid_rvoice_param_t param[MAX_EVENT_PARAMS])
+fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler, fluid_rvoice_function_t method, void* object, fluid_rvoice_param_t param[MAX_EVENT_PARAMS])
 {
   fluid_rvoice_event_t local_event;
   

--- a/src/rvoice/fluid_rvoice_event.c
+++ b/src/rvoice/fluid_rvoice_event.c
@@ -54,13 +54,13 @@ fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler,
 }
 
 int
-fluid_rvoice_eventhandler_push_param(fluid_rvoice_eventhandler_t* handler, fluid_rvoice_function_t method, void* object, fluid_rvoice_param_t param[EVENT_PARAMS])
+fluid_rvoice_eventhandler_push_param(fluid_rvoice_eventhandler_t* handler, fluid_rvoice_function_t method, void* object, fluid_rvoice_param_t param[MAX_EVENT_PARAMS])
 {
   fluid_rvoice_event_t local_event;
   
   local_event.method = method;
   local_event.object = object;
-  FLUID_MEMCPY(&local_event.param, param, sizeof(*param) * EVENT_PARAMS);
+  FLUID_MEMCPY(&local_event.param, param, sizeof(*param) * MAX_EVENT_PARAMS);
   
   return fluid_rvoice_eventhandler_push_LOCAL(handler, &local_event);
 }

--- a/src/rvoice/fluid_rvoice_event.c
+++ b/src/rvoice/fluid_rvoice_event.c
@@ -24,136 +24,13 @@
 #include "fluid_iir_filter.h"
 #include "fluid_lfo.h"
 #include "fluid_adsr_env.h"
-/* Calling proc without data parameters */
-#define EVENTFUNC_0(proc, type) \
-  if (event->method == proc) { \
-    proc((type) event->object); \
-    return; }
-
-/* Calling proc passing only one real data parameter */
-#define EVENTFUNC_R1(proc, type) \
-  if (event->method == proc) { \
-    if(event->intparam != 0) { FLUID_LOG(FLUID_DBG, "IR-mismatch"); }  \
-    proc((type) event->object, event->realparams[0]); \
-    return; }
-
-/* Calling proc passing pointer parameter */
-#define EVENTFUNC_PTR(proc, type, type2) \
-  if (event->method == proc) { \
-    proc((type) event->object, (type2) event->ptr); \
-    return; }
-
-/* Calling proc passing only int parameter */
-#define EVENTFUNC_I1(proc, type) \
-  if (event->method == proc) { \
-    if(event->realparams[0] != 0.0f) { FLUID_LOG(FLUID_DBG, "IR-mismatch"); }  \
-    proc((type) event->object, event->intparam); \
-    return; } 
-
-/* Calling proc passing: int,int data parameters */
-#define EVENTFUNC_II(proc, type) \
-  if (event->method == proc) { \
-    proc((type) event->object, event->intparam, (int) event->realparams[0]); \
-    return; } 
-
-/* Calling proc passing: int,real data parameters */
-#define EVENTFUNC_IR(proc, type) \
-  if (event->method == proc) { \
-    proc((type) event->object, event->intparam, event->realparams[0]); \
-    return; } 
-  
-/* Calling proc passing: int,real,real,real,real,real data parameters */
-#define EVENTFUNC_ALL(proc, type) \
-  if (event->method == proc) { \
-    proc((type) event->object, event->intparam, event->realparams[0], \
-      event->realparams[1], event->realparams[2], event->realparams[3], \
-      event->realparams[4]); \
-    return; }
-
-/* Calling proc passing: int,int,real,real,real,int data parameters */
-#define EVENTFUNC_IIR3I(proc, type) \
-  if (event->method == proc) { \
-    proc((type) event->object, event->intparam, (int)event->realparams[0], \
-      event->realparams[1], event->realparams[2], event->realparams[3], \
-      (int)event->realparams[4]); \
-    return; }
-
-/* Calling proc passing: int,int,real,real,real,real data parameters */
-#define EVENTFUNC_IIR4(proc, type) \
-  if (event->method == proc) { \
-    proc((type) event->object, event->intparam, (int)event->realparams[0], \
-      event->realparams[1], event->realparams[2], event->realparams[3], \
-      event->realparams[4]); \
-    return; }
-
-/* Calling proc passing: int,real,real,real,real data parameters */
-#define EVENTFUNC_R4(proc, type) \
-  if (event->method == proc) { \
-    proc((type) event->object, event->intparam, event->realparams[0], \
-      event->realparams[1], event->realparams[2], event->realparams[3]); \
-    return; }
-
 
 static int fluid_rvoice_eventhandler_push_LOCAL(fluid_rvoice_eventhandler_t* handler, const fluid_rvoice_event_t* src_event);
 
-void
+static FLUID_INLINE void
 fluid_rvoice_event_dispatch(fluid_rvoice_event_t* event)
 {
-  EVENTFUNC_PTR(fluid_rvoice_mixer_add_voice, fluid_rvoice_mixer_t*, fluid_rvoice_t*);
-  EVENTFUNC_I1(fluid_rvoice_noteoff, fluid_rvoice_t*);
-  EVENTFUNC_0(fluid_rvoice_voiceoff, fluid_rvoice_t*);
-  EVENTFUNC_0(fluid_rvoice_reset, fluid_rvoice_t*);
-  
-  EVENTFUNC_0(fluid_rvoice_multi_retrigger_attack, fluid_rvoice_t*);
-  EVENTFUNC_IR(fluid_rvoice_set_portamento, fluid_rvoice_t*);
-
-  EVENTFUNC_IIR4(fluid_adsr_env_set_data, fluid_adsr_env_t*);
-
-  EVENTFUNC_I1(fluid_lfo_set_delay, fluid_lfo_t*);
-  EVENTFUNC_R1(fluid_lfo_set_incr, fluid_lfo_t*);
-
-  EVENTFUNC_II(fluid_iir_filter_init, fluid_iir_filter_t*);
-  EVENTFUNC_R1(fluid_iir_filter_set_fres, fluid_iir_filter_t*);
-  EVENTFUNC_R1(fluid_iir_filter_set_q, fluid_iir_filter_t*);
-
-  EVENTFUNC_II(fluid_rvoice_buffers_set_mapping, fluid_rvoice_buffers_t*);
-  EVENTFUNC_IR(fluid_rvoice_buffers_set_amp, fluid_rvoice_buffers_t*);
-
-  EVENTFUNC_R1(fluid_rvoice_set_modenv_to_pitch, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_output_rate, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_root_pitch_hz, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_synth_gain, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_pitch, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_attenuation, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_min_attenuation_cB, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_viblfo_to_pitch, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_modlfo_to_pitch, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_modlfo_to_vol, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_modlfo_to_fc, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_modenv_to_fc, fluid_rvoice_t*);
-  EVENTFUNC_R1(fluid_rvoice_set_modenv_to_pitch, fluid_rvoice_t*);
-  EVENTFUNC_I1(fluid_rvoice_set_interp_method, fluid_rvoice_t*);
-  EVENTFUNC_I1(fluid_rvoice_set_start, fluid_rvoice_t*);
-  EVENTFUNC_I1(fluid_rvoice_set_end, fluid_rvoice_t*);
-  EVENTFUNC_I1(fluid_rvoice_set_loopstart, fluid_rvoice_t*);
-  EVENTFUNC_I1(fluid_rvoice_set_loopend, fluid_rvoice_t*);
-  EVENTFUNC_I1(fluid_rvoice_set_samplemode, fluid_rvoice_t*);
-  EVENTFUNC_PTR(fluid_rvoice_set_sample, fluid_rvoice_t*, fluid_sample_t*);
-
-  EVENTFUNC_R1(fluid_rvoice_mixer_set_samplerate, fluid_rvoice_mixer_t*);
-  EVENTFUNC_I1(fluid_rvoice_mixer_set_polyphony, fluid_rvoice_mixer_t*);
-  EVENTFUNC_I1(fluid_rvoice_mixer_set_reverb_enabled, fluid_rvoice_mixer_t*);
-  EVENTFUNC_I1(fluid_rvoice_mixer_set_chorus_enabled, fluid_rvoice_mixer_t*);
-  EVENTFUNC_I1(fluid_rvoice_mixer_set_mix_fx, fluid_rvoice_mixer_t*);
-  EVENTFUNC_0(fluid_rvoice_mixer_reset_fx, fluid_rvoice_mixer_t*);
-  EVENTFUNC_0(fluid_rvoice_mixer_reset_reverb, fluid_rvoice_mixer_t*);
-  EVENTFUNC_0(fluid_rvoice_mixer_reset_chorus, fluid_rvoice_mixer_t*);
-  EVENTFUNC_II(fluid_rvoice_mixer_set_threads, fluid_rvoice_mixer_t*);
- 
-  EVENTFUNC_IIR3I(fluid_rvoice_mixer_set_chorus_params, fluid_rvoice_mixer_t*);
-  EVENTFUNC_R4(fluid_rvoice_mixer_set_reverb_params, fluid_rvoice_mixer_t*);
-
-  FLUID_LOG(FLUID_ERR, "fluid_rvoice_event_dispatch: Unknown method %p to dispatch!", event->method);
+    event->method(event->object, event->param);
 }
 
 
@@ -163,29 +40,40 @@ fluid_rvoice_event_dispatch(fluid_rvoice_event_t* event)
  * queue. If threadsafe is false, all events are processed immediately. */
 int
 fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler, 
-                                void* method, void* object, int intparam, 
+                                fluid_rvoice_function_t method, void* object, int intparam, 
                                 fluid_real_t realparam)
 {
   fluid_rvoice_event_t local_event;
   
   local_event.method = method;
   local_event.object = object;
-  local_event.intparam = intparam;
-  local_event.realparams[0] = realparam;
+  local_event.param[0].i = intparam;
+  local_event.param[1].real = realparam;
   
   return fluid_rvoice_eventhandler_push_LOCAL(handler, &local_event);
 }
 
-
-int 
-fluid_rvoice_eventhandler_push_ptr(fluid_rvoice_eventhandler_t* handler, 
-                                   void* method, void* object, void* ptr)
+int
+fluid_rvoice_eventhandler_push_param(fluid_rvoice_eventhandler_t* handler, fluid_rvoice_function_t method, void* object, fluid_rvoice_param_t param[EVENT_PARAMS])
 {
   fluid_rvoice_event_t local_event;
   
   local_event.method = method;
   local_event.object = object;
-  local_event.ptr = ptr;
+  FLUID_MEMCPY(&local_event.param, param, sizeof(*param) * EVENT_PARAMS);
+  
+  return fluid_rvoice_eventhandler_push_LOCAL(handler, &local_event);
+}
+
+int 
+fluid_rvoice_eventhandler_push_ptr(fluid_rvoice_eventhandler_t* handler, 
+                                   fluid_rvoice_function_t method, void* object, void* ptr)
+{
+  fluid_rvoice_event_t local_event;
+  
+  local_event.method = method;
+  local_event.object = object;
+  local_event.param[0].ptr = ptr;
   
   return fluid_rvoice_eventhandler_push_LOCAL(handler, &local_event);
 }
@@ -193,7 +81,7 @@ fluid_rvoice_eventhandler_push_ptr(fluid_rvoice_eventhandler_t* handler,
 
 int 
 fluid_rvoice_eventhandler_push5(fluid_rvoice_eventhandler_t* handler, 
-                                void* method, void* object, int intparam, 
+                                fluid_rvoice_function_t method, void* object, int intparam, 
                                 fluid_real_t r1, fluid_real_t r2, 
                                 fluid_real_t r3, fluid_real_t r4, fluid_real_t r5)
 {
@@ -201,12 +89,12 @@ fluid_rvoice_eventhandler_push5(fluid_rvoice_eventhandler_t* handler,
   
   local_event.method = method;
   local_event.object = object;
-  local_event.intparam = intparam;
-  local_event.realparams[0] = r1;
-  local_event.realparams[1] = r2;
-  local_event.realparams[2] = r3;
-  local_event.realparams[3] = r4;
-  local_event.realparams[4] = r5;
+  local_event.param[0].i = intparam;
+  local_event.param[1].real = r1;
+  local_event.param[2].real = r2;
+  local_event.param[3].real = r3;
+  local_event.param[4].real = r4;
+  local_event.param[5].real = r5;
   
   return fluid_rvoice_eventhandler_push_LOCAL(handler, &local_event);
     
@@ -225,7 +113,7 @@ static int fluid_rvoice_eventhandler_push_LOCAL(fluid_rvoice_eventhandler_t* han
     return FLUID_FAILED; // Buffer full...
   }
 
-  memcpy(event, src_event, sizeof(*event));
+  FLUID_MEMCPY(event, src_event, sizeof(*event));
   
   return FLUID_OK;
 }

--- a/src/rvoice/fluid_rvoice_event.c
+++ b/src/rvoice/fluid_rvoice_event.c
@@ -78,28 +78,6 @@ fluid_rvoice_eventhandler_push_ptr(fluid_rvoice_eventhandler_t* handler,
   return fluid_rvoice_eventhandler_push_LOCAL(handler, &local_event);
 }
 
-
-int 
-fluid_rvoice_eventhandler_push5(fluid_rvoice_eventhandler_t* handler, 
-                                fluid_rvoice_function_t method, void* object, int intparam, 
-                                fluid_real_t r1, fluid_real_t r2, 
-                                fluid_real_t r3, fluid_real_t r4, fluid_real_t r5)
-{
-  fluid_rvoice_event_t local_event;
-  
-  local_event.method = method;
-  local_event.object = object;
-  local_event.param[0].i = intparam;
-  local_event.param[1].real = r1;
-  local_event.param[2].real = r2;
-  local_event.param[3].real = r3;
-  local_event.param[4].real = r4;
-  local_event.param[5].real = r5;
-  
-  return fluid_rvoice_eventhandler_push_LOCAL(handler, &local_event);
-    
-}
-
 static int fluid_rvoice_eventhandler_push_LOCAL(fluid_rvoice_eventhandler_t* handler, const fluid_rvoice_event_t* src_event)
 {
   fluid_rvoice_event_t* event;

--- a/src/rvoice/fluid_rvoice_event.h
+++ b/src/rvoice/fluid_rvoice_event.h
@@ -88,11 +88,6 @@ int fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler,
 int fluid_rvoice_eventhandler_push_ptr(fluid_rvoice_eventhandler_t* handler, 
                                 fluid_rvoice_function_t method, void* object, void* ptr); 
 
-int fluid_rvoice_eventhandler_push5(fluid_rvoice_eventhandler_t* handler, 
-                                fluid_rvoice_function_t method, void* object, int intparam, 
-                                fluid_real_t r1, fluid_real_t r2, 
-                                fluid_real_t r3, fluid_real_t r4, fluid_real_t r5);
-
 int fluid_rvoice_eventhandler_push_param(fluid_rvoice_eventhandler_t* handler,
                                          fluid_rvoice_function_t method, void* object,
                                          fluid_rvoice_param_t param[EVENT_PARAMS]);

--- a/src/rvoice/fluid_rvoice_event.h
+++ b/src/rvoice/fluid_rvoice_event.h
@@ -26,21 +26,14 @@
 #include "fluid_rvoice_mixer.h"
 #include "fluid_ringbuffer.h"
 
-#define EVENT_REAL_PARAMS (5)
-
 typedef struct _fluid_rvoice_event_t fluid_rvoice_event_t;
 typedef struct _fluid_rvoice_eventhandler_t fluid_rvoice_eventhandler_t;
 
 struct _fluid_rvoice_event_t {
-	void* method;
+	fluid_rvoice_function_t method;
 	void* object;
-	void* ptr;
-	int intparam;
-	fluid_real_t realparams[EVENT_REAL_PARAMS];
+    fluid_rvoice_param_t param[EVENT_PARAMS];
 };
-
-void fluid_rvoice_event_dispatch(fluid_rvoice_event_t* event);
-
 
 /*
  * Bridge between the renderer thread and the midi state thread. 
@@ -89,16 +82,20 @@ fluid_rvoice_eventhandler_get_finished_voice(fluid_rvoice_eventhandler_t* handle
 
 
 int fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler, 
-                                void* method, void* object, int intparam, 
+                                fluid_rvoice_function_t method, void* object, int intparam, 
                                 fluid_real_t realparam);
 
 int fluid_rvoice_eventhandler_push_ptr(fluid_rvoice_eventhandler_t* handler, 
-                                void* method, void* object, void* ptr); 
+                                fluid_rvoice_function_t method, void* object, void* ptr); 
 
 int fluid_rvoice_eventhandler_push5(fluid_rvoice_eventhandler_t* handler, 
-                                void* method, void* object, int intparam, 
+                                fluid_rvoice_function_t method, void* object, int intparam, 
                                 fluid_real_t r1, fluid_real_t r2, 
                                 fluid_real_t r3, fluid_real_t r4, fluid_real_t r5);
+
+int fluid_rvoice_eventhandler_push_param(fluid_rvoice_eventhandler_t* handler,
+                                         fluid_rvoice_function_t method, void* object,
+                                         fluid_rvoice_param_t param[EVENT_PARAMS]);
 
 static FLUID_INLINE void
 fluid_rvoice_eventhandler_add_rvoice(fluid_rvoice_eventhandler_t* handler, 

--- a/src/rvoice/fluid_rvoice_event.h
+++ b/src/rvoice/fluid_rvoice_event.h
@@ -81,14 +81,14 @@ fluid_rvoice_eventhandler_get_finished_voice(fluid_rvoice_eventhandler_t* handle
 }
 
 
-int fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler, 
+int fluid_rvoice_eventhandler_push_int_real(fluid_rvoice_eventhandler_t* handler, 
                                 fluid_rvoice_function_t method, void* object, int intparam, 
                                 fluid_real_t realparam);
 
 int fluid_rvoice_eventhandler_push_ptr(fluid_rvoice_eventhandler_t* handler, 
                                 fluid_rvoice_function_t method, void* object, void* ptr); 
 
-int fluid_rvoice_eventhandler_push_param(fluid_rvoice_eventhandler_t* handler,
+int fluid_rvoice_eventhandler_push(fluid_rvoice_eventhandler_t* handler,
                                          fluid_rvoice_function_t method, void* object,
                                          fluid_rvoice_param_t param[MAX_EVENT_PARAMS]);
 

--- a/src/rvoice/fluid_rvoice_event.h
+++ b/src/rvoice/fluid_rvoice_event.h
@@ -32,7 +32,7 @@ typedef struct _fluid_rvoice_eventhandler_t fluid_rvoice_eventhandler_t;
 struct _fluid_rvoice_event_t {
 	fluid_rvoice_function_t method;
 	void* object;
-    fluid_rvoice_param_t param[EVENT_PARAMS];
+    fluid_rvoice_param_t param[MAX_EVENT_PARAMS];
 };
 
 /*
@@ -90,7 +90,7 @@ int fluid_rvoice_eventhandler_push_ptr(fluid_rvoice_eventhandler_t* handler,
 
 int fluid_rvoice_eventhandler_push_param(fluid_rvoice_eventhandler_t* handler,
                                          fluid_rvoice_function_t method, void* object,
-                                         fluid_rvoice_param_t param[EVENT_PARAMS]);
+                                         fluid_rvoice_param_t param[MAX_EVENT_PARAMS]);
 
 static FLUID_INLINE void
 fluid_rvoice_eventhandler_add_rvoice(fluid_rvoice_eventhandler_t* handler, 

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -502,7 +502,6 @@ fluid_mixer_buffers_init(fluid_mixer_buffers_t* buffers, fluid_rvoice_mixer_t* m
  */
 DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_samplerate)
 {
-  int i;
   fluid_rvoice_mixer_t* mixer = obj;
   fluid_real_t samplerate = param[1].real; // becausee fluid_synth_update_mixer() puts real into arg2
   

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -311,14 +311,15 @@ static int fluid_mixer_buffers_replace_voice(fluid_mixer_buffers_t* buffers,
 }
 */
 
-int 
-fluid_rvoice_mixer_add_voice(fluid_rvoice_mixer_t* mixer, fluid_rvoice_t* voice)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_add_voice)
 {
   int i;
+  fluid_rvoice_mixer_t* mixer = obj;
+  fluid_rvoice_t* voice = param[0].ptr;
 
   if (mixer->active_voices < mixer->polyphony) {
     mixer->rvoices[mixer->active_voices++] = voice;
-    return FLUID_OK;
+    return; // success
   }
   
   /* See if any voices just finished, if so, take its place.
@@ -326,18 +327,18 @@ fluid_rvoice_mixer_add_voice(fluid_rvoice_mixer_t* mixer, fluid_rvoice_t* voice)
   for (i=0; i < mixer->active_voices; i++) {
     if (mixer->rvoices[i] == voice) {
       FLUID_LOG(FLUID_ERR, "Internal error: Trying to replace an existing rvoice in fluid_rvoice_mixer_add_voice?!");
-      return FLUID_FAILED;
+      return;
     }
     if (mixer->rvoices[i]->envlfo.volenv.section == FLUID_VOICE_ENVFINISHED) {
       fluid_finish_rvoice(&mixer->buffers, mixer->rvoices[i]);
       mixer->rvoices[i] = voice;
-      return FLUID_OK;
+      return; // success
     }
   }
 
   /* This should never happen */
   FLUID_LOG(FLUID_ERR, "Trying to exceed polyphony in fluid_rvoice_mixer_add_voice");
-  return FLUID_FAILED;
+  return;
 }
 
 static int 
@@ -359,21 +360,23 @@ fluid_mixer_buffers_update_polyphony(fluid_mixer_buffers_t* buffers, int value)
  * Update polyphony - max number of voices (NOTE: not hard real-time capable)
  * @return FLUID_OK or FLUID_FAILED
  */
-int 
-fluid_rvoice_mixer_set_polyphony(fluid_rvoice_mixer_t* handler, int value)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_polyphony)
 {
   void* newptr;
+  fluid_rvoice_mixer_t* handler = obj;
+  int value = param[0].i;
+  
   if (handler->active_voices > value) 
-    return FLUID_FAILED;
+    return /*FLUID_FAILED*/;
 
   newptr = FLUID_REALLOC(handler->rvoices, value * sizeof(fluid_rvoice_t*));
   if (newptr == NULL) 
-    return FLUID_FAILED;
+    return /*FLUID_FAILED*/;
   handler->rvoices = newptr;
 
   if (fluid_mixer_buffers_update_polyphony(&handler->buffers, value) 
       == FLUID_FAILED)
-    return FLUID_FAILED;
+    return /*FLUID_FAILED*/;
 
 #ifdef ENABLE_MIXER_THREADS
   {
@@ -381,12 +384,12 @@ fluid_rvoice_mixer_set_polyphony(fluid_rvoice_mixer_t* handler, int value)
     for (i=0; i < handler->thread_count; i++)
       if (fluid_mixer_buffers_update_polyphony(&handler->threads[i], value) 
           == FLUID_FAILED)
-        return FLUID_FAILED;
+        return /*FLUID_FAILED*/;
   }
 #endif
 
   handler->polyphony = value;
-  return FLUID_OK;
+  return /*FLUID_OK*/;
 }
 
 
@@ -497,17 +500,20 @@ fluid_mixer_buffers_init(fluid_mixer_buffers_t* buffers, fluid_rvoice_mixer_t* m
 /**
  * Note: Not hard real-time capable (calls malloc)
  */
-void 
-fluid_rvoice_mixer_set_samplerate(fluid_rvoice_mixer_t* mixer, fluid_real_t samplerate)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_samplerate)
 {
   int i;
+  fluid_rvoice_mixer_t* mixer = obj;
+  fluid_real_t samplerate = param[1].real;
+  param[0].real = param[1].real; // FIXME: this is needed for fluid_rvoice_set_output_rate()
+  
   if (mixer->fx.chorus)
     delete_fluid_chorus(mixer->fx.chorus);
   mixer->fx.chorus = new_fluid_chorus(samplerate);
   if (mixer->fx.reverb)
 	  fluid_revmodel_samplerate_change(mixer->fx.reverb, samplerate);
   for (i=0; i < mixer->active_voices; i++)
-    fluid_rvoice_set_output_rate(mixer->rvoices[i], samplerate);
+    fluid_rvoice_set_output_rate(mixer->rvoices[i], param);
 #if LADSPA
   if (mixer->ladspa_fx != NULL)
   {
@@ -612,7 +618,6 @@ void delete_fluid_rvoice_mixer(fluid_rvoice_mixer_t* mixer)
 {
   fluid_return_if_fail(mixer != NULL);
   
-  fluid_rvoice_mixer_set_threads(mixer, 0, 0);
 #ifdef ENABLE_MIXER_THREADS
   if (mixer->thread_ready)
     delete_fluid_cond(mixer->thread_ready);
@@ -660,13 +665,18 @@ void fluid_rvoice_mixer_set_ladspa(fluid_rvoice_mixer_t* mixer,
 }
 #endif
 
-void fluid_rvoice_mixer_set_reverb_enabled(fluid_rvoice_mixer_t* mixer, int on)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_reverb_enabled)
 {
+  fluid_rvoice_mixer_t* mixer = obj;
+  int on = param[0].i;
+  
   mixer->fx.with_reverb = on;
 }
 
-void fluid_rvoice_mixer_set_chorus_enabled(fluid_rvoice_mixer_t* mixer, int on)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_chorus_enabled)
 {
+  fluid_rvoice_mixer_t* mixer = obj;
+  int on = param[0].i;
   mixer->fx.with_chorus = on;
 }
 
@@ -675,32 +685,40 @@ void fluid_rvoice_mixer_set_mix_fx(fluid_rvoice_mixer_t* mixer, int on)
   mixer->fx.mix_fx_to_out = on;
 }
 
-void fluid_rvoice_mixer_set_chorus_params(fluid_rvoice_mixer_t* mixer, int set, 
-				         int nr, fluid_real_t level, fluid_real_t speed, 
-				         fluid_real_t depth_ms, int type)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_chorus_params)
 {
+  fluid_rvoice_mixer_t* mixer = obj;
+  int set = param[0].i;
+  int nr = param[1].i;
+  fluid_real_t level = param[2].real;
+  fluid_real_t speed = param[3].real;
+  fluid_real_t depth_ms = param[4].real;
+  int type = param[5].i;
+  
   fluid_chorus_set(mixer->fx.chorus, set, nr, level, speed, depth_ms, type);
 }
-void fluid_rvoice_mixer_set_reverb_params(fluid_rvoice_mixer_t* mixer, int set, 
-					 fluid_real_t roomsize, fluid_real_t damping, 
-					 fluid_real_t width, fluid_real_t level)
+
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_reverb_params)
 {
+    fluid_rvoice_mixer_t* mixer = obj;
+    int set = param[0].i;
+    fluid_real_t roomsize = param[1].real;
+    fluid_real_t damping = param[2].real;
+    fluid_real_t width = param[3].real;
+    fluid_real_t level = param[4].real;
+    
   fluid_revmodel_set(mixer->fx.reverb, set, roomsize, damping, width, level); 
 }
 
-void fluid_rvoice_mixer_reset_fx(fluid_rvoice_mixer_t* mixer)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_reset_reverb)
 {
-  fluid_revmodel_reset(mixer->fx.reverb);
-  fluid_chorus_reset(mixer->fx.chorus);
-}
-
-void fluid_rvoice_mixer_reset_reverb(fluid_rvoice_mixer_t* mixer)
-{
+  fluid_rvoice_mixer_t* mixer = obj;
   fluid_revmodel_reset(mixer->fx.reverb);
 }
 
-void fluid_rvoice_mixer_reset_chorus(fluid_rvoice_mixer_t* mixer)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_reset_chorus)
 {
+  fluid_rvoice_mixer_t* mixer = obj;
   fluid_chorus_reset(mixer->fx.chorus);
 }
 
@@ -913,13 +931,14 @@ fluid_render_loop_multithread(fluid_rvoice_mixer_t* mixer)
  * @param thread_count Number of extra mixer threads for multi-core rendering
  * @param prio_level real-time prio level for the extra mixer threads
  */
-void 
-fluid_rvoice_mixer_set_threads(fluid_rvoice_mixer_t* mixer, int thread_count, 
-  			       int prio_level)
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_threads)
 {
 #ifdef ENABLE_MIXER_THREADS
   char name[16];
   int i;
+  fluid_rvoice_mixer_t* mixer = obj;
+  int thread_count = param[0].i;
+  int prio_level = param[1].real;
  
   // Kill all existing threads first
   if (mixer->thread_count) {

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -504,16 +504,15 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_samplerate)
 {
   int i;
   fluid_rvoice_mixer_t* mixer = obj;
-  fluid_real_t samplerate = param[1].real;
-  param[0].real = param[1].real; // FIXME: this is needed for fluid_rvoice_set_output_rate()
+  fluid_real_t samplerate = param[1].real; // becausee fluid_synth_update_mixer() puts real into arg2
   
   if (mixer->fx.chorus)
     delete_fluid_chorus(mixer->fx.chorus);
+  
   mixer->fx.chorus = new_fluid_chorus(samplerate);
   if (mixer->fx.reverb)
 	  fluid_revmodel_samplerate_change(mixer->fx.reverb, samplerate);
-  for (i=0; i < mixer->active_voices; i++)
-    fluid_rvoice_set_output_rate(mixer->rvoices[i], param);
+  
 #if LADSPA
   if (mixer->ladspa_fx != NULL)
   {

--- a/src/rvoice/fluid_rvoice_mixer.h
+++ b/src/rvoice/fluid_rvoice_mixer.h
@@ -51,26 +51,23 @@ fluid_rvoice_mixer_t* new_fluid_rvoice_mixer(int buf_count, int fx_buf_count,
 
 void delete_fluid_rvoice_mixer(fluid_rvoice_mixer_t*);
 
-void fluid_rvoice_mixer_set_samplerate(fluid_rvoice_mixer_t* mixer, fluid_real_t samplerate);
-void fluid_rvoice_mixer_set_reverb_enabled(fluid_rvoice_mixer_t* mixer, int on);
-void fluid_rvoice_mixer_set_chorus_enabled(fluid_rvoice_mixer_t* mixer, int on);
-void fluid_rvoice_mixer_set_mix_fx(fluid_rvoice_mixer_t* mixer, int on);
-int fluid_rvoice_mixer_set_polyphony(fluid_rvoice_mixer_t* handler, int value);
-int fluid_rvoice_mixer_add_voice(fluid_rvoice_mixer_t* mixer, fluid_rvoice_t* voice);
-void fluid_rvoice_mixer_set_chorus_params(fluid_rvoice_mixer_t* mixer, int set, 
-				         int nr, fluid_real_t level, fluid_real_t speed, 
-				         fluid_real_t depth_ms, int type);
-void fluid_rvoice_mixer_set_reverb_params(fluid_rvoice_mixer_t* mixer, int set, 
-					 fluid_real_t roomsize, fluid_real_t damping, 
-					 fluid_real_t width, fluid_real_t level);
-void fluid_rvoice_mixer_reset_fx(fluid_rvoice_mixer_t* mixer);
-void fluid_rvoice_mixer_reset_reverb(fluid_rvoice_mixer_t* mixer);
-void fluid_rvoice_mixer_reset_chorus(fluid_rvoice_mixer_t* mixer);
 
-void fluid_rvoice_mixer_set_threads(fluid_rvoice_mixer_t* mixer, int thread_count, 
-				    int prio_level);
-				    
-#ifdef LADSPA				    
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_add_voice);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_samplerate);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_polyphony);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_chorus_enabled);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_reverb_enabled);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_chorus_params);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_reverb_params);
+
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_reset_reverb);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_reset_chorus);
+
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_threads);
+
+
+void fluid_rvoice_mixer_set_mix_fx(fluid_rvoice_mixer_t* mixer, int on);
+#ifdef LADSPA
 void fluid_rvoice_mixer_set_ladspa(fluid_rvoice_mixer_t* mixer,
         fluid_ladspa_fx_t *ladspa_fx, int audio_groups);
 #endif

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -544,7 +544,7 @@ fluid_synth_update_mixer(fluid_synth_t* synth, fluid_rvoice_function_t method, i
 {
   fluid_return_if_fail(synth != NULL && synth->eventhandler != NULL);
   fluid_return_if_fail(synth->eventhandler->mixer != NULL);
-  fluid_rvoice_eventhandler_push(synth->eventhandler, method, 
+  fluid_rvoice_eventhandler_push_int_real(synth->eventhandler, method, 
 				 synth->eventhandler->mixer,
 				 intparam, realparam);
 }
@@ -4204,7 +4204,7 @@ fluid_synth_set_reverb_full_LOCAL(fluid_synth_t* synth, int set, double roomsize
   param[3].real = width;
   param[4].real = level;
   /* finally enqueue an rvoice event to the mixer to actual update reverb */
-  ret = fluid_rvoice_eventhandler_push_param(synth->eventhandler,
+  ret = fluid_rvoice_eventhandler_push(synth->eventhandler,
                                              fluid_rvoice_mixer_set_reverb_params,
                                              synth->eventhandler->mixer,
                                              param);
@@ -4404,7 +4404,7 @@ fluid_synth_set_chorus_full(fluid_synth_t* synth, int set, int nr, double level,
   param[3].real = speed;
   param[4].real = depth_ms;
   param[5].i = type;
-  ret = fluid_rvoice_eventhandler_push_param(synth->eventhandler,
+  ret = fluid_rvoice_eventhandler_push(synth->eventhandler,
                                              fluid_rvoice_mixer_set_chorus_params,
                                              synth->eventhandler->mixer,
                                              param);

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -763,7 +763,7 @@ new_fluid_synth(fluid_settings_t *settings)
     goto error_recovery;
   }
   for (i = 0; i < synth->nvoice; i++) {
-    synth->voice[i] = new_fluid_voice(synth->sample_rate);
+    synth->voice[i] = new_fluid_voice(synth->eventhandler, synth->sample_rate);
     if (synth->voice[i] == NULL) {
       goto error_recovery;
     }
@@ -2732,7 +2732,7 @@ fluid_synth_update_polyphony_LOCAL(fluid_synth_t* synth, int new_polyphony)
       return FLUID_FAILED;
     synth->voice = new_voices;
     for (i = synth->nvoice; i < new_polyphony; i++) {
-      synth->voice[i] = new_fluid_voice(synth->sample_rate);
+      synth->voice[i] = new_fluid_voice(synth->eventhandler, synth->sample_rate);
       if (synth->voice[i] == NULL) 
 	return FLUID_FAILED;
     

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -4184,7 +4184,7 @@ fluid_synth_set_reverb_full_LOCAL(fluid_synth_t* synth, int set, double roomsize
                             double damping, double width, double level)
 {
   int ret;
-  fluid_rvoice_param_t param[EVENT_PARAMS];
+  fluid_rvoice_param_t param[MAX_EVENT_PARAMS];
   
   if (set & FLUID_REVMODEL_SET_ROOMSIZE)
     synth->reverb_roomsize = roomsize;
@@ -4374,7 +4374,7 @@ fluid_synth_set_chorus_full(fluid_synth_t* synth, int set, int nr, double level,
                             double speed, double depth_ms, int type)
 {
   int ret;
-  fluid_rvoice_param_t param[EVENT_PARAMS];
+  fluid_rvoice_param_t param[MAX_EVENT_PARAMS];
   
   fluid_return_val_if_fail (synth != NULL, FLUID_FAILED);
   /* if non of the flags is set, fail */

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -218,12 +218,15 @@ new_fluid_voice(fluid_rvoice_eventhandler_t* handler, fluid_real_t output_rate)
     FLUID_LOG(FLUID_ERR, "Out of memory");
     return NULL;
   }
+  
+  voice->can_access_rvoice = TRUE;
+  voice->can_access_overflow_rvoice = TRUE;
+  
   voice->rvoice = FLUID_NEW(fluid_rvoice_t);
   voice->overflow_rvoice = FLUID_NEW(fluid_rvoice_t);
   if (voice->rvoice == NULL || voice->overflow_rvoice == NULL) {
     FLUID_LOG(FLUID_ERR, "Out of memory");
-    FLUID_FREE(voice->rvoice);
-    FLUID_FREE(voice);
+    delete_fluid_voice(voice);
     return NULL;
   }
 
@@ -237,11 +240,9 @@ new_fluid_voice(fluid_rvoice_eventhandler_t* handler, fluid_real_t output_rate)
   voice->output_rate = output_rate;
 
   /* Initialize both the rvoice and overflow_rvoice */
-  voice->can_access_rvoice = TRUE; 
-  voice->can_access_overflow_rvoice = TRUE; 
   fluid_voice_initialize_rvoice(voice, output_rate);
   fluid_voice_swap_rvoice(voice);
-  fluid_voice_initialize_rvoice(voice, output_rate);  
+  fluid_voice_initialize_rvoice(voice, output_rate);
 
   return voice;
 }

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -357,11 +357,8 @@ fluid_voice_set_output_rate(fluid_voice_t* voice, fluid_real_t value)
     fluid_voice_off(voice);
   
   voice->output_rate = value;
-  UPDATE_RVOICE_R1(fluid_rvoice_set_output_rate, value);
-  /* Update the other rvoice as well */
-  fluid_voice_swap_rvoice(voice);
-  UPDATE_RVOICE_R1(fluid_rvoice_set_output_rate, value);
-  fluid_voice_swap_rvoice(voice);
+  UPDATE_RVOICE_GENERIC_R1(fluid_rvoice_set_output_rate, voice->rvoice, value);
+  UPDATE_RVOICE_GENERIC_R1(fluid_rvoice_set_output_rate, voice->overflow_rvoice, value);
 }
 
 

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -48,27 +48,27 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
 
 #define UPDATE_RVOICE0(proc) \
   do { \
-      fluid_rvoice_param_t param[EVENT_PARAMS]; \
+      fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, voice->rvoice, param); \
   } while (0)
 
 #define UPDATE_RVOICE_GENERIC_R1(proc, obj, rarg) \
   do { \
-      fluid_rvoice_param_t param[EVENT_PARAMS]; \
+      fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       param[0].real = rarg; \
       fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
   } while (0)
 
 #define UPDATE_RVOICE_GENERIC_I1(proc, obj, iarg) \
   do { \
-      fluid_rvoice_param_t param[EVENT_PARAMS]; \
+      fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       param[0].i = iarg; \
       fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
   } while (0)
   
 #define UPDATE_RVOICE_GENERIC_I2(proc, obj, iarg1, iarg2) \
   do { \
-      fluid_rvoice_param_t param[EVENT_PARAMS]; \
+      fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       param[0].i = iarg1; \
       param[1].i = iarg2; \
       fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
@@ -76,7 +76,7 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
 
 #define UPDATE_RVOICE_GENERIC_IR(proc, obj, iarg, rarg) \
   do { \
-      fluid_rvoice_param_t param[EVENT_PARAMS]; \
+      fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       param[0].i = iarg; \
       param[1].real = rarg; \
       fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
@@ -100,7 +100,7 @@ fluid_voice_update_volenv(fluid_voice_t* voice,
                           fluid_real_t min,
                           fluid_real_t max)
 {
-    fluid_rvoice_param_t param[EVENT_PARAMS];
+    fluid_rvoice_param_t param[MAX_EVENT_PARAMS];
     
     param[0].i = section;
     param[1].i = count;
@@ -132,7 +132,7 @@ fluid_voice_update_modenv(fluid_voice_t* voice,
                           fluid_real_t min,
                           fluid_real_t max)
 {
-    fluid_rvoice_param_t param[EVENT_PARAMS];
+    fluid_rvoice_param_t param[MAX_EVENT_PARAMS];
     
     param[0].i = section;
     param[1].i = count;
@@ -177,7 +177,7 @@ static void fluid_voice_swap_rvoice(fluid_voice_t* voice)
 
 static void fluid_voice_initialize_rvoice(fluid_voice_t* voice, fluid_real_t output_rate)
 {
-  fluid_rvoice_param_t param[EVENT_PARAMS];
+  fluid_rvoice_param_t param[MAX_EVENT_PARAMS];
     
   FLUID_MEMSET(voice->rvoice, 0, sizeof(fluid_rvoice_t));
 

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -49,21 +49,21 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
 #define UPDATE_RVOICE0(proc) \
   do { \
       fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
-      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, voice->rvoice, param); \
+      fluid_rvoice_eventhandler_push(voice->eventhandler, proc, voice->rvoice, param); \
   } while (0)
 
 #define UPDATE_RVOICE_GENERIC_R1(proc, obj, rarg) \
   do { \
       fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       param[0].real = rarg; \
-      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
+      fluid_rvoice_eventhandler_push(voice->eventhandler, proc, obj, param); \
   } while (0)
 
 #define UPDATE_RVOICE_GENERIC_I1(proc, obj, iarg) \
   do { \
       fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       param[0].i = iarg; \
-      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
+      fluid_rvoice_eventhandler_push(voice->eventhandler, proc, obj, param); \
   } while (0)
   
 #define UPDATE_RVOICE_GENERIC_I2(proc, obj, iarg1, iarg2) \
@@ -71,7 +71,7 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
       fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       param[0].i = iarg1; \
       param[1].i = iarg2; \
-      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
+      fluid_rvoice_eventhandler_push(voice->eventhandler, proc, obj, param); \
   } while (0)
 
 #define UPDATE_RVOICE_GENERIC_IR(proc, obj, iarg, rarg) \
@@ -79,7 +79,7 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
       fluid_rvoice_param_t param[MAX_EVENT_PARAMS]; \
       param[0].i = iarg; \
       param[1].real = rarg; \
-      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
+      fluid_rvoice_eventhandler_push(voice->eventhandler, proc, obj, param); \
   } while (0)
 
 
@@ -111,7 +111,7 @@ fluid_voice_update_volenv(fluid_voice_t* voice,
     
     if(enqueue)
     {
-    fluid_rvoice_eventhandler_push_param(voice->eventhandler,
+    fluid_rvoice_eventhandler_push(voice->eventhandler,
                                     fluid_adsr_env_set_data,
                                     &voice->rvoice->envlfo.volenv,
                                     param);
@@ -143,7 +143,7 @@ fluid_voice_update_modenv(fluid_voice_t* voice,
     
     if(enqueue)
     {
-    fluid_rvoice_eventhandler_push_param(voice->eventhandler,
+    fluid_rvoice_eventhandler_push(voice->eventhandler,
                                     fluid_adsr_env_set_data,
                                     &voice->rvoice->envlfo.modenv,
                                     param);

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -49,21 +49,21 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
 #define UPDATE_RVOICE0(proc) \
   do { \
       fluid_rvoice_param_t param[EVENT_PARAMS]; \
-      fluid_rvoice_eventhandler_push_param(voice->channel->synth->eventhandler, proc, voice->rvoice, param); \
+      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, voice->rvoice, param); \
   } while (0)
 
 #define UPDATE_RVOICE_GENERIC_R1(proc, obj, rarg) \
   do { \
       fluid_rvoice_param_t param[EVENT_PARAMS]; \
       param[0].real = rarg; \
-      fluid_rvoice_eventhandler_push_param(voice->channel->synth->eventhandler, proc, obj, param); \
+      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
   } while (0)
 
 #define UPDATE_RVOICE_GENERIC_I1(proc, obj, iarg) \
   do { \
       fluid_rvoice_param_t param[EVENT_PARAMS]; \
       param[0].i = iarg; \
-      fluid_rvoice_eventhandler_push_param(voice->channel->synth->eventhandler, proc, obj, param); \
+      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
   } while (0)
   
 #define UPDATE_RVOICE_GENERIC_I2(proc, obj, iarg1, iarg2) \
@@ -71,7 +71,7 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
       fluid_rvoice_param_t param[EVENT_PARAMS]; \
       param[0].i = iarg1; \
       param[1].i = iarg2; \
-      fluid_rvoice_eventhandler_push_param(voice->channel->synth->eventhandler, proc, obj, param); \
+      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
   } while (0)
 
 #define UPDATE_RVOICE_GENERIC_IR(proc, obj, iarg, rarg) \
@@ -79,7 +79,7 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice);
       fluid_rvoice_param_t param[EVENT_PARAMS]; \
       param[0].i = iarg; \
       param[1].real = rarg; \
-      fluid_rvoice_eventhandler_push_param(voice->channel->synth->eventhandler, proc, obj, param); \
+      fluid_rvoice_eventhandler_push_param(voice->eventhandler, proc, obj, param); \
   } while (0)
 
 
@@ -111,7 +111,7 @@ fluid_voice_update_volenv(fluid_voice_t* voice,
     
     if(enqueue)
     {
-    fluid_rvoice_eventhandler_push_param(voice->channel->synth->eventhandler,
+    fluid_rvoice_eventhandler_push_param(voice->eventhandler,
                                     fluid_adsr_env_set_data,
                                     &voice->rvoice->envlfo.volenv,
                                     param);
@@ -143,7 +143,7 @@ fluid_voice_update_modenv(fluid_voice_t* voice,
     
     if(enqueue)
     {
-    fluid_rvoice_eventhandler_push_param(voice->channel->synth->eventhandler,
+    fluid_rvoice_eventhandler_push_param(voice->eventhandler,
                                     fluid_adsr_env_set_data,
                                     &voice->rvoice->envlfo.modenv,
                                     param);
@@ -210,7 +210,7 @@ static void fluid_voice_initialize_rvoice(fluid_voice_t* voice, fluid_real_t out
  * new_fluid_voice
  */
 fluid_voice_t*
-new_fluid_voice(fluid_real_t output_rate)
+new_fluid_voice(fluid_rvoice_eventhandler_t* handler, fluid_real_t output_rate)
 {
   fluid_voice_t* voice;
   voice = FLUID_NEW(fluid_voice_t);
@@ -231,6 +231,7 @@ new_fluid_voice(fluid_real_t output_rate)
   voice->chan = NO_CHANNEL;
   voice->key = 0;
   voice->vel = 0;
+  voice->eventhandler = handler;
   voice->channel = NULL;
   voice->sample = NULL;
   voice->output_rate = output_rate;
@@ -309,7 +310,7 @@ fluid_voice_init(fluid_voice_t* voice, fluid_sample_t* sample,
      unloading of the soundfont while this voice is playing,
      once for us and once for the rvoice. */
   fluid_sample_incr_ref(sample);
-  fluid_rvoice_eventhandler_push_ptr(voice->channel->synth->eventhandler, fluid_rvoice_set_sample, voice->rvoice, sample);
+  fluid_rvoice_eventhandler_push_ptr(voice->eventhandler, fluid_rvoice_set_sample, voice->rvoice, sample);
   fluid_sample_incr_ref(sample);
   voice->sample = sample;
 

--- a/src/synth/fluid_voice.h
+++ b/src/synth/fluid_voice.h
@@ -29,6 +29,7 @@
 #include "fluid_adsr_env.h"
 #include "fluid_lfo.h"
 #include "fluid_rvoice.h"
+#include "fluid_rvoice_event.h"
 #include "fluid_sys.h"
 
 #define NO_CHANNEL             0xff
@@ -69,6 +70,7 @@ struct _fluid_voice_t
 	unsigned char key;              /* the key of the noteon event, quick access for noteoff */
 	unsigned char vel;              /* the velocity of the noteon event */
 	fluid_channel_t* channel;
+	fluid_rvoice_eventhandler_t* eventhandler;
 	fluid_gen_t gen[GEN_LAST];
 	fluid_mod_t mod[FLUID_NUM_MOD];
 	int mod_count;
@@ -114,7 +116,7 @@ struct _fluid_voice_t
 };
 
 
-fluid_voice_t* new_fluid_voice(fluid_real_t output_rate);
+fluid_voice_t* new_fluid_voice(fluid_rvoice_eventhandler_t* handler, fluid_real_t output_rate);
 void delete_fluid_voice(fluid_voice_t* voice);
 
 void fluid_voice_start(fluid_voice_t* voice);

--- a/src/synth/fluid_voice.h
+++ b/src/synth/fluid_voice.h
@@ -135,7 +135,7 @@ int fluid_voice_set_param(fluid_voice_t* voice, int gen, fluid_real_t value, int
 /** Set the gain. */
 int fluid_voice_set_gain(fluid_voice_t* voice, fluid_real_t gain);
 
-int fluid_voice_set_output_rate(fluid_voice_t* voice, fluid_real_t value);
+void fluid_voice_set_output_rate(fluid_voice_t* voice, fluid_real_t value);
 
 
 /** Update all the synthesis parameters, which depend on generator

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -214,12 +214,12 @@ typedef union _fluid_rvoice_param_t
     fluid_real_t real;
 } fluid_rvoice_param_t;
 enum { MAX_EVENT_PARAMS = 6 }; /**< Maximum number of #fluid_rvoice_param_t to be passed to an #fluid_rvoice_function_t */
-typedef void (*fluid_rvoice_function_t)(void* obj, fluid_rvoice_param_t param[MAX_EVENT_PARAMS]);
+typedef void (*fluid_rvoice_function_t)(void* obj, const fluid_rvoice_param_t param[MAX_EVENT_PARAMS]);
 
 /* Macro for declaring an rvoice event function (#fluid_rvoice_function_t). The functions may only access
  * those params that were previously set in fluid_voice.c
  */
-#define DECLARE_FLUID_RVOICE_FUNCTION(name) void name(void* obj, fluid_rvoice_param_t param[MAX_EVENT_PARAMS])
+#define DECLARE_FLUID_RVOICE_FUNCTION(name) void name(void* obj, const fluid_rvoice_param_t param[MAX_EVENT_PARAMS])
 
 
 /***************************************************************

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -205,18 +205,19 @@ typedef struct _fluid_server_socket_t fluid_server_socket_t;
 typedef struct _fluid_sample_timer_t fluid_sample_timer_t;
 typedef struct _fluid_zone_range_t fluid_zone_range_t;
 
+/* Declare rvoice related typedefs here instead of fluid_rvoice.h, as it's needed
+ * in fluid_lfo.c and fluid_adsr.c as well */
 typedef union _fluid_rvoice_param_t
 {
     void* ptr;
     int i;
     fluid_real_t real;
 } fluid_rvoice_param_t;
-typedef void (*fluid_rvoice_function_t)(void* obj, fluid_rvoice_param_t* param);
+enum { MAX_EVENT_PARAMS = 6 }; /**< Maximum number of #fluid_rvoice_param_t to be passed to an #fluid_rvoice_function_t */
+typedef void (*fluid_rvoice_function_t)(void* obj, fluid_rvoice_param_t param[MAX_EVENT_PARAMS]);
 
-enum { MAX_EVENT_PARAMS = 6 };
-
-/* macro for declaring an rvoice event function (#fluid_rvoice_function_t). the functions may only access those params that were
- * previously set in fluid_voice.c
+/* Macro for declaring an rvoice event function (#fluid_rvoice_function_t). The functions may only access
+ * those params that were previously set in fluid_voice.c
  */
 #define DECLARE_FLUID_RVOICE_FUNCTION(name) void name(void* obj, fluid_rvoice_param_t param[MAX_EVENT_PARAMS])
 

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -205,6 +205,22 @@ typedef struct _fluid_server_socket_t fluid_server_socket_t;
 typedef struct _fluid_sample_timer_t fluid_sample_timer_t;
 typedef struct _fluid_zone_range_t fluid_zone_range_t;
 
+typedef union _fluid_rvoice_param_t
+{
+    void* ptr;
+    int i;
+    fluid_real_t real;
+} fluid_rvoice_param_t;
+typedef void (*fluid_rvoice_function_t)(void* obj, fluid_rvoice_param_t* param);
+
+enum { EVENT_PARAMS = 6 };
+
+/* macro for declaring an rvoice event function (#fluid_rvoice_function_t). the functions may only access those params that were
+ * previously set in fluid_voice.c
+ */
+#define DECLARE_FLUID_RVOICE_FUNCTION(name) void name(void* obj, fluid_rvoice_param_t param[EVENT_PARAMS])
+
+
 /***************************************************************
  *
  *                      CONSTANTS

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -213,12 +213,12 @@ typedef union _fluid_rvoice_param_t
 } fluid_rvoice_param_t;
 typedef void (*fluid_rvoice_function_t)(void* obj, fluid_rvoice_param_t* param);
 
-enum { EVENT_PARAMS = 6 };
+enum { MAX_EVENT_PARAMS = 6 };
 
 /* macro for declaring an rvoice event function (#fluid_rvoice_function_t). the functions may only access those params that were
  * previously set in fluid_voice.c
  */
-#define DECLARE_FLUID_RVOICE_FUNCTION(name) void name(void* obj, fluid_rvoice_param_t param[EVENT_PARAMS])
+#define DECLARE_FLUID_RVOICE_FUNCTION(name) void name(void* obj, fluid_rvoice_param_t param[MAX_EVENT_PARAMS])
 
 
 /***************************************************************


### PR DESCRIPTION
* Introduce a proper function typedef for functions that need to be called by `rvoice_eventhandler`
* Get rid of that huge macro crap in fluid_rvoice_event.c and all its branch indirection it caused

During this cleanup I recognized that there are many duplicate executions, like setting the sample rate of a voice on synth creation which is done three (!) times. Partly fixed that, however this made other bugs and crashes come to light. Will fix them later, just wanting to provide this for reference and feedback now.

Addresses #197.