### PR TITLE
Always build unit tests

### DIFF
--- a/.appveyor-vcpkg.yml
+++ b/.appveyor-vcpkg.yml
@@ -57,8 +57,7 @@ build_script:
   - cd build
   - cmake -G "%generator%" %CMAKE_FLAGS% -Denable-pkgconfig=0 -DCMAKE_TOOLCHAIN_FILE=c:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
   - cmake --build . --config Release # build libfluidsynth and fluidsynth exec
-  - cmake -Denable-tests=1 ..
-  - cmake --build . --config Release --target check # build unittests
+  - cmake --build . --config Release --target check # build and exec unittests
 
 after_build:
   - 7z a fluidsynth-vcpkg-%platform%.zip %APPVEYOR_BUILD_FOLDER%\build\src\Release\*

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,10 +72,8 @@ build_script:
   - mkdir build
   - cd build
   - cmake -G "%generator%" ..
-  - cmake --build . --config Release # build libfluidsynth and fluidsynth exec
-# FIXME the linker doesnt find gthread-2.0.lib in the second run, why???
-#  - cmake -Denable-tests=1 ..
-#  - cmake --build . --config Release --target check # build unittests
+  - cmake --build . --config Release
+  - cmake --build . --config Release --target check # build and exec unittests
 
 after_build:
   - 7z a fluidsynth-%platform%.zip %APPVEYOR_BUILD_FOLDER%\build\src\Release\* c:\deps\bin\libglib*.dll c:\deps\bin\libgthread*.dll c:\deps\bin\*intl*.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,6 +220,7 @@ before_script:
     - mkdir build && cd build
     
 script:
-    - cmake -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} "-Denable-portaudio=1" "-Denable-ladspa=1" "-DCMAKE_BUILD_TYPE=RelWithDebInfo" ..
+    - cmake -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} "-Denable-portaudio=1" "-Denable-ladspa=1" "-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1" ..
     - make -j4
-    - if [ $TRAVIS_OS_NAME = linux ]; then make install; cmake -Denable-tests=1 ..; make check; fi # install only on linux, as CMAKE_INSTALL_PREFIX is ignored for frameworks on macosx and I cant tell whether that's correct or a bug. also build unit test only on linux, as libintl is not found on macosx
+    - make check
+    - if [ $TRAVIS_OS_NAME = linux ]; then make install; fi # install only on linux, as CMAKE_INSTALL_PREFIX is ignored for frameworks on macosx and I cant tell whether that's correct or a bug.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ option ( enable-fpe-check "enable Floating Point Exception checks and debug mess
 option ( enable-portaudio "compile PortAudio support" off )
 option ( enable-profiling "profile the dsp code" off )
 option ( enable-trap-on-fpe "enable SIGFPE trap on Floating Point Exceptions" off )
-option ( enable-tests "build unit tests (implicitly disables BUILD_SHARED_LIBS)" off )
 
 # Options enabled by default
 option ( enable-aufile "compile support for sound file output" on )
@@ -106,6 +105,11 @@ mark_as_advanced ( LIB_SUFFIX )
 
 # the default C standard to use for all targets
 set(CMAKE_C_STANDARD 90)
+
+# Compile with position independent code if the user requested a shared lib, i.e. no PIC if static requested.
+# This is cmakes default behavior, but here it's explicitly required due to the use of libfluidsynth-OBJ as object library,
+# which would otherwise always be compiled without PIC.
+set ( CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS} )
 
 # the default global visibility level for all target
 # no visibility support on OS2
@@ -543,19 +547,11 @@ if ( OpenMP_FOUND OR OpenMP_C_FOUND )
     endif()
 endif()
 
+# manipulate some variables to setup a proper test env
+set(TEST_SOUNDFONT "${CMAKE_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf2")
+set(TEST_SOUNDFONT_SF3 "${CMAKE_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf3")
 
