### PR TITLE
Only import Soundfont instruments once

### DIFF
--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -115,6 +115,7 @@ struct _fluid_defsfont_t
   fluid_sfont_t *sfont;      /* pointer to parent sfont */
   fluid_list_t* sample;      /* the samples in this soundfont */
   fluid_list_t* preset;      /* the presets of this soundfont */
+  fluid_list_t* inst;        /* the instruments of this soundfont */
   int mlock;                 /* Should we try memlock (avoid swapping)? */
   int dynamic_samples;       /* Enables dynamic sample loading if set */
 
@@ -189,13 +190,13 @@ fluid_inst_t* fluid_preset_zone_get_inst(fluid_preset_zone_t* zone);
 struct _fluid_inst_t
 {
   char name[21];
+  int source_idx; /* Index of instrument in source Soundfont */
   fluid_inst_zone_t* global_zone;
   fluid_inst_zone_t* zone;
 };
 
 fluid_inst_t* new_fluid_inst(void);
-int fluid_inst_import_sfont(fluid_preset_zone_t* preset_zone, fluid_inst_t* inst,
-							SFInst *sfinst, fluid_defsfont_t* defsfont);
+fluid_inst_t* fluid_inst_import_sfont(fluid_preset_zone_t* preset_zone, SFInst *sfinst, fluid_defsfont_t* defsfont);
 void delete_fluid_inst(fluid_inst_t* inst);
 int fluid_inst_set_global_zone(fluid_inst_t* inst, fluid_inst_zone_t* zone);
 int fluid_inst_add_zone(fluid_inst_t* inst, fluid_inst_zone_t* zone);

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -53,6 +53,7 @@ typedef struct _fluid_defpreset_t fluid_defpreset_t;
 typedef struct _fluid_preset_zone_t fluid_preset_zone_t;
 typedef struct _fluid_inst_t fluid_inst_t;
 typedef struct _fluid_inst_zone_t fluid_inst_zone_t;            /**< Soundfont Instrument Zone */
+typedef struct _fluid_voice_zone_t fluid_voice_zone_t;
 
 /* defines the velocity and key range for a zone */
 struct _fluid_zone_range_t
@@ -64,6 +65,13 @@ struct _fluid_zone_range_t
   unsigned char ignore;	/* set to TRUE for legato playing to ignore this range zone */
 };
 
+/* Stored on a preset zone to keep track of the inst zones that could start a voice
+ * and their combined preset zone/instument zone ranges */
+struct _fluid_voice_zone_t
+{
+    fluid_inst_zone_t *inst_zone;
+    fluid_zone_range_t range;
+};
 
 /*
 
@@ -163,6 +171,7 @@ struct _fluid_preset_zone_t
   fluid_preset_zone_t* next;
   char* name;
   fluid_inst_t* inst;
+  fluid_list_t* voice_zone;
   fluid_zone_range_t range;
   fluid_gen_t gen[GEN_LAST];
   fluid_mod_t * mod; /* List of modulators */
@@ -210,8 +219,7 @@ struct _fluid_inst_zone_t
 fluid_inst_zone_t* new_fluid_inst_zone(char* name);
 void delete_fluid_inst_zone(fluid_inst_zone_t* zone);
 fluid_inst_zone_t* fluid_inst_zone_next(fluid_inst_zone_t* zone);
-int fluid_inst_zone_import_sfont(fluid_preset_zone_t* preset_zone,
-								 fluid_inst_zone_t* inst_zone, SFZone *sfzone, fluid_defsfont_t* defsfont);
+int fluid_inst_zone_import_sfont(fluid_inst_zone_t* inst_zone, SFZone *sfzone, fluid_defsfont_t* defsfont);
 fluid_sample_t* fluid_inst_zone_get_sample(fluid_inst_zone_t* zone);
 
 

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1281,6 +1281,7 @@ static int load_ihdr(SFData *sf, int size)
         p = FLUID_NEW(SFInst);
         sf->inst = fluid_list_append(sf->inst, p);
         p->zone = NULL; /* For proper cleanup if fail (fluid_sffile_close) */
+        p->idx = i;
         READSTR(sf, &p->name); /* Possible read failure ^ */
         READW(sf, zndx);
 

--- a/src/sfloader/fluid_sffile.h
+++ b/src/sfloader/fluid_sffile.h
@@ -114,6 +114,7 @@ struct _SFSample
 struct _SFInst
 { /* Instrument structure */
     char name[21]; /* Name of instrument */
+    int idx; /* Index of this instrument in the Soundfont */
     fluid_list_t *zone; /* list of instrument zones */
 };
 


### PR DESCRIPTION
This is a follow up PR to the dynamic-sample-loading feature. It reduces the memory footprint of imported Soundfonts by ensuring that instruments are only imported once and then re-used in each preset zone that links to them.

Previously, each preset zone got its own copy of the complete instrument information from the Soundfont, which increased memory consumption dramatically for Soundfonts with lots of preset/instrument zones. For example, the memory footprint of the standard FluidR3_GM Soundfont is reduced by 30 MB after this change.

In order to allow this change, I had to split the mutable parts of the instrument zones (i.e. the zone ranges) from the imported instrument, creating a new fluid_voice_zone_t structure. 