### PR TITLE
Preload presets in fluid_player before playback (if using dynamic sample loading)

### DIFF
--- a/include/fluidsynth/sfont.h
+++ b/include/fluidsynth/sfont.h
@@ -241,6 +241,27 @@ typedef int (*fluid_preset_get_num_t)(fluid_preset_t* preset);
 typedef int (*fluid_preset_noteon_t)(fluid_preset_t* preset, fluid_synth_t* synth, int chan, int key, int vel);
 
 /**
+ * Method to load a virtual SoundFont preset when using dynamic sample loading
+ * @param preset Virtual SoundFont preset
+ * @return #FLUID_OK on success (0) or #FLUID_FAILED (-1) otherwise
+ */
+typedef int (*fluid_preset_load_t)(fluid_preset_t* preset);
+
+/**
+ * Method to unload a virtual SoundFont preset when using dynamic sample loading
+ * @param preset Virtual SoundFont preset
+ * @return #FLUID_OK on success (0) or #FLUID_FAILED (-1) otherwise
+ */
+typedef int (*fluid_preset_unload_t)(fluid_preset_t* preset);
+
+/**
+ * Method to check if a virtual SoundFont preset has been loaded
+ * @param preset Virtual SoundFont preset
+ * @return TRUE if loaded, otherwise FALSE
+ */
+typedef int (*fluid_preset_is_loaded_t)(fluid_preset_t* preset);
+
+/**
  * Method to free a virtual SoundFont preset. Any custom user provided cleanup function must ultimately call
  * delete_fluid_preset() to ensure proper cleanup of the #fluid_preset_t struct. If no private data
  * needs to be freed, setting this to delete_fluid_preset() is sufficient.

--- a/src/midi/fluid_midi.h
+++ b/src/midi/fluid_midi.h
@@ -26,6 +26,7 @@
 #include "fluid_list.h"
 
 typedef struct _fluid_midi_parser_t fluid_midi_parser_t;
+typedef struct _fluid_player_preset_info_t fluid_player_preset_info_t;
 
 fluid_midi_parser_t* new_fluid_midi_parser(void);
 void delete_fluid_midi_parser(fluid_midi_parser_t* parser);
@@ -277,6 +278,17 @@ typedef struct
     size_t buffer_len;  /** Number of bytes in buffer; 0 if filename */
 } fluid_playlist_item;
 
+
+/* Stores information about selected presets. Used by the preset
+ * preloading function of fluid_player if dynamic sample loading is enabled */
+struct _fluid_player_preset_info_t
+{
+    int sfont_id;
+    int bank;
+    int prog;
+};
+
+
 /*
  * fluid_player
  */
