### PR TITLE
Optimize Travis and AppVeyor CI builds

### DIFF
--- a/.appveyor-vcpkg.yml
+++ b/.appveyor-vcpkg.yml
@@ -1,5 +1,4 @@
 image:
-  - Visual Studio 2015
   - Visual Studio 2017
 
 build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 image:
   - Visual Studio 2015
-  - Visual Studio 2017
 
 build:
   parallel: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,12 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.8
-    - llvm-toolchain-trusty-4.0
-    - llvm-toolchain-trusty-5.0
     - llvm-toolchain-trusty-6.0
     - llvm-toolchain-trusty-7
     packages:
     - g++-4.8
-    - g++-6
     - g++-7
     - g++-8
-    - clang-4.0
-    - clang-5.0
     - clang-6.0
     - clang-7
     - cmake-data
@@ -33,7 +28,6 @@ env:
     - CMAKE_FLAGS="-Denable-profiling=1"
     - CMAKE_FLAGS="-Denable-floats=1 -Denable-profiling=1"
     - CMAKE_FLAGS="-Denable-floats=0"
-    - CMAKE_FLAGS="-Denable-debug=1"
     - CMAKE_FLAGS="-Denable-trap-on-fpe=1"
     - CMAKE_FLAGS="-Denable-fpe-check=1"
     - CMAKE_FLAGS="-Denable-ipv6=0"
@@ -54,28 +48,17 @@ matrix:
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-
-    - os: linux
-      env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
         
     - os: linux
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+        - CMAKE_FLAGS="-Denable-debug=1"
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-
-    - os: linux
-      env:
-        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
-
-    - os: linux
-      env:
-        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
-
+        
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
@@ -86,7 +69,7 @@ matrix:
 
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio && brew link gettext; fi
     - eval "${MATRIX_EVAL}"
     
 before_script:
@@ -94,7 +77,7 @@ before_script:
     - mkdir build && cd build
     
 script:
-    - cmake -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} -Denable-portaudio=1 -Denable-ladspa=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1 ..
+    - cmake -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} -Denable-portaudio=1 -Denable-ladspa=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=0 ..
     - make -j4
     - make check
     - if [ $TRAVIS_OS_NAME = linux ]; then make install; fi # install only on linux, as CMAKE_INSTALL_PREFIX is ignored for frameworks on macosx and I cant tell whether that's correct or a bug.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ env:
     - CMAKE_FLAGS="-DBUILD_SHARED_LIBS=0"
 matrix:
   include:
+    - os: osx
+      osx_image: xcode10
+      env:
+        - MATRIX_EVAL="brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio && brew link gettext && CC=gcc-8 && CXX=g++-8"
+
     - os: linux
       addons:
         apt:
@@ -198,21 +203,6 @@ matrix:
             - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
-        
-    - os: osx
-      osx_image: xcode8
-      env:
-        - MATRIX_EVAL="brew install gcc5 glib gettext && brew link gettext && CC=gcc-5 && CXX=g++-5" # gettext should provide libintl, but doesnt work
-
-    - os: osx
-      osx_image: xcode8
-      env:
-        - MATRIX_EVAL="brew install gcc6 glib gettext && brew link gettext && CC=gcc-6 && CXX=g++-6"
-
-    - os: osx
-      osx_image: xcode8
-      env:
-        - MATRIX_EVAL="brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio && brew link gettext && CC=gcc-8 && CXX=g++-8"
 
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,29 +36,29 @@ matrix:
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && sudo apt-get install $CC"
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8 && sudo apt-get install $CC"
         - CMAKE_FLAGS="-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8 && sudo apt-get install $CC"
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0 && sudo apt-get install $CC"
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7 && sudo apt-get install $CC"
 
 before_install:
-    - eval "${MATRIX_EVAL}"
-    - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update && sudo apt-get $CC; else brew update; fi
+    - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install glib gettext libsndfile jack dbus-glib pulseaudio portaudio; fi # && brew link gettext
+    - eval "${MATRIX_EVAL}"
     
 before_script:
     - mkdir $HOME/fluidsynth_install/

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,48 +37,28 @@ matrix:
     - os: linux
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-      addons:
-        apt:
-          packages:
-          - g++-7
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
         - CMAKE_FLAGS="-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
-      addons:
-        apt:
-          packages:
-          - g++-8
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-      addons:
-        apt:
-          packages:
-          - clang-3.8
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
-      addons:
-        apt:
-          packages:
-          - clang-6.0
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
-      addons:
-        apt:
-          packages:
-          - clang-7
 
 before_install:
-    - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install glib gettext libsndfile jack dbus-glib pulseaudio portaudio; fi # && brew link gettext
     - eval "${MATRIX_EVAL}"
+    - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update && sudo apt-get $CC; else brew update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install glib gettext libsndfile jack dbus-glib pulseaudio portaudio; fi # && brew link gettext
     
 before_script:
     - mkdir $HOME/fluidsynth_install/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,211 +1,94 @@
 language: c
