### PR TITLE
Win driver selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ option ( enable-libsndfile "compile libsndfile support (if it is available)" on 
 option ( enable-midishare "compile MidiShare support (if it is available)" on )
 option ( enable-network "enable network support (requires BSD sockets)" on )
 option ( enable-oss "compile OSS support (if it is available)" on )
+option ( enable-dsound "compile DirectSound support (if it is available)" on )
+option ( enable-winmidi "compile Windows MIDI support (if it is available)" on )
 option ( enable-pkgconfig "use pkg-config to locate fluidsynth's (mostly optional) dependencies" on )
 option ( enable-pulseaudio "compile PulseAudio support (if it is available)" on )
 option ( enable-readline "compile readline lib line editing (if it is available)" on )
@@ -190,15 +192,34 @@ endif ( CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE
 # Windows
 unset ( WINDOWS_SUPPORT CACHE )
 unset ( WINDOWS_LIBS CACHE )
+unset ( DSOUND_SUPPORT CACHE )
+unset ( WINMIDI_SUPPORT CACHE )
 unset ( MINGW32 CACHE )
 if ( WIN32 )
   include ( CheckIncludeFiles )
+
+  # Check presence of MS include files
   check_include_file ( windows.h HAVE_WINDOWS_H )
   check_include_file ( io.h HAVE_IO_H )
   check_include_file ( dsound.h HAVE_DSOUND_H )
   check_include_files ( "windows.h;mmsystem.h" HAVE_MMSYSTEM_H )
+
   set ( WINDOWS_SUPPORT ${HAVE_WINDOWS_H} )
-  set ( WINDOWS_LIBS "dsound;winmm;ws2_32" )
+
+  if ( NETWORK_SUPPORT )
+    set ( WINDOWS_LIBS "${WINDOWS_LIBS};ws2_32" )
+  endif ( NETWORK_SUPPORT )
+
+  if ( enable-dsound AND HAVE_DSOUND_H )
+    set ( WINDOWS_LIBS "${WINDOWS_LIBS};dsound" )
+    set ( DSOUND_SUPPORT 1 )
+  endif ()
+
+  if ( enable-winmidi AND HAVE_MMSYSTEM_H )
+    set ( WINDOWS_LIBS "${WINDOWS_LIBS};winmm" )
+    set ( WINMIDI_SUPPORT 1 )
+  endif ()
+
   set ( LIBFLUID_CPPFLAGS "-DFLUIDSYNTH_DLL_EXPORTS" )
   set ( FLUID_CPPFLAGS "-DFLUIDSYNTH_NOT_A_DLL" )
   if  ( MSVC )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ if ( WIN32 )
   # MinGW compiler (a Windows GCC port)
   if ( MINGW )
     set ( MINGW32 1 )
-    add_definitions ( -mms-bitfields )
+    add_compile_options ( -mms-bitfields )
   endif  ( MINGW )
 else ( WIN32 )
 # Check PThreads, but not in Windows

--- a/cmake_admin/VersionResource.rc
+++ b/cmake_admin/VersionResource.rc
@@ -1,5 +1,5 @@
 #include "VersionInfo.h"
-#include "winres.h"
+#include "winver.h"
 
 VS_VERSION_INFO VERSIONINFO
     FILEVERSION FILE_VERSION_RESOURCE

--- a/cmake_admin/report.cmake
+++ b/cmake_admin/report.cmake
@@ -74,6 +74,18 @@ else ( WINDOWS_SUPPORT )
   message ( "Windows:               no" )
 endif ( WINDOWS_SUPPORT )
 
+if ( DSOUND_SUPPORT )
+  message ( "DSound:                yes" )
+else ( DSOUND_SUPPORT )
+  message ( "DSound:                no" )
+endif ( DSOUND_SUPPORT )
+
+if ( WINMIDI_SUPPORT )
+  message ( "WinMidi support:       yes" )
+else ( WINMIDI_SUPPORT )
+  message ( "WinMidi support:       no" )
+endif ( WINMIDI_SUPPORT )
+
 if ( LADSPA_SUPPORT )
   message ( "LADSPA support:        yes" )
 else ( LADSPA_SUPPORT )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,9 +78,13 @@ if ( PORTAUDIO_SUPPORT )
   include_directories ( ${PORTAUDIO_INCLUDE_DIRS} )
 endif ( PORTAUDIO_SUPPORT )
 
-if ( WINDOWS_SUPPORT )
-  set ( fluid_windows_SOURCES drivers/fluid_dsound.c drivers/fluid_winmidi.c )
-endif ( WINDOWS_SUPPORT )
+if ( DSOUND_SUPPORT )
+  set ( fluid_dsound_SOURCES drivers/fluid_dsound.c )
+endif ( DSOUND_SUPPORT )
+
+if ( WINMIDI_SUPPORT )
+  set ( fluid_winmidi_SOURCES drivers/fluid_winmidi.c )
+endif ( WINMIDI_SUPPORT )
 
 if ( OSS_SUPPORT )
   set ( fluid_oss_SOURCES drivers/fluid_oss.c )
@@ -243,7 +247,8 @@ add_library ( libfluidsynth-OBJ OBJECT
     ${fluid_oss_SOURCES}
     ${fluid_portaudio_SOURCES}
     ${fluid_pulse_SOURCES}
-    ${fluid_windows_SOURCES}
+    ${fluid_dsound_SOURCES}
+    ${fluid_winmidi_SOURCES}
     ${libfluidsynth_SOURCES}
     ${public_HEADERS}
     ${public_main_HEADER}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -216,7 +216,7 @@ configure_file ( ${CMAKE_SOURCE_DIR}/include/fluidsynth/version.h.in
 configure_file ( ${CMAKE_SOURCE_DIR}/include/fluidsynth.cmake
                  ${public_main_HEADER} )
 
-if ( WIN32 AND NOT MINGW )
+if ( WIN32 )
 include(generate_product_version)
 generate_product_version(
     VersionFilesOutputVariable
@@ -231,7 +231,7 @@ generate_product_version(
     ORIGINAL_FILENAME "libfluidsynth.dll"
     FILE_DESCRIPTION "Fluidsynth"
 )
-endif ( WIN32 AND NOT MINGW )
+endif ( WIN32 )
 
 add_library ( libfluidsynth-OBJ OBJECT
     ${config_SOURCES}

--- a/src/config.cmake
+++ b/src/config.cmake
@@ -190,6 +190,12 @@
 /* Define to enable PulseAudio driver */
 #cmakedefine PULSE_SUPPORT @PULSE_SUPPORT@
 
+/* Define to enable DirectSound driver */
+#cmakedefine DSOUND_SUPPORT @DSOUND_SUPPORT@
+
+/* Define to enable Windows MIDI driver */
+#cmakedefine WINMIDI_SUPPORT @WINMIDI_SUPPORT@
+
 /* Define to 1 if you have the ANSI C header files. */
 #cmakedefine STDC_HEADERS @STDC_HEADERS@
 

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -137,8 +137,6 @@ typedef guint64  uint64_t;
 #include <ws2tcpip.h>	/* Provides also socklen_t */
 
 /* WIN32 special defines */
-#define DSOUND_SUPPORT 1
-#define WINMIDI_SUPPORT 1
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2


### PR DESCRIPTION
This PR allows to configure the Windows MIDI and the DirectSound driver and removed the hardcoded WINMIDI_SUPPORT and DSOUND_SUPPORT from the code.

During this fix, I also noticed that the VersionInfo manifest was not generated for MINGW. Actually, it generated an error when compiling with MINGW, but this happened because the "-mms-bitfields" option was introduced with add_definitions() instead of add_compile_options(). The add_definitions() command does not filter the options that are not supported by a particular tool. Indeed, it should not be used for that purpose. Instead, add_compile_options() does. The "-mms-bitfields" option is not recognized by WINDRES and so it failed. Fixing with add_compile_options() has resolved the problem on both MINGW and MSVC.