### PR TITLE
Promote player.reset-synth to real-time setting 

### DIFF
--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -283,15 +283,15 @@ static const fluid_cmd_t fluid_commands[] =
     /* settings commands */
     {
         "set", "settings", fluid_handle_set,
-        "set name value             Set the value of a controller or settings"
+        "set name value             Set the value of a setting (must be a real-time setting to take effect immediately)"
     },
     {
         "get", "settings", fluid_handle_get,
-        "get name                   Get the value of a controller or settings"
+        "get name                   Get the value of a setting"
     },
     {
         "info", "settings", fluid_handle_info,
-        "info name                  Get information about a controller or settings"
+        "info name                  Get information about a setting"
     },
     {
         "settings", "settings", fluid_handle_settings,
@@ -304,7 +304,7 @@ static const fluid_cmd_t fluid_commands[] =
     /* Sleep command, useful to insert a delay between commands */
     {
         "sleep", "general", fluid_handle_sleep,
-        "sleep  duration            sleep duration(in ms)"
+        "sleep  duration            sleep duration (in ms)"
     },
     /* LADSPA-related commands */
 #ifdef LADSPA
@@ -1875,6 +1875,11 @@ fluid_handle_set(void *data, int ac, char **av, fluid_ostream_t out)
     if(ret == FLUID_FAILED)
     {
         fluid_ostream_printf(out, "set: Value out of range.\n");
+    }
+    
+    if(!fluid_settings_is_realtime(handler->synth->settings, av[0]))
+    {
+        fluid_ostream_printf(out, "Warning: '%s' is not a realtime setting, changes won't take effect.\n", av[0]);
     }
 
     return ret;

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -872,7 +872,10 @@ int main(int argc, char **argv)
 
     if(config_file != NULL)
     {
-        fluid_source(cmd_handler, config_file);
+        if(fluid_source(cmd_handler, config_file) < 0)
+        {
+            fprintf(stderr, "Failed to execute user provided command configuration file '%s'\n", config_file);
+        }
     }
     else if(fluid_get_userconf(buf, sizeof(buf)) != NULL)
     {

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -1543,6 +1543,14 @@ fluid_track_send_events(fluid_track_t *track,
  *
  *     fluid_player
  */
+static void
+fluid_player_handle_reset_synth(void *data, const char *name, int value)
+{
+    fluid_player_t *player = data;
+    fluid_return_if_fail(player != NULL);
+
+    player->reset_synth_between_songs = value;
+}
 
 /**
  * Create a new MIDI player.
@@ -1588,7 +1596,10 @@ new_fluid_player(fluid_synth_t *synth)
                                "player.timing-source", "system");
 
     fluid_settings_getint(synth->settings, "player.reset-synth", &i);
-    player->reset_synth_between_songs = i;
+    fluid_player_handle_reset_synth(player, NULL, i);
+    
+    fluid_settings_callback_int(synth->settings, "player.reset-synth",
+                                fluid_player_handle_reset_synth, player);
 
     return player;
 }


### PR DESCRIPTION
Addresses the intention behind #400 by warning the user when attempting to `set` a setting that is non-realtime.