-#sudo: required
+
+os: linux
 dist: trusty
 env:
     - CMAKE_FLAGS="-Denable-profiling=1"
     - CMAKE_FLAGS="-Denable-floats=1 -Denable-profiling=1"
+    - CMAKE_FLAGS="-Denable-floats=0"
+    - CMAKE_FLAGS="-Denable-debug=1"
     - CMAKE_FLAGS="-Denable-trap-on-fpe=1"
     - CMAKE_FLAGS="-Denable-fpe-check=1"
     - CMAKE_FLAGS="-Denable-ipv6=0"
     - CMAKE_FLAGS="-Denable-network=0"
     - CMAKE_FLAGS="-Denable-aufile=0"
     - CMAKE_FLAGS="-DBUILD_SHARED_LIBS=0"
+    
+addons:
+apt:
+    sources:
+        - ubuntu-toolchain-r-test
+        - llvm-toolchain-precise-3.8
+        - llvm-toolchain-trusty-4.0
+        - llvm-toolchain-trusty-5.0
+        - llvm-toolchain-trusty-6.0
+        - llvm-toolchain-trusty-7
+    packages:
+        - g++-4.8
+        - g++-6
+        - g++-7
+        - g++-8
+        - clang-4.0
+        - clang-5.0
+        - clang-6.0
+        - clang-7
+        - cmake-data
+        - cmake
+        - libglib2.0-0
+        - libsndfile-dev
+        - libasound2-dev
+        - libjack-dev
+        - portaudio19-dev
+        - libpulse-dev
+        - libdbus-glib-1-dev
+        - ladspa-sdk
+    
 matrix:
   include:
     - os: osx
       osx_image: xcode10
       env:
-        - MATRIX_EVAL="brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio && brew link gettext && CC=gcc-8 && CXX=g++-8"
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.8
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - libsndfile-dev
-            - libasound2-dev
-            - libjack-dev
-            - portaudio19-dev
-            - libpulse-dev
-            - libdbus-glib-1-dev
-            - ladspa-sdk
       env:
-         - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
-         - CMAKE_FLAGS="-Denable-floats=1"
-         
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.8
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - libsndfile-dev
-            - libasound2-dev
-            - libjack-dev
-            - portaudio19-dev
-            - libpulse-dev
-            - libdbus-glib-1-dev
-            - ladspa-sdk
-      env:
-         - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
-         - CMAKE_FLAGS="-Denable-floats=0"
+        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
 
-    # works on Precise and Trusty
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - ladspa-sdk
-      env:
-         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-         - CMAKE_FLAGS="-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
-    # works on Precise and Trusty
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-
-    # works on Precise and Trusty
+        
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-8
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
-    # works on Precise and Trusty
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-          packages:
-            - clang-3.8
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - libsndfile-dev
-            - libasound2-dev
-            - libjack-dev
-            - portaudio19-dev
-            - libpulse-dev
-            - libdbus-glib-1-dev
-            - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
 
-    # works on Trusty
     - os: linux
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-4.0
-          packages:
-            - clang-4.0
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
 
-    # works on Trusty
     - os: linux
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 
-    # works on Trusty
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
-          packages:
-            - clang-6.0
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
-        
-    # works on Trusty
+
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
-          packages:
-            - clang-7
-            - cmake-data
-            - cmake
-            - libglib2.0-0
-            - ladspa-sdk
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
 
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio && brew link gettext; fi
     - eval "${MATRIX_EVAL}"
     
 before_script:
@@ -213,7 +96,7 @@ before_script:
     - mkdir build && cd build
     
 script:
-    - cmake -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} "-Denable-portaudio=1" "-Denable-ladspa=1" "-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1" ..
+    - cmake -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} -Denable-portaudio=1 -Denable-ladspa=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1 ..
     - make -j4
     - make check
     - if [ $TRAVIS_OS_NAME = linux ]; then make install; fi # install only on linux, as CMAKE_INSTALL_PREFIX is ignored for frameworks on macosx and I cant tell whether that's correct or a bug.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ addons:
     - llvm-toolchain-trusty-6.0
     - llvm-toolchain-trusty-7
     packages:
-    - g++-7
-    - g++-8
-    - clang-3.8
-    - clang-6.0
-    - clang-7
     - cmake-data
     - cmake
     - libglib2.0-0
@@ -42,23 +37,43 @@ matrix:
     - os: linux
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+      addons:
+        apt:
+          packages:
+          - g++-7
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
         - CMAKE_FLAGS="-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
+      addons:
+        apt:
+          packages:
+          - g++-8
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+      addons:
+        apt:
+          packages:
+          - clang-3.8
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+      addons:
+        apt:
+          packages:
+          - clang-6.0
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+      addons:
+        apt:
+          packages:
+          - clang-7
 
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     - llvm-toolchain-trusty-6.0
     - llvm-toolchain-trusty-7
     packages:
-    - g++-4.8
     - g++-7
     - g++-8
     - clang-6.0
