### PR TITLE
WinXP compatible CI builds

### DIFF
--- a/.appveyor-vcpkg.yml
+++ b/.appveyor-vcpkg.yml
@@ -43,9 +43,10 @@ init:
   - if "%platform%"=="ARM" ( set TARGET_PLATFORM= ARM)
   - echo %TARGET_PLATFORM%
   - echo %APPVEYOR_BUILD_WORKER_IMAGE%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set "generator=Visual Studio 15 2017%TARGET_PLATFORM%" )
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" ( set "generator=Visual Studio 14 2015%TARGET_PLATFORM%" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set "generator=Visual Studio 15 2017%TARGET_PLATFORM%" && set "toolset=v150_xp" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" ( set "generator=Visual Studio 14 2015%TARGET_PLATFORM%" && set "toolset=v140_xp" )
   - echo %generator%
+  - echo %toolset%
   
 install:
 # make sure the latest version of git is installed
@@ -55,7 +56,7 @@ install:
 build_script:
   - mkdir build
   - cd build
-  - cmake -G "%generator%" %CMAKE_FLAGS% -Denable-pkgconfig=0 -DCMAKE_TOOLCHAIN_FILE=c:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+  - cmake -G "%generator%" -T "%toolset%" %CMAKE_FLAGS% -Denable-pkgconfig=0 -DCMAKE_TOOLCHAIN_FILE=c:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
   - cmake --build . --config Release # build libfluidsynth and fluidsynth exec
   - cmake -Denable-tests=1 ..
   - cmake --build . --config Release --target check # build unittests

--- a/.appveyor-vcpkg.yml
+++ b/.appveyor-vcpkg.yml
@@ -43,7 +43,7 @@ init:
   - if "%platform%"=="ARM" ( set TARGET_PLATFORM= ARM)
   - echo %TARGET_PLATFORM%
   - echo %APPVEYOR_BUILD_WORKER_IMAGE%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set "generator=Visual Studio 15 2017%TARGET_PLATFORM%" && set "toolset=v150_xp" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set "generator=Visual Studio 15 2017%TARGET_PLATFORM%" && set "toolset=v141_xp" )
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" ( set "generator=Visual Studio 14 2015%TARGET_PLATFORM%" && set "toolset=v140_xp" )
   - echo %generator%
   - echo %toolset%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,9 +44,10 @@ init:
   - if "%platform%"=="x64" ( set TARGET_PLATFORM= Win64)
   - echo %TARGET_PLATFORM%
   - echo %APPVEYOR_BUILD_WORKER_IMAGE%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set "generator=Visual Studio 15 2017%TARGET_PLATFORM%" )
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" ( set "generator=Visual Studio 14 2015%TARGET_PLATFORM%" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set "generator=Visual Studio 15 2017%TARGET_PLATFORM%" && set "toolset=v150_xp" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" ( set "generator=Visual Studio 14 2015%TARGET_PLATFORM%" && set "toolset=v140_xp" )
   - echo %generator%
+  - echo %toolset%
 
 install:
 # make sure the latest version of git is installed
@@ -71,7 +72,7 @@ build_script:
   - cd C:\projects\fluidsynth
   - mkdir build
   - cd build
-  - cmake -G "%generator%" ..
+  - cmake -G "%generator%" -T "%toolset%" ..
   - cmake --build . --config Release # build libfluidsynth and fluidsynth exec
 # FIXME the linker doesnt find gthread-2.0.lib in the second run, why???
 #  - cmake -Denable-tests=1 ..

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,7 +44,7 @@ init:
   - if "%platform%"=="x64" ( set TARGET_PLATFORM= Win64)
   - echo %TARGET_PLATFORM%
   - echo %APPVEYOR_BUILD_WORKER_IMAGE%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set "generator=Visual Studio 15 2017%TARGET_PLATFORM%" && set "toolset=v150_xp" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set "generator=Visual Studio 15 2017%TARGET_PLATFORM%" && set "toolset=v141_xp" )
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" ( set "generator=Visual Studio 14 2015%TARGET_PLATFORM%" && set "toolset=v140_xp" )
   - echo %generator%
   - echo %toolset%

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,9 +195,31 @@ if ( WIN32 )
   set ( WINDOWS_LIBS "dsound;winmm;ws2_32" )
   set ( LIBFLUID_CPPFLAGS "-DFLUIDSYNTH_DLL_EXPORTS" )
   set ( FLUID_CPPFLAGS "-DFLUIDSYNTH_NOT_A_DLL" )
-  if (NOT MSVC)
+  if  ( MSVC )
+    # statically link in the CRT library to avoid a bunch of runtime DLL dependencies and allow 
+    # the CI windows builds to be run under WinXP
+    foreach ( flag_var
+        CMAKE_C_FLAGS
+        CMAKE_C_FLAGS_DEBUG
+        CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_MINSIZEREL
+        CMAKE_C_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_DEBUG
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL
+        CMAKE_CXX_FLAGS_RELWITHDEBINFO
+        )
+      if ( ${flag_var} MATCHES "/MD" )
+        string ( REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}" )
+      endif ( ${flag_var} MATCHES "/MD" )
+    endforeach ( flag_var )
+    
+  else ( MSVC )
+    # only set debug postfix if not MSVS building
     set ( CMAKE_DEBUG_POSTFIX "_debug" )
-  endif()
+  endif ( MSVC )
+  
   # MinGW compiler (a Windows GCC port)
   if ( MINGW )
     set ( MINGW32 1 )


### PR DESCRIPTION
Originating from the discussion started in #380, here's another attempt to deliver WinXP compatible CI builds of fluidsynth. Trying to avoid any runtime dependency on \*CRT\*.dll by linking it statically.

@jjceresa Please try: https://ci.appveyor.com/project/derselbst/fluidsynth/build/1205/job/y00g4jvxsg15yocw/artifacts