### PR TITLE
Avoid use of C++ reserved keyword in variables

### DIFF
--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -28,7 +28,7 @@
 typedef struct _fluid_audriver_definition_t
 {
     const char *name;
-    fluid_audio_driver_t *(*new)(fluid_settings_t *settings, fluid_synth_t *synth);
+    fluid_audio_driver_t *(*new1)(fluid_settings_t *settings, fluid_synth_t *synth);
     fluid_audio_driver_t *(*new2)(fluid_settings_t *settings,
                                   fluid_audio_func_t func,
                                   void *data);
@@ -294,7 +294,7 @@ new_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 
     if(def)
     {
-        fluid_audio_driver_t *driver = (*def->new)(settings, synth);
+        fluid_audio_driver_t *driver = (*def->new1)(settings, synth);
 
         if(driver)
         {


### PR DESCRIPTION
If it is possible, I would like to suggest to not use the 'new' reserved keyword in this way: hopefully this structure is used only internally, so it is not too difficut to fix it.