### PR TITLE
Fix the sfload_mem example to actually read back the pointer address

### DIFF
--- a/doc/fluidsynth_sfload_mem.c
+++ b/doc/fluidsynth_sfload_mem.c
@@ -19,14 +19,13 @@ void *my_open(const char *filename)
         return NULL;
     }
 
-    scanf("&%p", &p);
+    sscanf(filename, "&%p", &p);
     return p;
 }
 
 int my_read(void *buf, int count, void *handle)
 {
-    // not yet implemented
-    memset(buf, 0, count);
+    // NYI
     return FLUID_OK;
 }
 


### PR DESCRIPTION
Almost a year later (sorry about that) from my sfload_mem functionality request, I have finally got around to use it with the 2.0 release.
This is just something minor I noticed: scanf reads from stdin, but in this case we need sscanf since we have to read back the pointer address from the "abused filename".

I was tempted to leave useful indications on the other routines but if anyone needs those callbacks they probably know what they are doing anyway.

For the record, a working implementation can be found [here](https://github.com/vgmtrans/vgmtrans/blob/22251c4f73ec3446ac02934b2fbc6ac5815fb744/src/ui/qt/MusicPlayer.h#L56)