### PR TITLE
Check if at least a driver is supported/enabled (2).

### DIFF
--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -21,6 +21,18 @@
 #include "fluid_adriver.h"
 #include "fluid_settings.h"
 
+#undef FLUID_AOUT_SUPPORT
+
+#if JACK_SUPPORT || ALSA_SUPPORT || OSS_SUPPORT || PULSE_SUPPORT || \
+    COREAUDIO_SUPPORT || DSOUND_SUPPORT || PORTAUDIO_SUPPORT || \
+    SNDMAN_SUPPORT || DART_SUPPORT || AUFILE_SUPPORT
+/* At least an output driver exits */
+#define FLUID_AOUT_SUPPORT  1
+#endif
+
+
+#ifdef FLUID_AOUT_SUPPORT
+
 /*
  * fluid_adriver_definition_t
  */
@@ -148,9 +160,13 @@ static const fluid_audriver_definition_t fluid_audio_drivers[] =
 
 static uint8_t fluid_adriver_disable_mask[(FLUID_N_ELEMENTS(fluid_audio_drivers) + 7) / 8] = {0};
 
+#endif /* FLUID_AOUT_SUPPORT */
+
 void fluid_audio_driver_settings(fluid_settings_t *settings)
 {
+#ifdef FLUID_AOUT_SUPPORT
     unsigned int i;
+#endif
 
     fluid_settings_register_str(settings, "audio.sample-format", "16bits", 0);
     fluid_settings_add_option(settings, "audio.sample-format", "16bits");
@@ -227,6 +243,7 @@ void fluid_audio_driver_settings(fluid_settings_t *settings)
     fluid_settings_add_option(settings, "audio.driver", "file");
 #endif
 
+#ifdef FLUID_AOUT_SUPPORT
     for(i = 0; i < FLUID_N_ELEMENTS(fluid_audio_drivers); i++)
     {
         if(fluid_audio_drivers[i].settings != NULL &&
@@ -235,7 +252,10 @@ void fluid_audio_driver_settings(fluid_settings_t *settings)
             fluid_audio_drivers[i].settings(settings);
         }
     }
+#endif
 }
+
+#ifdef FLUID_AOUT_SUPPORT
 
 static const fluid_audriver_definition_t *
 find_fluid_audio_driver(fluid_settings_t *settings)
@@ -277,6 +297,8 @@ find_fluid_audio_driver(fluid_settings_t *settings)
     return NULL;
 }
 
+#endif /* FLUID_AOUT_SUPPORT */
+
 /**
  * Create a new audio driver.
  * @param settings Configuration settings used to select and create the audio
@@ -290,6 +312,7 @@ find_fluid_audio_driver(fluid_settings_t *settings)
 fluid_audio_driver_t *
 new_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 {
+#ifdef FLUID_AOUT_SUPPORT
     const fluid_audriver_definition_t *def = find_fluid_audio_driver(settings);
 
     if(def)
@@ -303,7 +326,7 @@ new_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 
         return driver;
     }
-
+#endif
     return NULL;
 }
 
@@ -324,6 +347,7 @@ new_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 fluid_audio_driver_t *
 new_fluid_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
 {
+#ifdef FLUID_AOUT_SUPPORT
     const fluid_audriver_definition_t *def = find_fluid_audio_driver(settings);
 
     if(def)
@@ -346,7 +370,7 @@ new_fluid_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, voi
 
         return driver;
     }
-
+#endif
     return NULL;
 }
 
@@ -359,6 +383,7 @@ new_fluid_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, voi
 void
 delete_fluid_audio_driver(fluid_audio_driver_t *driver)
 {
+#ifdef FLUID_AOUT_SUPPORT
     unsigned int i;
     fluid_return_if_fail(driver != NULL);
 
@@ -371,6 +396,7 @@ delete_fluid_audio_driver(fluid_audio_driver_t *driver)
             return;
         }
     }
+#endif
 }
 
 
@@ -400,6 +426,7 @@ delete_fluid_audio_driver(fluid_audio_driver_t *driver)
  */
 int fluid_audio_driver_register(const char **adrivers)
 {
+#ifdef FLUID_AOUT_SUPPORT
     unsigned int i;
     uint8_t      disable_mask[FLUID_N_ELEMENTS(fluid_adriver_disable_mask)];
 
@@ -444,4 +471,7 @@ int fluid_audio_driver_register(const char **adrivers)
     FLUID_MEMCPY(fluid_adriver_disable_mask, disable_mask, sizeof(disable_mask));
 
     return FLUID_OK;
+#else
+    return FLUID_FAILED;
+#endif
 }

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -472,6 +472,12 @@ int fluid_audio_driver_register(const char **adrivers)
 
     return FLUID_OK;
 #else
