### PR TITLE
Preset stack removal

### DIFF
--- a/bindings/fluidmax/fluidmax.c
+++ b/bindings/fluidmax/fluidmax.c
@@ -1123,18 +1123,18 @@ fluidmax_print(t_object *o, Symbol *s, short ac, Atom *at)
             
             if(sf != NULL)
             {
-              fluid_preset_t preset;
+              fluid_preset_t *preset;
               
               fluid_sfont_iteration_start(sf);
               
               post("fluidsynth~ presets of soundfont '%s':", ftmax_symbol_name(name));
               
-              while(fluid_sfont_iteration_next(sf, &preset) > 0)
+              while((preset = fluid_sfont_iteration_next(sf)) != NULL)
               {
-                char *preset_str = fluid_preset_get_name(&preset);
+                char *preset_str = fluid_preset_get_name(preset);
                 ftmax_symbol_t preset_name = ftmax_new_symbol(preset_str);
-                int bank_num = fluid_preset_get_banknum(&preset);
-                int prog_num = fluid_preset_get_num(&preset);
+                int bank_num = fluid_preset_get_banknum(preset);
+                int prog_num = fluid_preset_get_num(preset);
                 
                 post("  '%s': bank %d, program %d", ftmax_symbol_name(preset_name), bank_num, prog_num);
               }
@@ -1340,16 +1340,16 @@ fluidmax_info(t_object *o, Symbol *s, short ac, Atom *at)
             
             if(sf != NULL)
             {
-              fluid_preset_t preset;
+              fluid_preset_t *preset;
               
               fluid_sfont_iteration_start(sf);
               
-              while(fluid_sfont_iteration_next(sf, &preset) > 0)
+              while((preset = fluid_sfont_iteration_next(sf)) != NULL)
               {
-                char *preset_str = fluid_preset_get_name(&preset);
+                char *preset_str = fluid_preset_get_name(preset);
                 ftmax_symbol_t preset_name = ftmax_new_symbol(preset_str);
-                int bank_num = fluid_preset_get_banknum(&preset);
-                int prog_num = fluid_preset_get_num(&preset);
+                int bank_num = fluid_preset_get_banknum(preset);
+                int prog_num = fluid_preset_get_num(preset);
                 ftmax_atom_t a[4];
                 
                 ftmax_set_symbol(a , preset_name);

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -617,7 +617,7 @@ fluid_handle_inst(void* data, int ac, char** av, fluid_ostream_t out)
   FLUID_ENTRY_COMMAND(data);
   int font;
   fluid_sfont_t* sfont;
-  fluid_preset_t preset;
+  fluid_preset_t* preset;
   int offset;
 
   if (ac < 1) {
@@ -642,11 +642,11 @@ fluid_handle_inst(void* data, int ac, char** av, fluid_ostream_t out)
 
   fluid_sfont_iteration_start(sfont);
 
-  while (fluid_sfont_iteration_next(sfont, &preset)) {
+  while ((preset = fluid_sfont_iteration_next(sfont)) != NULL) {
     fluid_ostream_printf(out, "%03d-%03d %s\n",
-			fluid_preset_get_banknum(&preset) + offset,
-			fluid_preset_get_num(&preset),
-			fluid_preset_get_name(&preset));
+			fluid_preset_get_banknum(preset) + offset,
+			fluid_preset_get_num(preset),
+			fluid_preset_get_name(preset));
   }
 
   return FLUID_OK;

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -76,16 +76,18 @@ fluid_sfont_t* fluid_defsfloader_load(fluid_sfloader_t* loader, const char* file
     return NULL;
   }
 
-  if (fluid_defsfont_load(defsfont, &loader->file_callbacks, filename) == FLUID_FAILED) {
-    delete_fluid_defsfont(defsfont);
-    return NULL;
-  }
-
   sfont = new_fluid_sfont(fluid_defsfont_sfont_get_name,
                           fluid_defsfont_sfont_get_preset,
                           fluid_defsfont_sfont_delete);
   if (sfont == NULL)
   {
+    return NULL;
+  }
+
+  defsfont->sfont = sfont;
+
+  if (fluid_defsfont_load(defsfont, &loader->file_callbacks, filename) == FLUID_FAILED) {
+    delete_fluid_defsfont(defsfont);
     return NULL;
   }
 
@@ -120,37 +122,7 @@ const char* fluid_defsfont_sfont_get_name(fluid_sfont_t* sfont)
 fluid_preset_t*
 fluid_defsfont_sfont_get_preset(fluid_sfont_t* sfont, unsigned int bank, unsigned int prenum)
 {
-  fluid_preset_t* preset = NULL;
-  fluid_defpreset_t* defpreset;
-  fluid_defsfont_t* defsfont = fluid_sfont_get_data(sfont);
-
-  defpreset = fluid_defsfont_get_preset(defsfont, bank, prenum);
-
-  if (defpreset == NULL) {
-    return NULL;
-  }
-
-  if (defsfont->preset_stack_size > 0) {
-    defsfont->preset_stack_size--;
-    preset = defsfont->preset_stack[defsfont->preset_stack_size];
-  }
-  if (!preset)
-    preset = FLUID_NEW(fluid_preset_t);
-  if (!preset) {
-    FLUID_LOG(FLUID_ERR, "Out of memory");
-    return NULL;
-  }
-
-  preset->sfont = sfont;
-  preset->data = defpreset;
-  preset->free = fluid_defpreset_preset_delete;
-  preset->get_name = fluid_defpreset_preset_get_name;
-  preset->get_banknum = fluid_defpreset_preset_get_banknum;
-  preset->get_num = fluid_defpreset_preset_get_num;
-  preset->noteon = fluid_defpreset_preset_noteon;
-  preset->notify = NULL;
-
-  return preset;
+  return fluid_defsfont_get_preset(fluid_sfont_get_data(sfont), bank, prenum);
 }
 
 void fluid_defsfont_sfont_iteration_start(fluid_sfont_t* sfont)
@@ -158,29 +130,26 @@ void fluid_defsfont_sfont_iteration_start(fluid_sfont_t* sfont)
   fluid_defsfont_iteration_start(fluid_sfont_get_data(sfont));
 }
 
-int fluid_defsfont_sfont_iteration_next(fluid_sfont_t* sfont, fluid_preset_t* preset)
+fluid_preset_t *fluid_defsfont_sfont_iteration_next(fluid_sfont_t* sfont)
 {
-  preset->free = fluid_defpreset_preset_delete;
-  preset->get_name = fluid_defpreset_preset_get_name;
-  preset->get_banknum = fluid_defpreset_preset_get_banknum;
-  preset->get_num = fluid_defpreset_preset_get_num;
-  preset->noteon = fluid_defpreset_preset_noteon;
-  preset->notify = NULL;
-
-  return fluid_defsfont_iteration_next(fluid_sfont_get_data(sfont), preset);
+  return fluid_defsfont_iteration_next(fluid_sfont_get_data(sfont));
 }
 
 void fluid_defpreset_preset_delete(fluid_preset_t* preset)
 {
-  fluid_defpreset_t* defpreset = fluid_preset_get_data(preset);
-  fluid_defsfont_t* defsfont = defpreset ? defpreset->defsfont : NULL;
+  fluid_defsfont_t* defsfont;
+  fluid_defpreset_t* defpreset;
 
-  if (defsfont && defsfont->preset_stack_size < defsfont->preset_stack_capacity) {
-     defsfont->preset_stack[defsfont->preset_stack_size] = preset;
-     defsfont->preset_stack_size++;
+  defsfont = fluid_sfont_get_data(preset->sfont);
+  defpreset = fluid_preset_get_data(preset);
+
+  if (defsfont)
+  {
+      defsfont->preset = fluid_list_remove(defsfont->preset, defpreset);
   }
-  else
-      delete_fluid_preset(preset);
+
+  delete_fluid_defpreset(defpreset);
+  delete_fluid_preset(preset);
 }
 
 const char* fluid_defpreset_preset_get_name(fluid_preset_t* preset)
@@ -260,7 +229,7 @@ fluid_defsfont_t* new_fluid_defsfont(fluid_settings_t* settings)
 int delete_fluid_defsfont(fluid_defsfont_t* defsfont)
 {
   fluid_list_t *list;
-  fluid_defpreset_t* defpreset;
+  fluid_preset_t* preset;
   fluid_sample_t* sample;
 
   fluid_return_val_if_fail(defsfont != NULL, FLUID_OK);
@@ -293,12 +262,11 @@ int delete_fluid_defsfont(fluid_defsfont_t* defsfont)
     FLUID_FREE(defsfont->preset_stack[--defsfont->preset_stack_size]);
   FLUID_FREE(defsfont->preset_stack);
 
-  defpreset = defsfont->preset;
-  while (defpreset != NULL) {
-    defsfont->preset = defpreset->next;
-    delete_fluid_defpreset(defpreset);
-    defpreset = defsfont->preset;
+  for (list = defsfont->preset; list; list = fluid_list_next(list)) {
+      preset = (fluid_preset_t *)fluid_list_get(list);
+      fluid_defpreset_preset_delete(preset);
   }
+  delete_fluid_list(defsfont->preset);
 
   FLUID_FREE(defsfont);
   return FLUID_OK;
@@ -385,7 +353,10 @@ int fluid_defsfont_load(fluid_defsfont_t* defsfont, const fluid_file_callbacks_t
     if (fluid_defpreset_import_sfont(defpreset, sfpreset, defsfont) != FLUID_OK)
       goto err_exit;
 
-    fluid_defsfont_add_preset(defsfont, defpreset);
+    if (fluid_defsfont_add_preset(defsfont, defpreset) == FLUID_FAILED)
+    {
+        goto err_exit;
+    }
     p = fluid_list_next(p);
   }
   fluid_sffile_close (sfdata);
@@ -414,33 +385,24 @@ int fluid_defsfont_add_sample(fluid_defsfont_t* defsfont, fluid_sample_t* sample
  */
 int fluid_defsfont_add_preset(fluid_defsfont_t* defsfont, fluid_defpreset_t* defpreset)
 {
-  fluid_defpreset_t *cur, *prev;
-  if (defsfont->preset == NULL) {
-    defpreset->next = NULL;
-    defsfont->preset = defpreset;
-  } else {
-    /* sort them as we go along. very basic sorting trick. */
-    cur = defsfont->preset;
-    prev = NULL;
-    while (cur != NULL) {
-      if ((defpreset->bank < cur->bank)
-	  || ((defpreset->bank == cur->bank) && (defpreset->num < cur->num))) {
-	if (prev == NULL) {
-	  defpreset->next = cur;
-	  defsfont->preset = defpreset;
-	} else {
-	  defpreset->next = cur;
-	  prev->next = defpreset;
-	}
-	return FLUID_OK;
-      }
-      prev = cur;
-      cur = cur->next;
+    fluid_preset_t *preset;
+
+    preset = new_fluid_preset(defsfont->sfont,
+                              fluid_defpreset_preset_get_name,
+                              fluid_defpreset_preset_get_banknum,
+                              fluid_defpreset_preset_get_num,
+                              fluid_defpreset_preset_noteon,
+                              fluid_defpreset_preset_delete);
+
+    if (preset == NULL) {
+        return FLUID_FAILED;
     }
-    defpreset->next = NULL;
-    prev->next = defpreset;
-  }
-  return FLUID_OK;
+
+    fluid_preset_set_data(preset, defpreset);
+
+    defsfont->preset = fluid_list_append(defsfont->preset, preset);
+
+    return FLUID_OK;
 }
 
 /*
@@ -469,16 +431,22 @@ fluid_defsfont_load_sampledata(fluid_defsfont_t* defsfont, const fluid_file_call
 /*
  * fluid_defsfont_get_preset
  */
-fluid_defpreset_t* fluid_defsfont_get_preset(fluid_defsfont_t* defsfont, unsigned int bank, unsigned int num)
+fluid_preset_t* fluid_defsfont_get_preset(fluid_defsfont_t* defsfont, unsigned int bank, unsigned int num)
 {
-  fluid_defpreset_t* defpreset = defsfont->preset;
-  while (defpreset != NULL) {
-    if ((defpreset->bank == bank) && ((defpreset->num == num))) {
-      return defpreset;
+    fluid_preset_t *preset;
+    fluid_list_t *list;
+
+    for(list = defsfont->preset; list != NULL; list = fluid_list_next(list))
+    {
+        preset = (fluid_preset_t *)fluid_list_get(list);
+
+        if ((fluid_preset_get_banknum(preset) == bank) && (fluid_preset_get_num(preset) == num))
+        {
+            return preset;
+        }
     }
-    defpreset = defpreset->next;
-  }
-  return NULL;
+
+    return NULL;
 }
 
 /*
@@ -486,21 +454,19 @@ fluid_defpreset_t* fluid_defsfont_get_preset(fluid_defsfont_t* defsfont, unsigne
  */
 void fluid_defsfont_iteration_start(fluid_defsfont_t* defsfont)
 {
-  defsfont->iter_cur = defsfont->preset;
+  defsfont->preset_iter_cur = defsfont->preset;
 }
 
 /*
  * fluid_defsfont_iteration_next
  */
-int fluid_defsfont_iteration_next(fluid_defsfont_t* defsfont, fluid_preset_t* preset)
+fluid_preset_t *fluid_defsfont_iteration_next(fluid_defsfont_t* defsfont)
 {
-  if (defsfont->iter_cur == NULL) {
-    return 0;
-  }
+    fluid_preset_t *preset = (fluid_preset_t *)fluid_list_get(defsfont->preset_iter_cur);
 
-  preset->data = (void*) defsfont->iter_cur;
-  defsfont->iter_cur = fluid_defpreset_next(defsfont->iter_cur);
-  return 1;
+    defsfont->preset_iter_cur = fluid_list_next(defsfont->preset_iter_cur);
+
+    return preset;
 }
 
 /***************************************************************

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -185,7 +185,6 @@ int fluid_defpreset_preset_noteon(fluid_preset_t* preset, fluid_synth_t* synth,
 fluid_defsfont_t* new_fluid_defsfont(fluid_settings_t* settings)
 {
   fluid_defsfont_t* defsfont;
-  int i;
 
   defsfont = FLUID_NEW(fluid_defsfont_t);
   if (defsfont == NULL) {

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -109,10 +109,6 @@ struct _fluid_defsfont_t
   int mlock;                 /* Should we try memlock (avoid swapping)? */
 
   fluid_list_t *preset_iter_cur;       /* the current preset in the iteration */
-
-  fluid_preset_t** preset_stack; /* List of presets that are available to use */
-  int preset_stack_capacity;     /* Length of preset_stack array */
-  int preset_stack_size;         /* Current number of items in the stack */
 };
 
 

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -78,7 +78,7 @@ int fluid_defsfont_sfont_delete(fluid_sfont_t* sfont);
 const char* fluid_defsfont_sfont_get_name(fluid_sfont_t* sfont);
 fluid_preset_t* fluid_defsfont_sfont_get_preset(fluid_sfont_t* sfont, unsigned int bank, unsigned int prenum);
 void fluid_defsfont_sfont_iteration_start(fluid_sfont_t* sfont);
-int fluid_defsfont_sfont_iteration_next(fluid_sfont_t* sfont, fluid_preset_t* preset);
+fluid_preset_t *fluid_defsfont_sfont_iteration_next(fluid_sfont_t* sfont);
 
 
 void fluid_defpreset_preset_delete(fluid_preset_t* preset);
@@ -103,11 +103,12 @@ struct _fluid_defsfont_t
   unsigned int sample24size;		/* length within sffd of the sm24 chunk */
   char* sample24data;        /* if not NULL, the least significant byte of the 24bit sample data, loaded in ram */
   
+  fluid_sfont_t *sfont;      /* pointer to parent sfont */
   fluid_list_t* sample;      /* the samples in this soundfont */
-  fluid_defpreset_t* preset; /* the presets of this soundfont */
+  fluid_list_t* preset;      /* the presets of this soundfont */
   int mlock;                 /* Should we try memlock (avoid swapping)? */
 
-  fluid_defpreset_t* iter_cur;       /* the current preset in the iteration */
+  fluid_list_t *preset_iter_cur;       /* the current preset in the iteration */
 
   fluid_preset_t** preset_stack; /* List of presets that are available to use */
   int preset_stack_capacity;     /* Length of preset_stack array */
@@ -119,9 +120,9 @@ fluid_defsfont_t* new_fluid_defsfont(fluid_settings_t* settings);
 int delete_fluid_defsfont(fluid_defsfont_t* defsfont);
 int fluid_defsfont_load(fluid_defsfont_t* defsfont, const fluid_file_callbacks_t* file_callbacks, const char* file);
 const char* fluid_defsfont_get_name(fluid_defsfont_t* defsfont);
-fluid_defpreset_t* fluid_defsfont_get_preset(fluid_defsfont_t* defsfont, unsigned int bank, unsigned int prenum);
+fluid_preset_t* fluid_defsfont_get_preset(fluid_defsfont_t* defsfont, unsigned int bank, unsigned int prenum);
 void fluid_defsfont_iteration_start(fluid_defsfont_t* defsfont);
-int fluid_defsfont_iteration_next(fluid_defsfont_t* defsfont, fluid_preset_t* preset);
+fluid_preset_t *fluid_defsfont_iteration_next(fluid_defsfont_t* defsfont);
 int fluid_defsfont_load_sampledata(fluid_defsfont_t* defsfont, const fluid_file_callbacks_t* file_callbacks);
 int fluid_defsfont_add_sample(fluid_defsfont_t* defsfont, fluid_sample_t* sample);
 int fluid_defsfont_add_preset(fluid_defsfont_t* defsfont, fluid_defpreset_t* defpreset);

--- a/src/sfloader/fluid_ramsfont.h
+++ b/src/sfloader/fluid_ramsfont.h
@@ -41,11 +41,11 @@ extern "C" {
 struct _fluid_ramsfont_t
 {
   char name[21];                        /* the name of the soundfont */
+  fluid_sfont_t* sfont;    /* parent sfont */
   fluid_list_t* sample;    /* the samples in this soundfont */
-  fluid_rampreset_t* preset;    /* the presets of this soundfont */
+  fluid_list_t* preset;    /* the presets of this soundfont */
 
-  fluid_preset_t iter_preset;        /* preset interface used in the iteration */
-  fluid_rampreset_t* iter_cur;       /* the current preset in the iteration */
+  fluid_list_t* preset_iter_cur;       /* the current preset in the iteration */
 };
 
 /*

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -42,7 +42,7 @@ int fluid_sample_decompress_vorbis(fluid_sample_t *sample);
 #define fluid_sfont_get_name(_sf) (*(_sf)->get_name)(_sf)
 #define fluid_sfont_get_preset(_sf,_bank,_prenum) (*(_sf)->get_preset)(_sf,_bank,_prenum)
 #define fluid_sfont_iteration_start(_sf) { if((_sf) && (_sf)->iteration_start) (*(_sf)->iteration_start)(_sf); }
-#define fluid_sfont_iteration_next(_sf,_pr) (((_sf) && (_sf)->iteration_start) ? (*(_sf)->iteration_next)(_sf,_pr) : 0)
+#define fluid_sfont_iteration_next(_sf) (((_sf) && (_sf)->iteration_start) ? (*(_sf)->iteration_next)(_sf) : 0)
 
 
 #define fluid_preset_delete_internal(_preset) \
@@ -112,7 +112,7 @@ typedef void (*fluid_sfont_iteration_start_t)(fluid_sfont_t* sfont);
  * and advance the internal iteration state to the next preset for subsequent
  * calls.
  */
-typedef int (*fluid_sfont_iteration_next_t)(fluid_sfont_t* sfont, fluid_preset_t* preset);
+typedef fluid_preset_t* (*fluid_sfont_iteration_next_t)(fluid_sfont_t* sfont);
 
 void fluid_sfont_set_iteration_start(fluid_sfont_t* sfont, fluid_sfont_iteration_start_t iter_start);
 void fluid_sfont_set_iteration_next(fluid_sfont_t* sfont, fluid_sfont_iteration_next_t iter_next);

--- a/src/synth/fluid_chan.c
+++ b/src/synth/fluid_chan.c
@@ -204,7 +204,6 @@ delete_fluid_channel(fluid_channel_t* chan)
 {
   fluid_return_if_fail(chan != NULL);
   
-  fluid_preset_delete_internal (chan->preset);
   FLUID_FREE(chan);
 }
 
@@ -220,13 +219,11 @@ fluid_channel_reset(fluid_channel_t* chan)
 int
 fluid_channel_set_preset(fluid_channel_t* chan, fluid_preset_t* preset)
 {
-
   fluid_preset_notify (chan->preset, FLUID_PRESET_UNSELECTED, chan->channum);
 
   if (chan->preset) {
     fluid_sfont_t *sfont;
     sfont = chan->preset->sfont;
-    fluid_preset_delete_internal (chan->preset);
     fluid_synth_sfont_unref (chan->synth, sfont); /* -- unref preset's SoundFont */
   }
   

--- a/src/synth/fluid_chan.c
+++ b/src/synth/fluid_chan.c
@@ -219,15 +219,26 @@ fluid_channel_reset(fluid_channel_t* chan)
 int
 fluid_channel_set_preset(fluid_channel_t* chan, fluid_preset_t* preset)
 {
-  fluid_preset_notify (chan->preset, FLUID_PRESET_UNSELECTED, chan->channum);
+  fluid_sfont_t *sfont;
+
+  if (chan->preset == preset)
+  {
+      return FLUID_OK;
+  }
 
   if (chan->preset) {
-    fluid_sfont_t *sfont;
     sfont = chan->preset->sfont;
-    fluid_synth_sfont_unref (chan->synth, sfont); /* -- unref preset's SoundFont */
+    sfont->refcount--;
   }
-  
+
+  fluid_preset_notify (chan->preset, FLUID_PRESET_UNSELECTED, chan->channum);
+
   chan->preset = preset;
+
+  if (preset) {
+    sfont = preset->sfont;
+    sfont->refcount++;
+  }
 
   fluid_preset_notify (preset, FLUID_PRESET_SELECTED, chan->channum);
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -2214,7 +2214,6 @@ static fluid_preset_t*
 fluid_synth_get_preset(fluid_synth_t* synth, unsigned int sfontnum,
                        unsigned int banknum, unsigned int prognum)
 {
-  fluid_preset_t *preset = NULL;
   fluid_sfont_t *sfont;
   fluid_list_t *list;
 
@@ -2226,14 +2225,11 @@ fluid_synth_get_preset(fluid_synth_t* synth, unsigned int sfontnum,
 
     if (fluid_sfont_get_id (sfont) == sfontnum)
     {
-      preset = fluid_sfont_get_preset (sfont,
-                                       banknum - sfont->bankofs, prognum);
-      if (preset) sfont->refcount++;       /* Add reference to SoundFont */
-      break;
+      return fluid_sfont_get_preset (sfont, banknum - sfont->bankofs, prognum);
     }
   }
 
-  return preset;
+  return NULL;
 }
 
 /* Get a preset by SoundFont name, bank and program.
@@ -2243,7 +2239,6 @@ static fluid_preset_t*
 fluid_synth_get_preset_by_sfont_name(fluid_synth_t* synth, const char *sfontname,
                                      unsigned int banknum, unsigned int prognum)
 {
-  fluid_preset_t *preset = NULL;
   fluid_sfont_t *sfont;
   fluid_list_t *list;
 
@@ -2252,14 +2247,11 @@ fluid_synth_get_preset_by_sfont_name(fluid_synth_t* synth, const char *sfontname
 
     if (FLUID_STRCMP (fluid_sfont_get_name (sfont), sfontname) == 0)
     {
-      preset = fluid_sfont_get_preset (sfont,
-                                       banknum - sfont->bankofs, prognum);
-      if (preset) sfont->refcount++;       /* Add reference to SoundFont */
-      break;
+      return fluid_sfont_get_preset (sfont, banknum - sfont->bankofs, prognum);
     }
   }
 
-  return preset;
+  return NULL;
 }
 
 /* Find a preset by bank and program numbers.
@@ -2269,23 +2261,21 @@ fluid_preset_t*
 fluid_synth_find_preset(fluid_synth_t* synth, unsigned int banknum,
                         unsigned int prognum)
 {
-  fluid_preset_t *preset = NULL;
+  fluid_preset_t *preset;
   fluid_sfont_t *sfont;
   fluid_list_t *list;
 
   for (list = synth->sfont; list; list = fluid_list_next (list)) {
     sfont = fluid_list_get (list);
 
-    preset = fluid_sfont_get_preset (sfont,
-                                     banknum - sfont->bankofs, prognum);
+    preset = fluid_sfont_get_preset (sfont, banknum - sfont->bankofs, prognum);
     if (preset)
     {
-      sfont->refcount++;       /* Add reference to SoundFont */
-      break;
+      return preset;
     }
   }
 
-  return preset;
+  return NULL;
 }
 
 /**

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -2209,9 +2209,6 @@ fluid_synth_set_preset (fluid_synth_t *synth, int chan, fluid_preset_t *preset)
 
 /* Get a preset by SoundFont, bank and program numbers.
  * Returns preset pointer or NULL.
- *
- * @note The returned preset has been allocated, caller owns it and should
- *       free it when finished using it.
  */
 static fluid_preset_t*
 fluid_synth_get_preset(fluid_synth_t* synth, unsigned int sfontnum,
@@ -2241,9 +2238,6 @@ fluid_synth_get_preset(fluid_synth_t* synth, unsigned int sfontnum,
 
 /* Get a preset by SoundFont name, bank and program.
  * Returns preset pointer or NULL.
- *
- * @note The returned preset has been allocated, caller owns it and should
- *       free it when finished using it.
  */
 static fluid_preset_t*
 fluid_synth_get_preset_by_sfont_name(fluid_synth_t* synth, const char *sfontname,
@@ -2270,9 +2264,7 @@ fluid_synth_get_preset_by_sfont_name(fluid_synth_t* synth, const char *sfontname
 
 /* Find a preset by bank and program numbers.
  * Returns preset pointer or NULL.
- *
- * @note The returned preset has been allocated, caller owns it and should
- *       free it when finished using it. */
+ */
 fluid_preset_t*
 fluid_synth_find_preset(fluid_synth_t* synth, unsigned int banknum,
                         unsigned int prognum)

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -2494,7 +2494,7 @@ fluid_synth_program_select(fluid_synth_t* synth, int chan, unsigned int sfont_id
   FLUID_API_RETURN_IF_CHAN_DISABLED(FLUID_FAILED);
   
   channel = synth->channel[chan];
-  	  /* ++ Allocate preset */
+  
 	  preset = fluid_synth_get_preset (synth, sfont_id, bank_num, preset_num);
 
 	  if (preset == NULL) {
@@ -2536,7 +2536,7 @@ fluid_synth_program_select_by_sfont_name (fluid_synth_t* synth, int chan,
   FLUID_API_RETURN_IF_CHAN_DISABLED(FLUID_FAILED);
   
   channel = synth->channel[chan];
-	  /* ++ Allocate preset */
+  
 	  preset = fluid_synth_get_preset_by_sfont_name (synth, sfont_name, bank_num,
 													 preset_num);
 	  if (preset == NULL) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ include ( FluidUnitTest )
 ## add unit tests here ##
 ADD_FLUID_TEST(test_sample_cache)
 ADD_FLUID_TEST(test_sfont_loading)
+ADD_FLUID_TEST(test_defsfont_preset_iteration)
 
 
 add_custom_target(check
@@ -14,4 +15,5 @@ COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG>  --output-on-failure
 DEPENDS
 test_sample_cache
 test_sfont_loading
+test_defsfont_preset_iteration
 )

--- a/test/test_defsfont_preset_iteration.c
+++ b/test/test_defsfont_preset_iteration.c
@@ -5,18 +5,17 @@
 
 int main(void)
 {
-    char *s;
     int id;
     fluid_sfont_t *sfont;
     fluid_preset_t *preset;
-    fluid_preset_t *prev_preset;
+    fluid_preset_t *prev_preset = NULL;
     int count = 0;
 
     /* setup */
     fluid_settings_t *settings = new_fluid_settings();
     fluid_synth_t *synth = new_fluid_synth(settings);
-    fluid_settings_dupstr(settings, "synth.default-soundfont", &s);
-    id = fluid_synth_sfload(synth, s, 1);
+    /* Load the VintageDreams soundfont */
+    id = fluid_synth_sfload(synth, DEFAULT_SOUNDFONT, 1);
     sfont = fluid_synth_get_sfont_by_id(synth, id);
 
     /* code under test */
@@ -27,10 +26,12 @@ int main(void)
 
         /* make sure we actually got a different preset */
         TEST_ASSERT(preset != prev_preset);
+
         prev_preset = preset;
     }
 
-    TEST_ASSERT(count > 0);
+    /* VintageDreams has 136 presets */
+    TEST_ASSERT(count == 136);
 
     /* teardown */
     delete_fluid_synth(synth);

--- a/test/test_defsfont_preset_iteration.c
+++ b/test/test_defsfont_preset_iteration.c
@@ -1,0 +1,40 @@
+#include "test.h"
+#include "fluidsynth.h"
+#include "sfloader/fluid_sfont.h"
+#include "utils/fluidsynth_priv.h"
+
+int main(void)
+{
+    char *s;
+    int id;
+    fluid_sfont_t *sfont;
+    fluid_preset_t *preset;
+    fluid_preset_t *prev_preset;
+    int count = 0;
+
+    /* setup */
+    fluid_settings_t *settings = new_fluid_settings();
+    fluid_synth_t *synth = new_fluid_synth(settings);
+    fluid_settings_dupstr(settings, "synth.default-soundfont", &s);
+    id = fluid_synth_sfload(synth, s, 1);
+    sfont = fluid_synth_get_sfont_by_id(synth, id);
+
+    /* code under test */
+    fluid_sfont_iteration_start(sfont);
+
+    while ((preset = fluid_sfont_iteration_next(sfont)) != NULL) {
+        count++;
+
+        /* make sure we actually got a different preset */
+        TEST_ASSERT(preset != prev_preset);
+        prev_preset = preset;
+    }
+
+    TEST_ASSERT(count > 0);
+
+    /* teardown */
+    delete_fluid_synth(synth);
+    delete_fluid_settings(settings);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR removes the preset stack and makes presets returned by the loaders unique objects, as discussed in #360.

I also changed the signature of the sfont::iteration_next function to return a pointer to the next preset or NULL if it has reached the end of the list. The old interface made sense as the caller had to create a preset which got filled by the iteration. But we now have unique presets which we can simply return.

Last but not least, I changed the way the sfont::refcount gets increased/decreased when selecting presets. Previously, the refcount was increased when *getting* a preset from the loader and decreased only when a preset was unselected from a channel. It's now symmetric: increase when selected for channel, decreased when unselected from channel. 