### PR TITLE
Fix fluid log

### DIFF
--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -117,7 +117,7 @@ new_fluid_sequencer2(int use_system_timer)
 
     if(seq == NULL)
     {
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         return NULL;
     }
 
@@ -132,7 +132,7 @@ new_fluid_sequencer2(int use_system_timer)
     if(-1 == _fluid_seq_queue_init(seq, FLUID_SEQUENCER_EVENTS_MAX))
     {
         FLUID_FREE(seq);
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         return NULL;
     }
 
@@ -144,7 +144,7 @@ new_fluid_sequencer2(int use_system_timer)
     {
         _fluid_seq_queue_end(seq);
         FLUID_FREE(seq);
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         return NULL;
     }
 
@@ -297,7 +297,7 @@ fluid_sequencer_register_client(fluid_sequencer_t *seq, const char *name,
 
     if(client == NULL)
     {
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         return FLUID_FAILED;
     }
 
@@ -305,7 +305,7 @@ fluid_sequencer_register_client(fluid_sequencer_t *seq, const char *name,
 
     if(nameCopy == NULL)
     {
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         FLUID_FREE(client);
         return FLUID_FAILED;
     }
@@ -575,7 +575,7 @@ fluid_sequencer_set_time_scale(fluid_sequencer_t *seq, double scale)
 {
     if(scale <= 0)
     {
-        fluid_log(FLUID_WARN, "sequencer: scale <= 0 : %f\n", scale);
+        FLUID_LOG(FLUID_WARN, "sequencer: scale <= 0 : %f\n", scale);
         return;
     }
 
@@ -722,7 +722,7 @@ _fluid_seq_queue_init(fluid_sequencer_t *seq, int maxEvents)
 
     if(seq->heap == NULL)
     {
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         return -1;
     }
 
@@ -801,7 +801,7 @@ _fluid_seq_queue_pre_insert(fluid_sequencer_t *seq, fluid_event_t *evt)
     if(evtentry == NULL)
     {
         /* should not happen */
-        fluid_log(FLUID_PANIC, "sequencer: no more free events\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: no more free events\n");
         return -1;
     }
 
@@ -839,7 +839,7 @@ _fluid_seq_queue_pre_remove(fluid_sequencer_t *seq, fluid_seq_id_t src, fluid_se
     if(evtentry == NULL)
     {
         /* should not happen */
-        fluid_log(FLUID_PANIC, "sequencer: no more free events\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: no more free events\n");
         return;
     }
 

--- a/src/midi/fluid_seqbind.c
+++ b/src/midi/fluid_seqbind.c
@@ -108,7 +108,7 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
 
     if(seqbind == NULL)
     {
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         return FLUID_FAILED;
     }
 
@@ -125,7 +125,7 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
 
         if(seqbind->sample_timer == NULL)
         {
-            fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+            FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
             delete_fluid_seqbind(seqbind);
             return FLUID_FAILED;
         }
@@ -359,5 +359,3 @@ fluid_sequencer_add_midi_event_to_buffer(void *data, fluid_midi_event_t *event)
     /* Schedule for sending at next call to fluid_sequencer_process */
     return fluid_sequencer_send_at(seq, &evt, 0, 0);
 }
-
-

--- a/src/rvoice/fluid_chorus.c
+++ b/src/rvoice/fluid_chorus.c
@@ -149,7 +149,7 @@ new_fluid_chorus(fluid_real_t sample_rate)
 
     if(chorus == NULL)
     {
-        fluid_log(FLUID_PANIC, "chorus: Out of memory");
+        FLUID_LOG(FLUID_PANIC, "chorus: Out of memory");
         return NULL;
     }
 
@@ -191,7 +191,7 @@ new_fluid_chorus(fluid_real_t sample_rate)
 
     if(chorus->lookup_tab == NULL)
     {
-        fluid_log(FLUID_PANIC, "chorus: Out of memory");
+        FLUID_LOG(FLUID_PANIC, "chorus: Out of memory");
         goto error_recovery;
     }
 
@@ -201,7 +201,7 @@ new_fluid_chorus(fluid_real_t sample_rate)
 
     if(chorus->chorusbuf == NULL)
     {
-        fluid_log(FLUID_PANIC, "chorus: Out of memory");
+        FLUID_LOG(FLUID_PANIC, "chorus: Out of memory");
         goto error_recovery;
     }
 
@@ -293,32 +293,32 @@ fluid_chorus_set(fluid_chorus_t *chorus, int set, int nr, fluid_real_t level,
 
     if(chorus->number_blocks < 0)
     {
-        fluid_log(FLUID_WARN, "chorus: number blocks must be >=0! Setting value to 0.");
+        FLUID_LOG(FLUID_WARN, "chorus: number blocks must be >=0! Setting value to 0.");
         chorus->number_blocks = 0;
     }
     else if(chorus->number_blocks > MAX_CHORUS)
     {
-        fluid_log(FLUID_WARN, "chorus: number blocks larger than max. allowed! Setting value to %d.",
+        FLUID_LOG(FLUID_WARN, "chorus: number blocks larger than max. allowed! Setting value to %d.",
                   MAX_CHORUS);
         chorus->number_blocks = MAX_CHORUS;
     }
 
     if(chorus->speed_Hz < MIN_SPEED_HZ)
     {
-        fluid_log(FLUID_WARN, "chorus: speed is too low (min %f)! Setting value to min.",
+        FLUID_LOG(FLUID_WARN, "chorus: speed is too low (min %f)! Setting value to min.",
                   (double) MIN_SPEED_HZ);
         chorus->speed_Hz = MIN_SPEED_HZ;
     }
     else if(chorus->speed_Hz > MAX_SPEED_HZ)
     {
-        fluid_log(FLUID_WARN, "chorus: speed must be below %f Hz! Setting value to max.",
+        FLUID_LOG(FLUID_WARN, "chorus: speed must be below %f Hz! Setting value to max.",
                   (double) MAX_SPEED_HZ);
         chorus->speed_Hz = MAX_SPEED_HZ;
     }
 
     if(chorus->depth_ms < 0.0)
     {
-        fluid_log(FLUID_WARN, "chorus: depth must be positive! Setting value to 0.");
+        FLUID_LOG(FLUID_WARN, "chorus: depth must be positive! Setting value to 0.");
         chorus->depth_ms = 0.0;
     }
 
@@ -326,12 +326,12 @@ fluid_chorus_set(fluid_chorus_t *chorus, int set, int nr, fluid_real_t level,
 
     if(chorus->level < 0.0)
     {
-        fluid_log(FLUID_WARN, "chorus: level must be positive! Setting value to 0.");
+        FLUID_LOG(FLUID_WARN, "chorus: level must be positive! Setting value to 0.");
         chorus->level = 0.0;
     }
     else if(chorus->level > 10)
     {
-        fluid_log(FLUID_WARN, "chorus: level must be < 10. A reasonable level is << 1! "
+        FLUID_LOG(FLUID_WARN, "chorus: level must be < 10. A reasonable level is << 1! "
                   "Setting it to 0.1.");
         chorus->level = 0.1;
     }
@@ -346,7 +346,7 @@ fluid_chorus_set(fluid_chorus_t *chorus, int set, int nr, fluid_real_t level,
 
     if(modulation_depth_samples > MAX_SAMPLES)
     {
-        fluid_log(FLUID_WARN, "chorus: Too high depth. Setting it to max (%d).", MAX_SAMPLES);
+        FLUID_LOG(FLUID_WARN, "chorus: Too high depth. Setting it to max (%d).", MAX_SAMPLES);
         modulation_depth_samples = MAX_SAMPLES;
         // set depth to maximum to avoid spamming console with above warning
         chorus->depth_ms = (modulation_depth_samples * 1000) / chorus->sample_rate;
@@ -356,7 +356,7 @@ fluid_chorus_set(fluid_chorus_t *chorus, int set, int nr, fluid_real_t level,
     switch(chorus->type)
     {
     default:
-        fluid_log(FLUID_WARN, "chorus: Unknown modulation type. Using sinewave.");
+        FLUID_LOG(FLUID_WARN, "chorus: Unknown modulation type. Using sinewave.");
         chorus->type = FLUID_CHORUS_MOD_SINE;
         /* fall-through */
         

--- a/src/synth/fluid_event.c
+++ b/src/synth/fluid_event.c
@@ -62,7 +62,7 @@ new_fluid_event()
 
     if(evt == NULL)
     {
-        fluid_log(FLUID_PANIC, "event: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "event: Out of memory\n");
         return NULL;
     }
 
@@ -751,7 +751,7 @@ _fluid_evt_heap_init(int nbEvents)
 
     if(heap == NULL)
     {
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         return NULL;
     }
 
@@ -782,7 +782,7 @@ _fluid_evt_heap_init(int nbEvents)
 
     if(heap == NULL)
     {
-        fluid_log(FLUID_PANIC, "sequencer: Out of memory\n");
+        FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
         return NULL;
     }
 

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -638,4 +638,22 @@ static FLUID_INLINE void *fluid_align_ptr(const void *ptr, unsigned int alignmen
 
 #define FLUID_DEFAULT_ALIGNMENT (64U)
 
+/* For people who wants to strip a bit the size of the binary, it is
+ * possible to reduce the size of the executable by modifing the content
+ * of the FLUID_LOG macro. In this way, you can get a smaller file without
+ * performance costs, at the price of loosing the logging messages.
+ * Depending on the C compiler, on C99 and greater it will use vararg
+ * support into the preprocessor, while on older it will use and empty
+ * inline function that will be removed by the code optimizer.
+ */
+#if 0
+#if defined(__STDC__) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define FLUID_LOG(...)
+#else
+static FLUID_INLINE void FLUID_LOG(int level, const char *fmt, ...) {}
+#endif
+#else
+#define FLUID_LOG       fluid_log
+#endif
+
 #endif /* _FLUID_SYS_H */

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -638,22 +638,4 @@ static FLUID_INLINE void *fluid_align_ptr(const void *ptr, unsigned int alignmen
 
 #define FLUID_DEFAULT_ALIGNMENT (64U)
 
-/* For people who wants to strip a bit the size of the binary, it is
- * possible to reduce the size of the executable by modifing the content
- * of the FLUID_LOG macro. In this way, you can get a smaller file without
- * performance costs, at the price of loosing the logging messages.
- * Depending on the C compiler, on C99 and greater it will use vararg
- * support into the preprocessor, while on older it will use and empty
- * inline function that will be removed by the code optimizer.
- */
-#if 0
-#if defined(__STDC__) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#define FLUID_LOG(...)
-#else
-static FLUID_INLINE void FLUID_LOG(int level, const char *fmt, ...) {}
-#endif
-#else
-#define FLUID_LOG       fluid_log
-#endif
-
 #endif /* _FLUID_SYS_H */

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -322,8 +322,6 @@ do { strncpy(_dst,_src,_n); \
 #define FLUID_FLUSH()                fflush(stdout)
 #endif
 
-#define FLUID_LOG                    fluid_log
-
 #ifndef M_PI
 #define M_PI 3.1415926535897932384626433832795
 #endif

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -322,10 +322,10 @@ do { strncpy(_dst,_src,_n); \
 #define FLUID_FLUSH()                fflush(stdout)
 #endif
 
-/* For people who wants to strip a bit the size of the binary, it is
- * possible to reduce the size of the executable by modifing the content
- * of the FLUID_LOG macro. In this way, you can get a smaller file without
- * performance costs, at the price of loosing the logging messages.
+/* People who want to reduce the size of the may do this by entirely
+ * removing the logging system. This will cause all log messages to
+ * be discarded at compile time, allowing to save about 80 KiB for
+ * the compiled binary.
  */
 #if 0
 #define FLUID_LOG                    (void)sizeof

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -322,6 +322,17 @@ do { strncpy(_dst,_src,_n); \
 #define FLUID_FLUSH()                fflush(stdout)
 #endif
 
+/* For people who wants to strip a bit the size of the binary, it is
+ * possible to reduce the size of the executable by modifing the content
+ * of the FLUID_LOG macro. In this way, you can get a smaller file without
+ * performance costs, at the price of loosing the logging messages.
+ */
+#if 0
+#define FLUID_LOG                    (void)sizeof
+#else
+#define FLUID_LOG                    fluid_log
+#endif
+
 #ifndef M_PI
 #define M_PI 3.1415926535897932384626433832795
 #endif


### PR DESCRIPTION
For people who wants to strip a bit the size of the binary, it is possible to reduce the size of the executable by commenting the content of the FLUID_LOG macro. However, I discovered that there are some points in the code that are calling directly the function fluid_log() instead of using FLUID_LOG macro. So, this patch fixes the sources that still need to replace fluid_log() with FLUID_LOG macro.
