### PR TITLE
Fix single thread build

### DIFF
--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -1290,8 +1290,8 @@ fluid_rvoice_mixer_render(fluid_rvoice_mixer_t *mixer, int blockcount)
         fluid_render_loop_multithread(mixer, blockcount);
     }
     else
-    {
 #endif
+    {
         fluid_render_loop_singlethread(mixer, blockcount);
     }
 


### PR DESCRIPTION
Compilation fails if ENABLE_MIXER_THREADS is set to zero, because a mismatch with parenthesis.