### PR TITLE
Simplify fluid_mod_get_xxx_value() signature.

### DIFF
--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -164,10 +164,10 @@ static fluid_real_t
 fluid_mod_get_source_value(const unsigned char mod_src,
                            const unsigned char mod_flags,
                            fluid_real_t *range,
-                           const fluid_channel_t *chan,
                            const fluid_voice_t *voice
                           )
 {
+    const fluid_channel_t *chan = voice->channel;
     fluid_real_t val;
 
     if(mod_flags & FLUID_MOD_CC)
@@ -367,17 +367,12 @@ fluid_mod_transform_source_value(fluid_real_t val, unsigned char mod_flags, cons
  * fluid_mod_get_value
  */
 fluid_real_t
-fluid_mod_get_value(fluid_mod_t *mod, fluid_channel_t *chan, fluid_voice_t *voice)
+fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice)
 {
     extern fluid_mod_t default_vel2filter_mod;
 
     fluid_real_t v1 = 0.0, v2 = 1.0;
     fluid_real_t range1 = 127.0, range2 = 127.0;
-
-    if(chan == NULL)
-    {
-        return 0.0f;
-    }
 
     /* 'special treatment' for default controller
      *
@@ -418,7 +413,8 @@ fluid_mod_get_value(fluid_mod_t *mod, fluid_channel_t *chan, fluid_voice_t *voic
     /* get the initial value of the first source */
     if(mod->src1 > 0)
     {
-        v1 = fluid_mod_get_source_value(mod->src1, mod->flags1, &range1, chan, voice);
+//        v1 = fluid_mod_get_source_value(mod->src1, mod->flags1, &range1, chan, voice);
+        v1 = fluid_mod_get_source_value(mod->src1, mod->flags1, &range1, voice);
 
         /* transform the input value */
         v1 = fluid_mod_transform_source_value(v1, mod->flags1, range1);
@@ -437,7 +433,8 @@ fluid_mod_get_value(fluid_mod_t *mod, fluid_channel_t *chan, fluid_voice_t *voic
     /* get the second input source */
     if(mod->src2 > 0)
     {
-        v2 = fluid_mod_get_source_value(mod->src2, mod->flags2, &range2, chan, voice);
+//        v2 = fluid_mod_get_source_value(mod->src2, mod->flags2, &range2, chan, voice);
+        v2 = fluid_mod_get_source_value(mod->src2, mod->flags2, &range2, voice);
 
         /* transform the second input value */
         v2 = fluid_mod_transform_source_value(v2, mod->flags2, range2);

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -413,7 +413,6 @@ fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice)
     /* get the initial value of the first source */
     if(mod->src1 > 0)
     {
-//        v1 = fluid_mod_get_source_value(mod->src1, mod->flags1, &range1, chan, voice);
         v1 = fluid_mod_get_source_value(mod->src1, mod->flags1, &range1, voice);
 
         /* transform the input value */
@@ -433,7 +432,6 @@ fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice)
     /* get the second input source */
     if(mod->src2 > 0)
     {
-//        v2 = fluid_mod_get_source_value(mod->src2, mod->flags2, &range2, chan, voice);
         v2 = fluid_mod_get_source_value(mod->src2, mod->flags2, &range2, voice);
 
         /* transform the second input value */

--- a/src/synth/fluid_mod.h
+++ b/src/synth/fluid_mod.h
@@ -43,7 +43,7 @@ struct _fluid_mod_t
     fluid_mod_t *next;
 };
 
-fluid_real_t fluid_mod_get_value(fluid_mod_t *mod, fluid_channel_t *chan, fluid_voice_t *voice);
+fluid_real_t fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice);
 
 #ifdef DEBUG
 void fluid_dump_modulator(fluid_mod_t *mod);

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -612,7 +612,7 @@ fluid_voice_calculate_runtime_synthesis_parameters(fluid_voice_t *voice)
     for(i = 0; i < voice->mod_count; i++)
     {
         fluid_mod_t *mod = &voice->mod[i];
-        fluid_real_t modval = fluid_mod_get_value(mod, voice->channel, voice);
+        fluid_real_t modval = fluid_mod_get_value(mod, voice);
         int dest_gen_index = mod->dest;
         fluid_gen_t *dest_gen = &voice->gen[dest_gen_index];
         dest_gen->mod += modval;
@@ -1202,7 +1202,7 @@ int fluid_voice_modulate(fluid_voice_t *voice, int cc, int ctrl)
             {
                 if(fluid_mod_has_dest(&voice->mod[k], gen))
                 {
-                    modval += fluid_mod_get_value(&voice->mod[k], voice->channel, voice);
+                    modval += fluid_mod_get_value(&voice->mod[k], voice);
                 }
             }
 
@@ -1251,7 +1251,7 @@ int fluid_voice_modulate_all(fluid_voice_t *voice)
         {
             if(fluid_mod_has_dest(&voice->mod[k], gen))
             {
-                modval += fluid_mod_get_value(&voice->mod[k], voice->channel, voice);
+                modval += fluid_mod_get_value(&voice->mod[k], voice);
             }
         }
 
@@ -1732,7 +1732,7 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t *voice)
                     || (mod->src2 == FLUID_MOD_PITCHWHEEL)))
         {
 
-            fluid_real_t current_val = fluid_mod_get_value(mod, voice->channel, voice);
+            fluid_real_t current_val = fluid_mod_get_value(mod, voice);
             fluid_real_t v = fabs(mod->amount);
 
             if((mod->src1 == FLUID_MOD_PITCHWHEEL)


### PR DESCRIPTION
For both `fluid_mod_get_source_value() `and `fluid_mod_get_value()` , `fluid_channel_t` parameter have been removed.