+    /* Return FLUID_OK if the user passed NULL or an empty list */
+    if(adrivers == NULL || (adrivers && adrivers[0] == NULL))
+    {
+        return FLUID_OK;
+    }
+
     return FLUID_FAILED;
 #endif
 }

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -166,6 +166,7 @@ void fluid_audio_driver_settings(fluid_settings_t *settings)
 {
 #ifdef FLUID_AOUT_SUPPORT
     unsigned int i;
+    const char *def_name = NULL;
 #endif
 
     fluid_settings_register_str(settings, "audio.sample-format", "16bits", 0);
@@ -186,72 +187,27 @@ void fluid_audio_driver_settings(fluid_settings_t *settings)
     fluid_settings_register_int(settings, "audio.realtime-prio",
                                 FLUID_DEFAULT_AUDIO_RT_PRIO, 0, 99, 0);
 
-    /* Set the default driver */
-#if JACK_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "jack", 0);
-#elif ALSA_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "alsa", 0);
-#elif PULSE_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "pulseaudio", 0);
-#elif OSS_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "oss", 0);
-#elif COREAUDIO_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "coreaudio", 0);
-#elif DSOUND_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "dsound", 0);
-#elif SNDMAN_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "sndman", 0);
-#elif PORTAUDIO_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "portaudio", 0);
-#elif DART_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "dart", 0);
-#elif AUFILE_SUPPORT
-    fluid_settings_register_str(settings, "audio.driver", "file", 0);
-#else
-    fluid_settings_register_str(settings, "audio.driver", "", 0);
-#endif
-
-    /* Add all drivers to the list of options */
-#if PULSE_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "pulseaudio");
-#endif
-#if ALSA_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "alsa");
-#endif
-#if OSS_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "oss");
-#endif
-#if COREAUDIO_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "coreaudio");
-#endif
-#if DSOUND_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "dsound");
-#endif
-#if SNDMAN_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "sndman");
-#endif
-#if PORTAUDIO_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "portaudio");
-#endif
-#if JACK_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "jack");
-#endif
-#if DART_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "dart");
-#endif
-#if AUFILE_SUPPORT
-    fluid_settings_add_option(settings, "audio.driver", "file");
-#endif
-
 #ifdef FLUID_AOUT_SUPPORT
     for(i = 0; i < FLUID_N_ELEMENTS(fluid_audio_drivers); i++)
     {
+        /* Select the default driver */
+        if (def_name == NULL)
+        {
+            def_name = fluid_audio_drivers[i].name;
+        }
+    
+        /* Add the driver to the list of options */
+        fluid_settings_add_option(settings, "audio.driver", fluid_audio_drivers[i].name);
+
         if(fluid_audio_drivers[i].settings != NULL &&
                 IS_AUDIO_DRIVER_ENABLED(fluid_adriver_disable_mask, i))
         {
             fluid_audio_drivers[i].settings(settings);
         }
     }
+
+    /* Set the default driver */
+    fluid_settings_register_str(settings, "audio.driver", def_name ? def_name : "", 0);
 #endif
 }
 


### PR DESCRIPTION
I had noticed that it is possible that FluidSynth does not compile if none of the audio out drivers is supported. I would like to suggest introduce a check, in the same manner it has been done for the MIDI input drivers. Actually, the absence of an audio driver does not mean that FluidSynth is not usable, it will always act as a rendering engine while the user will generate the samples with fluid_synth_write_float()/fluid_synth_write_s16() and play them with the audio API provided by his operating system.

EDIT: this PR improves #441 by returning FLUID_FAILED into function fluid_audio_driver_register(), if the library cannot provide a supported audio out driver.