-if(enable-tests)
-    # manipulate some variables to setup a proper test env
-    set(TEST_SOUNDFONT "${CMAKE_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf2")
-    set(TEST_SOUNDFONT_SF3 "${CMAKE_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf3")
-    
-    # force to build a static lib, in order to bypass the visibility control, allowing us
-    # to test fluidsynths private/internal functions
-    set(BUILD_SHARED_LIBS OFF)
-    
-    add_subdirectory ( test )
-endif(enable-tests)
-
+add_subdirectory ( test )
 
 # General configuration file
 configure_file ( ${CMAKE_SOURCE_DIR}/src/config.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,15 +551,25 @@ endif()
 set(TEST_SOUNDFONT "${CMAKE_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf2")
 set(TEST_SOUNDFONT_SF3 "${CMAKE_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf3")
 
-add_subdirectory ( test )
-
 # General configuration file
 configure_file ( ${CMAKE_SOURCE_DIR}/src/config.cmake
                  ${CMAKE_BINARY_DIR}/config.h )
 
+# Setup linker directories NOW, as the command will apply only to targets created after it has been called.
+link_directories (
+    ${GLIB_LIBRARY_DIRS}
+    ${LASH_LIBRARY_DIRS}
+    ${JACK_LIBRARY_DIRS}
+    ${ALSA_LIBRARY_DIRS}
+    ${PULSE_LIBRARY_DIRS}
+    ${PORTAUDIO_LIBRARY_DIRS}
+    ${LIBSNDFILE_LIBRARY_DIRS}
+    ${DBUS_LIBRARY_DIRS}
+)
 
 # Process subdirectories
 add_subdirectory ( src )
+add_subdirectory ( test )
 add_subdirectory ( doc )
 
 # pkg-config support

--- a/cmake_admin/FluidUnitTest.cmake
+++ b/cmake_admin/FluidUnitTest.cmake
@@ -1,5 +1,5 @@
 macro ( ADD_FLUID_TEST _test )
-    ADD_EXECUTABLE(${_test} ${_test}.c)
+    ADD_EXECUTABLE(${_test} ${_test}.c $<TARGET_OBJECTS:libfluidsynth-OBJ> )
     TARGET_LINK_LIBRARIES(${_test} libfluidsynth)
 
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed

--- a/cmake_admin/FluidUnitTest.cmake
+++ b/cmake_admin/FluidUnitTest.cmake
@@ -4,6 +4,8 @@ macro ( ADD_FLUID_TEST _test )
     # only build this unit test when explicitly requested by "make check"
     set_target_properties(${_test} PROPERTIES EXCLUDE_FROM_ALL TRUE)
     
+    # import necessary compile flags and dependency libraries
+    set_target_properties (${_test} PROPERTIES COMPILE_FLAGS $<TARGET_PROPERTY:fluidsynth,COMPILE_FLAGS> )
     TARGET_LINK_LIBRARIES(${_test} $<TARGET_PROPERTY:libfluidsynth,INTERFACE_LINK_LIBRARIES>)
 
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed

--- a/cmake_admin/FluidUnitTest.cmake
+++ b/cmake_admin/FluidUnitTest.cmake
@@ -5,7 +5,9 @@ macro ( ADD_FLUID_TEST _test )
     set_target_properties(${_test} PROPERTIES EXCLUDE_FROM_ALL TRUE)
     
     # import necessary compile flags and dependency libraries
-    set_target_properties (${_test} PROPERTIES COMPILE_FLAGS $<TARGET_PROPERTY:fluidsynth,COMPILE_FLAGS> )
+    if ( FLUID_CPPFLAGS )
+        set_target_properties ( ${_test} PROPERTIES COMPILE_FLAGS ${FLUID_CPPFLAGS} )
+    endif ( FLUID_CPPFLAGS )
     TARGET_LINK_LIBRARIES(${_test} $<TARGET_PROPERTY:libfluidsynth,INTERFACE_LINK_LIBRARIES>)
 
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed

--- a/cmake_admin/FluidUnitTest.cmake
+++ b/cmake_admin/FluidUnitTest.cmake
@@ -1,6 +1,10 @@
 macro ( ADD_FLUID_TEST _test )
     ADD_EXECUTABLE(${_test} ${_test}.c $<TARGET_OBJECTS:libfluidsynth-OBJ> )
-    TARGET_LINK_LIBRARIES(${_test} libfluidsynth)
+    
+    # only build this unit test when explicitly requested by "make check"
+    set_target_properties(${_test} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    
+    TARGET_LINK_LIBRARIES(${_test} $<TARGET_PROPERTY:libfluidsynth,INTERFACE_LINK_LIBRARIES>)
 
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed
     target_include_directories(${_test}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -247,10 +247,7 @@ link_directories (
     ${DBUS_LIBRARY_DIRS}
 )
 
-
-# note: by default this target creates a shared object (or dll). To build a
-# static library instead, set the option BUILD_SHARED_LIBS to FALSE.
-add_library ( libfluidsynth
+add_library ( libfluidsynth-OBJ OBJECT
     ${config_SOURCES}
     ${fluid_alsa_SOURCES}
     ${fluid_coreaudio_SOURCES}
@@ -269,6 +266,10 @@ add_library ( libfluidsynth
     ${public_main_HEADER}
     ${VersionFilesOutputVariable}
 )
+
+# note: by default this target creates a shared object (or dll). To build a
+# static library instead, set the option BUILD_SHARED_LIBS to FALSE.
+add_library ( libfluidsynth $<TARGET_OBJECTS:libfluidsynth-OBJ> )
 
 if ( MACOSX_FRAMEWORK )
      set_property ( SOURCE ${public_HEADERS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,6 +267,11 @@ add_library ( libfluidsynth-OBJ OBJECT
     ${VersionFilesOutputVariable}
 )
 
+if ( LIBFLUID_CPPFLAGS )
+  set_target_properties ( libfluidsynth-OBJ
+    PROPERTIES COMPILE_FLAGS ${LIBFLUID_CPPFLAGS} )
+endif ( LIBFLUID_CPPFLAGS )
+
 # note: by default this target creates a shared object (or dll). To build a
 # static library instead, set the option BUILD_SHARED_LIBS to FALSE.
 add_library ( libfluidsynth $<TARGET_OBJECTS:libfluidsynth-OBJ> )
@@ -313,11 +318,6 @@ else ( MACOSX_FRAMEWORK )
       SOVERSION ${LIB_VERSION_CURRENT}
   )
 endif ( MACOSX_FRAMEWORK )
-
-if ( LIBFLUID_CPPFLAGS )
-  set_target_properties ( libfluidsynth
-    PROPERTIES COMPILE_FLAGS ${LIBFLUID_CPPFLAGS} )
-endif ( LIBFLUID_CPPFLAGS )
 
 target_link_libraries ( libfluidsynth
     ${GLIB_LIBRARIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,6 @@ include_directories (
 
 include_directories (
     SYSTEM
-    ${GLIB_INCLUDEDIR}
     ${GLIB_INCLUDE_DIRS}
 )
 
@@ -48,12 +47,12 @@ endif ( READLINE_SUPPORT )
 
 if ( PULSE_SUPPORT )
   set ( fluid_pulse_SOURCES drivers/fluid_pulse.c )
-  include_directories ( ${PULSE_INCLUDEDIR} ${PULSE_INCLUDE_DIRS} )
+  include_directories ( ${PULSE_INCLUDE_DIRS} )
 endif ( PULSE_SUPPORT )
 
 if ( ALSA_SUPPORT )
   set ( fluid_alsa_SOURCES drivers/fluid_alsa.c )
-  include_directories ( ${ALSA_INCLUDEDIR} ${ALSA_INCLUDE_DIRS} )
+  include_directories ( ${ALSA_INCLUDE_DIRS} )
 endif ( ALSA_SUPPORT )
 
 if ( COREAUDIO_SUPPORT )
@@ -66,17 +65,17 @@ endif ( COREMIDI_SUPPORT )
 
 if ( DBUS_SUPPORT )
   set ( fluid_dbus_SOURCES bindings/fluid_rtkit.c bindings/fluid_rtkit.h )
-  include_directories ( ${DBUS_INCLUDEDIR} ${DBUS_INCLUDE_DIRS} )
+  include_directories ( ${DBUS_INCLUDE_DIRS} )
 endif ( DBUS_SUPPORT )
 
 if ( JACK_SUPPORT )
   set ( fluid_jack_SOURCES drivers/fluid_jack.c )
-  include_directories ( ${JACK_INCLUDEDIR} ${JACK_INCLUDE_DIRS} )
+  include_directories ( ${JACK_INCLUDE_DIRS} )
 endif ( JACK_SUPPORT )
 
 if ( PORTAUDIO_SUPPORT )
   set ( fluid_portaudio_SOURCES drivers/fluid_portaudio.c )
-  include_directories ( ${PORTAUDIO_INCLUDEDIR} ${PORTAUDIO_INCLUDE_DIRS} )
+  include_directories ( ${PORTAUDIO_INCLUDE_DIRS} )
 endif ( PORTAUDIO_SUPPORT )
 
 if ( WINDOWS_SUPPORT )
@@ -89,8 +88,7 @@ endif ( OSS_SUPPORT )
 
 if ( LASH_SUPPORT )
   set ( fluid_lash_SOURCES bindings/fluid_lash.c bindings/fluid_lash.h )
-  include_directories ( ${LASH_INCLUDEDIR}
-                        ${LASH_INCLUDE_DIRS})
+  include_directories ( ${LASH_INCLUDE_DIRS})
 endif ( LASH_SUPPORT )
 
 if ( DART_SUPPORT )
@@ -99,7 +97,7 @@ if ( DART_SUPPORT )
 endif ( DART_SUPPORT )
 
 if ( LIBSNDFILE_SUPPORT )
-  include_directories ( ${LIBSNDFILE_INCLUDEDIR} ${LIBSNDFILE_INCLUDE_DIRS} )
+  include_directories ( ${LIBSNDFILE_INCLUDE_DIRS} )
 endif ( LIBSNDFILE_SUPPORT )
 
 if ( MIDISHARE_SUPPORT )
@@ -229,21 +227,13 @@ generate_product_version(
 endif ( WIN32 AND NOT MINGW )
 
 link_directories (
-    ${GLIB_LIBDIR}
     ${GLIB_LIBRARY_DIRS}
-    ${LASH_LIBDIR}
     ${LASH_LIBRARY_DIRS}
-    ${JACK_LIBDIR}
     ${JACK_LIBRARY_DIRS}
-    ${ALSA_LIBDIR}
     ${ALSA_LIBRARY_DIRS}
-    ${PULSE_LIBDIR}
     ${PULSE_LIBRARY_DIRS}
-    ${PORTAUDIO_LIBDIR}
     ${PORTAUDIO_LIBRARY_DIRS}
-    ${LIBSNDFILE_LIBDIR}
     ${LIBSNDFILE_LIBRARY_DIRS}
-    ${DBUS_LIBDIR}
     ${DBUS_LIBRARY_DIRS}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,17 +226,6 @@ generate_product_version(
 )
 endif ( WIN32 AND NOT MINGW )
 
-link_directories (
-    ${GLIB_LIBRARY_DIRS}
-    ${LASH_LIBRARY_DIRS}
-    ${JACK_LIBRARY_DIRS}
-    ${ALSA_LIBRARY_DIRS}
-    ${PULSE_LIBRARY_DIRS}
-    ${PORTAUDIO_LIBRARY_DIRS}
-    ${LIBSNDFILE_LIBRARY_DIRS}
-    ${DBUS_LIBRARY_DIRS}
-)
-
 add_library ( libfluidsynth-OBJ OBJECT
     ${config_SOURCES}
     ${fluid_alsa_SOURCES}

--- a/test/README.md
+++ b/test/README.md
@@ -16,6 +16,5 @@ To add a unit test just duplicate an existing one, give it a unique name and upd
 * adding a call to `ADD_FLUID_TEST()` and
 * a dependency to the custom `check` target.
 
-Make sure you call cmake with `-Denable-tests=1` to build and execute the tests via `make check`. Unit
-tests should use the `VintageDreamsWaves-v2.sf2` as test soundfont. Use the `TEST_SOUNDFONT` macro to
-access it.
+Execute the tests via `make check`. Unit tests should use the `VintageDreamsWaves-v2.sf2` as test soundfont.
+Use the `TEST_SOUNDFONT` macro to access it.


### PR DESCRIPTION
Always build unit test when explicitly requested by the user via `make check`. Removes the hackish `-Denable-tests=1` cmake flag, as `BUILD_SHARED_LIBS` is not modified anymore. Instead libfluidsynth is built as OBJECT library. The object files are then used to build libfluidsynth.[so|a] and linked directly against unit test to allow by passing visibility control and testing internal/private functions, etc.

Fixes and enables building unit tests on macosx and win32.

Also removes `<PREFIX>_INCLUDEDIR` and `<PREFIX>_LIBDIR` variables, as they are redundant and werent correctly usded either if multiple arguments are passed to `pkg_check_modules()` according to cmake docs.