### PR TITLE
Implement fluid_get_userconf() on windows

### DIFF
--- a/doc/fluidsynth-v20-devdoc.txt
+++ b/doc/fluidsynth-v20-devdoc.txt
@@ -81,6 +81,7 @@ FluidSynths major version was bumped. The API was reworked, deprecated functions
 - rename chorus getters to match naming conventions: fluid_synth_get_chorus_speed() and fluid_synth_get_chorus_depth()
 - fluid_synth_remove_sfont() returns FLUID_OK or FLUID_FAILED
 - introduce a separate data type for sequencer client IDs: #fluid_seq_id_t
+- fluid_get_userconf() has been implemented for Windows
 
 <strong>New Features and API additions:</strong>
 

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -623,22 +623,27 @@ fluid_source(fluid_cmd_handler_t *handler, const char *filename)
 char *
 fluid_get_userconf(char *buf, int len)
 {
-#if defined(WIN32) || defined(MACOS9)
-    return NULL;
-#else
-    char *home = getenv("HOME");
-
+    const char *home = NULL;
+    const char *config_file;
+#if defined(WIN32)
+    home = getenv("USERPROFILE");
+    config_file = "\\fluidsynth.ini";
+    
+#elif !defined(MACOS9)
+    home = getenv("HOME");
+    config_file = "/.fluidsynth";
+    
+#endif
+    
     if(home == NULL)
     {
         return NULL;
     }
     else
     {
-        FLUID_SNPRINTF(buf, len, "%s/.fluidsynth", home);
+        FLUID_SNPRINTF(buf, len, "%s%s", home, config_file);
         return buf;
     }
-
-#endif
 }
 
 /**

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -627,7 +627,7 @@ fluid_get_userconf(char *buf, int len)
     const char *config_file;
 #if defined(WIN32)
     home = getenv("USERPROFILE");
-    config_file = "\\fluidsynth.ini";
+    config_file = "\\fluidsynth.cfg";
     
 #elif !defined(MACOS9)
     home = getenv("HOME");


### PR DESCRIPTION
Suggests to implement `fluid_get_userconf()` on win32 starting with fluidsynth 2.0 to point to `%userprofile%\\fluidsynth.ini`. Not sure why it was avoided to implement. At least some user complained on the mailing list a couple of months ago.

@jjceresa Are you fine with this?