@@ -41,10 +40,6 @@ matrix:
       osx_image: xcode10
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
-
-    - os: linux
-      env:
-        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
 
     - os: linux
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-trusty-3.8
     - llvm-toolchain-trusty-6.0
     - llvm-toolchain-trusty-7
     packages:
@@ -43,15 +42,16 @@ matrix:
     - os: linux
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-        
+
     - os: linux
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+        - CMAKE_FLAGS="-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
 
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-        
+
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
@@ -59,7 +59,6 @@ matrix:
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
-        - CMAKE_FLAGS="-Denable-debug=1"
 
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,24 +36,24 @@ matrix:
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && sudo apt-get install $CC"
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && sudo apt-get install gcc-7"
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8 && sudo apt-get install $CC"
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8 && sudo apt-get install gcc-8"
         - CMAKE_FLAGS="-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8 && sudo apt-get install $CC"
+        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8 && sudo apt-get install clang-3.8"
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0 && sudo apt-get install $CC"
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0 && sudo apt-get install clang-6.0"
 
     - os: linux
       env:
-        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7 && sudo apt-get install $CC"
+        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7 && sudo apt-get install clang-7"
 
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,34 @@
 language: c
-
 os: linux
 dist: trusty
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.8
+    - llvm-toolchain-trusty-4.0
+    - llvm-toolchain-trusty-5.0
+    - llvm-toolchain-trusty-6.0
+    - llvm-toolchain-trusty-7
+    packages:
+    - g++-4.8
+    - g++-6
+    - g++-7
+    - g++-8
+    - clang-4.0
+    - clang-5.0
+    - clang-6.0
+    - clang-7
+    - cmake-data
+    - cmake
+    - libglib2.0-0
+    - libsndfile-dev
+    - libasound2-dev
+    - libjack-dev
+    - portaudio19-dev
+    - libpulse-dev
+    - libdbus-glib-1-dev
+    - ladspa-sdk
 env:
     - CMAKE_FLAGS="-Denable-profiling=1"
     - CMAKE_FLAGS="-Denable-floats=1 -Denable-profiling=1"
@@ -13,36 +40,7 @@ env:
     - CMAKE_FLAGS="-Denable-network=0"
     - CMAKE_FLAGS="-Denable-aufile=0"
     - CMAKE_FLAGS="-DBUILD_SHARED_LIBS=0"
-    
-addons:
-apt:
-    sources:
-        - ubuntu-toolchain-r-test
-        - llvm-toolchain-precise-3.8
-        - llvm-toolchain-trusty-4.0
-        - llvm-toolchain-trusty-5.0
-        - llvm-toolchain-trusty-6.0
-        - llvm-toolchain-trusty-7
-    packages:
-        - g++-4.8
-        - g++-6
-        - g++-7
-        - g++-8
-        - clang-4.0
-        - clang-5.0
-        - clang-6.0
-        - clang-7
-        - cmake-data
-        - cmake
-        - libglib2.0-0
-        - libsndfile-dev
-        - libasound2-dev
-        - libjack-dev
-        - portaudio19-dev
-        - libpulse-dev
-        - libdbus-glib-1-dev
-        - ladspa-sdk
-    
+
 matrix:
   include:
     - os: osx
@@ -88,7 +86,7 @@ matrix:
 
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio && brew link gettext; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio; fi
     - eval "${MATRIX_EVAL}"
     
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.8
+    - llvm-toolchain-trusty-3.8
     - llvm-toolchain-trusty-6.0
     - llvm-toolchain-trusty-7
     packages:
     - g++-7
     - g++-8
+    - clang-3.8
     - clang-6.0
     - clang-7
     - cmake-data
@@ -38,8 +39,6 @@ matrix:
   include:
     - os: osx
       osx_image: xcode10
-      env:
-        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
       env:
@@ -48,7 +47,6 @@ matrix:
     - os: linux
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
-        - CMAKE_FLAGS="-Denable-debug=1"
 
     - os: linux
       env:
@@ -61,10 +59,11 @@ matrix:
     - os: linux
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+        - CMAKE_FLAGS="-Denable-debug=1"
 
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; else brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc glib gettext libsndfile jack dbus-glib pulseaudio portaudio && brew link gettext; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install glib gettext libsndfile jack dbus-glib pulseaudio portaudio; fi # && brew link gettext
     - eval "${MATRIX_EVAL}"
     
 before_script:


### PR DESCRIPTION

* cleanup unneeded compiler variations (now builds in 7 min rather than 13 min)
* Windows:
  * use VS2017 for vcpkg, VS2015 for manual build
* Linux:
  * install alsa, jack, pulse, portaudio, ladspa, libsndfile for all builds
* MacOSX: 
  * use AppleClang
  * reorder macosx build in between linux build, as macosx usually takes longer to build, allowing to make better use of build time (via pipelining)
  * switch to XCode10, enabling TravisCI to support CoreAudio and CoreMidi