@@ -291,6 +303,9 @@ struct _fluid_player_t {
   int loop; /* -1 = loop infinitely, otherwise times left to loop the playlist */
   fluid_list_t* playlist; /* List of fluid_playlist_item* objects */
   fluid_list_t* currentfile; /* points to an item in files, or NULL if not playing */
+
+  int preload_presets;    /* If we should attempt to preload all presets used in MIDI files */
+  fluid_list_t* preloaded; /* List of preloaded preset info */
 
   char send_program_change; /* should we ignore the program changes? */
   char use_system_timer;   /* if zero, use sample timers, otherwise use system clock timer */

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -37,8 +37,12 @@
 static int load_preset_samples(fluid_defsfont_t *defsfont, fluid_preset_t *preset);
 static int unload_preset_samples(fluid_defsfont_t *defsfont, fluid_preset_t *preset);
 static void unload_sample(fluid_sample_t *sample);
-static int dynamic_samples_preset_notify(fluid_preset_t *preset, int reason, int chan);
 static int dynamic_samples_sample_notify(fluid_sample_t *sample, int reason);
+
+static int dynamic_samples_preset_notify(fluid_preset_t *preset, int reason, int chan);
+static int dynamic_samples_preset_load(fluid_preset_t *preset);
+static int dynamic_samples_preset_unload(fluid_preset_t *preset);
+static int dynamic_samples_preset_is_loaded(fluid_preset_t *preset);
 
 
 /***************************************************************
@@ -223,6 +227,18 @@ int delete_fluid_defsfont(fluid_defsfont_t* defsfont)
     sample = (fluid_sample_t*) fluid_list_get(list);
     if (sample->refcount != 0) {
       return FLUID_FAILED;
+    }
+  }
+
+  /* Unload any manually loaded presets */
+  if (defsfont->dynamic_samples)
+  {
+    for (list = defsfont->preset; list; list = fluid_list_next(list)) {
+        preset = fluid_list_get(list);
+        if (fluid_preset_is_loaded(preset))
+        {
+            fluid_preset_unload(preset);
+        }
     }
   }
 
@@ -497,6 +513,9 @@ int fluid_defsfont_add_preset(fluid_defsfont_t* defsfont, fluid_defpreset_t* def
     if (defsfont->dynamic_samples)
     {
         preset->notify = dynamic_samples_preset_notify;
+        preset->load = dynamic_samples_preset_load;
+        preset->unload = dynamic_samples_preset_unload;
+        preset->is_loaded = dynamic_samples_preset_is_loaded;
     }
 
     if (preset == NULL) {
@@ -574,6 +593,7 @@ new_fluid_defpreset(fluid_defsfont_t* defsfont)
   defpreset->num = 0;
   defpreset->global_zone = NULL;
   defpreset->zone = NULL;
+  defpreset->loaded_manually = FALSE;
   return defpreset;
 }
 
@@ -1696,6 +1716,54 @@ static int dynamic_samples_preset_notify(fluid_preset_t *preset, int reason, int
     }
 
     return FLUID_OK;
+}
+
+/* Manually loads all samples used by a preset. */
+static int dynamic_samples_preset_load(fluid_preset_t *preset)
+{
+    fluid_defpreset_t *defpreset = fluid_preset_get_data(preset);
+    fluid_return_val_if_fail(defpreset != NULL, FLUID_FAILED);
+
+    if (fluid_preset_is_loaded(preset))
+    {
+        return FLUID_OK;
+    }
+
+    if (load_preset_samples(defpreset->defsfont, preset) == FLUID_FAILED)
+    {
+        return FLUID_FAILED;
+    }
+
+    defpreset->loaded_manually = TRUE;
+    return FLUID_OK;
+}
+
+/* Manually unloads all samples used by a preset. */
+static int dynamic_samples_preset_unload(fluid_preset_t *preset)
+{
+    fluid_defpreset_t *defpreset = fluid_preset_get_data(preset);
+    fluid_return_val_if_fail(defpreset != NULL, FLUID_FAILED);
+
+    if (!defpreset->loaded_manually)
+    {
+        return FLUID_FAILED;
+    }
+
+    if (unload_preset_samples(defpreset->defsfont, preset) == FLUID_FAILED)
+    {
+        return FLUID_FAILED;
+    }
+
+    defpreset->loaded_manually = FALSE;
+    return FLUID_OK;
+}
+
+/* Checks if a preset has been manuall loaded. */
+static int dynamic_samples_preset_is_loaded(fluid_preset_t *preset)
+{
+    fluid_defpreset_t *defpreset = fluid_preset_get_data(preset);
+    fluid_return_val_if_fail(defpreset != NULL, FALSE);
+    return defpreset->loaded_manually;
 }
 
 

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -140,6 +140,7 @@ struct _fluid_defpreset_t
   unsigned int num;                     /* the preset number */
   fluid_preset_zone_t* global_zone;        /* the global zone of the preset */
   fluid_preset_zone_t* zone;               /* the chained list of preset zones */
+  char loaded_manually;                 /* Flag to indicate if preset has been manually loaded */
 };
 
 fluid_defpreset_t* new_fluid_defpreset(fluid_defsfont_t* defsfont);

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -57,6 +57,10 @@ int fluid_sample_sanitize_loop(fluid_sample_t *sample, unsigned int max_end);
 #define fluid_preset_notify(_preset,_reason,_chan) \
   { if ((_preset) && (_preset)->notify) { (*(_preset)->notify)(_preset,_reason,_chan); }}
 
+#define fluid_preset_load(_preset) (((_preset) && (_preset)->load) ? (*(_preset)->load)(_preset) : FLUID_FAILED)
+#define fluid_preset_unload(_preset) (((_preset) && (_preset)->unload) ? (*(_preset)->unload)(_preset) : FLUID_FAILED)
+#define fluid_preset_is_loaded(_preset) (((_preset) && (_preset)->is_loaded) ? (*(_preset)->is_loaded)(_preset) : TRUE)
+
 
 #define fluid_sample_incr_ref(_sample) { (_sample)->refcount++; }
 
@@ -152,6 +156,12 @@ struct _fluid_preset_t {
   fluid_preset_get_num_t get_num;
 
   fluid_preset_noteon_t noteon;
+
+  fluid_preset_load_t load;
+
+  fluid_preset_unload_t unload;
+
+  fluid_preset_is_loaded_t is_loaded;
 
   /**
    * Virtual SoundFont preset notify method.


### PR DESCRIPTION
**As discussed in the mail thread, the idea behind this pull request is too much of a hack and most likely not even needed. Will be closed in a few days***

This PR implements the preset sample preload function discussed in
http://lists.gnu.org/archive/html/fluid-dev/2018-04/msg00000.html

Preloading is always active on the MIDI player if dynamic sample loading is enabled.

This feature is best tested with a MIDI file containing lots of program changes and a fairly large SF3 Soundfont like the FluidR3_GM.sf3 from MuseScore, as uncompressing the Vorbis samples takes quite a wihle, even on fast computers.

Here is an example MIDI file that cycles through 10 presets in quick succession: [progchange-fast.zip](https://github.com/FluidSynth/fluidsynth/files/1939691/progchange-fast.zip) 

It should output a steady stream of notes. Without preloading, the playback is interrupted quite often.


