### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -144,7 +144,7 @@ fluid_audio_driver_t *
 new_fluid_core_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 {
     return new_fluid_core_audio_driver2(settings,
-                                        fluid_synth_process,
+                                        NULL,
                                         synth);
 }
 

--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -266,10 +266,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func
         }
     }
 
-    if(devname)
-    {
-        FLUID_FREE(devname);  /* free device name */
-    }
+    FLUID_FREE(devname);  /* free device name */
 
     dev->buffer_size = period_size * periods;
 
@@ -322,6 +319,12 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func
 
     dev->buffers[0] = FLUID_ARRAY(float, dev->buffer_size);
     dev->buffers[1] = FLUID_ARRAY(float, dev->buffer_size);
+    
+    if(dev->buffers[0] == NULL || dev->buffers[1] == NULL)
+    {
+        FLUID_LOG(FLUID_ERR, "Out of memory.");
+        goto error_recovery;
+    }
 
     // Initialize the audio unit
     status = AudioUnitInitialize(dev->outputUnit);

--- a/src/drivers/fluid_pulse.c
+++ b/src/drivers/fluid_pulse.c
@@ -176,7 +176,6 @@ new_fluid_pulse_audio_driver2(fluid_settings_t *settings,
     }
 
     buf = FLUID_ARRAY(float, period_size * 2);
-
     if(buf == NULL)
     {
         FLUID_LOG(FLUID_ERR, "Out of memory.");
@@ -196,29 +195,17 @@ new_fluid_pulse_audio_driver2(fluid_settings_t *settings,
         goto error_recovery;
     }
 
-    if(server)
-    {
-        FLUID_FREE(server);    /* -- free server string */
-    }
-
-    if(device)
-    {
-        FLUID_FREE(device);    /* -- free device string */
-    }
+    FLUID_FREE(server);    /* -- free server string */
+    FLUID_FREE(device);    /* -- free device string */
 
     return (fluid_audio_driver_t *) dev;
 
 error_recovery:
-
-    if(server)
-    {
-        FLUID_FREE(server);    /* -- free server string */
-    }
-
-    if(device)
-    {
-        FLUID_FREE(device);    /* -- free device string */
-    }
+    FLUID_FREE(server);    /* -- free server string */
+    FLUID_FREE(device);    /* -- free device string */
+    FLUID_FREE(left);
+    FLUID_FREE(right);
+    FLUID_FREE(buf);
 
     delete_fluid_pulse_audio_driver((fluid_audio_driver_t *) dev);
     return NULL;

--- a/src/rvoice/fluid_chorus.c
+++ b/src/rvoice/fluid_chorus.c
@@ -383,7 +383,7 @@ fluid_chorus_set(fluid_chorus_t *chorus, int set, int nr, fluid_real_t level,
 }
 
 
-void fluid_chorus_processmix(fluid_chorus_t *chorus, fluid_real_t *in,
+void fluid_chorus_processmix(fluid_chorus_t *chorus, const fluid_real_t *in,
                              fluid_real_t *left_out, fluid_real_t *right_out)
 {
     int sample_index;
@@ -456,7 +456,7 @@ void fluid_chorus_processmix(fluid_chorus_t *chorus, fluid_real_t *in,
 }
 
 /* Duplication of code ... (replaces sample data instead of mixing) */
-void fluid_chorus_processreplace(fluid_chorus_t *chorus, fluid_real_t *in,
+void fluid_chorus_processreplace(fluid_chorus_t *chorus, const fluid_real_t *in,
                                  fluid_real_t *left_out, fluid_real_t *right_out)
 {
     int sample_index;

--- a/src/rvoice/fluid_chorus.h
+++ b/src/rvoice/fluid_chorus.h
@@ -55,9 +55,9 @@ void fluid_chorus_reset(fluid_chorus_t *chorus);
 void fluid_chorus_set(fluid_chorus_t *chorus, int set, int nr, fluid_real_t level,
                       fluid_real_t speed, fluid_real_t depth_ms, int type);
 
-void fluid_chorus_processmix(fluid_chorus_t *chorus, fluid_real_t *in,
+void fluid_chorus_processmix(fluid_chorus_t *chorus, const fluid_real_t *in,
                              fluid_real_t *left_out, fluid_real_t *right_out);
-void fluid_chorus_processreplace(fluid_chorus_t *chorus, fluid_real_t *in,
+void fluid_chorus_processreplace(fluid_chorus_t *chorus, const fluid_real_t *in,
                                  fluid_real_t *left_out, fluid_real_t *right_out);
 
 

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -368,7 +368,7 @@ fluid_revmodel_reset(fluid_revmodel_t *rev)
 }
 
 void
-fluid_revmodel_processreplace(fluid_revmodel_t *rev, fluid_real_t *in,
+fluid_revmodel_processreplace(fluid_revmodel_t *rev, const fluid_real_t *in,
                               fluid_real_t *left_out, fluid_real_t *right_out)
 {
     int i, k = 0;
@@ -410,7 +410,7 @@ fluid_revmodel_processreplace(fluid_revmodel_t *rev, fluid_real_t *in,
 }
 
 void
-fluid_revmodel_processmix(fluid_revmodel_t *rev, fluid_real_t *in,
+fluid_revmodel_processmix(fluid_revmodel_t *rev, const fluid_real_t *in,
                           fluid_real_t *left_out, fluid_real_t *right_out)
 {
     int i, k = 0;

--- a/src/rvoice/fluid_rev.h
+++ b/src/rvoice/fluid_rev.h
@@ -61,10 +61,10 @@ typedef struct _fluid_revmodel_presets_t
 fluid_revmodel_t *new_fluid_revmodel(fluid_real_t sample_rate);
 void delete_fluid_revmodel(fluid_revmodel_t *rev);
 
-void fluid_revmodel_processmix(fluid_revmodel_t *rev, fluid_real_t *in,
+void fluid_revmodel_processmix(fluid_revmodel_t *rev, const fluid_real_t *in,
                                fluid_real_t *left_out, fluid_real_t *right_out);
 
-void fluid_revmodel_processreplace(fluid_revmodel_t *rev, fluid_real_t *in,
+void fluid_revmodel_processreplace(fluid_revmodel_t *rev, const fluid_real_t *in,
                                    fluid_real_t *left_out, fluid_real_t *right_out);
 
 void fluid_revmodel_reset(fluid_revmodel_t *rev);

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -130,8 +130,8 @@ fluid_rvoice_mixer_process_fx(fluid_rvoice_mixer_t *mixer, int current_blockcoun
     const int fx_channels_per_unit = mixer->buffers.fx_buf_count / mixer->fx_units;
     int i, f;
 
-    void (*reverb_process_func)(fluid_revmodel_t *rev, fluid_real_t *in, fluid_real_t *left_out, fluid_real_t *right_out);
-    void (*chorus_process_func)(fluid_chorus_t *chorus, fluid_real_t *in, fluid_real_t *left_out, fluid_real_t *right_out);
+    void (*reverb_process_func)(fluid_revmodel_t *rev, const fluid_real_t *in, fluid_real_t *left_out, fluid_real_t *right_out);
+    void (*chorus_process_func)(fluid_chorus_t *chorus, const fluid_real_t *in, fluid_real_t *left_out, fluid_real_t *right_out);
 
     fluid_real_t *out_rev_l, *out_rev_r, *out_ch_l, *out_ch_r;
 
@@ -375,7 +375,7 @@ get_dest_buf(fluid_rvoice_buffers_t *buffers, int index,
  */
 static void
 fluid_rvoice_buffers_mix(fluid_rvoice_buffers_t *buffers,
-                         fluid_real_t *FLUID_RESTRICT dsp_buf,
+                         const fluid_real_t *FLUID_RESTRICT dsp_buf,
                          int start_block, int sample_count,
                          fluid_real_t **dest_bufs, int dest_bufcount)
 {

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3939,7 +3939,7 @@ fluid_synth_write_s16(fluid_synth_t *synth, int len,
  * @note Currently private to libfluidsynth.
  */
 void
-fluid_synth_dither_s16(int *dither_index, int len, float *lin, float *rin,
+fluid_synth_dither_s16(int *dither_index, int len, const float *lin, const float *rin,
                        void *lout, int loff, int lincr,
                        void *rout, int roff, int rincr)
 {

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -95,8 +95,6 @@ static fluid_voice_t *fluid_synth_free_voice_by_kill_LOCAL(fluid_synth_t *synth)
 static void fluid_synth_kill_by_exclusive_class_LOCAL(fluid_synth_t *synth,
         fluid_voice_t *new_voice);
 static int fluid_synth_sfunload_callback(void *data, unsigned int msec);
-void fluid_synth_release_voice_on_same_note_LOCAL(fluid_synth_t *synth,
-        int chan, int key);
 static fluid_tuning_t *fluid_synth_get_tuning(fluid_synth_t *synth,
         int bank, int prog);
 static int fluid_synth_replace_tuning_LOCK(fluid_synth_t *synth,
@@ -147,7 +145,6 @@ static int fluid_synth_set_chorus_full_LOCAL(fluid_synth_t *synth, int set, int 
 /* has the synth module been initialized? */
 /* fluid_atomic_int_t may be anything, so init with {0} to catch most cases */
 static fluid_atomic_int_t fluid_synth_initialized = {0};
-static void fluid_synth_init(void);
 
 /* default modulators
  * SF2.01 page 52 ff:

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -190,7 +190,7 @@ fluid_preset_t *fluid_synth_find_preset(fluid_synth_t *synth,
                                         int prognum);
 void fluid_synth_sfont_unref(fluid_synth_t *synth, fluid_sfont_t *sfont);
 
-void fluid_synth_dither_s16(int *dither_index, int len, float *lin, float *rin,
+void fluid_synth_dither_s16(int *dither_index, int len, const float *lin, const float *rin,
                             void *lout, int loff, int lincr,
                             void *rout, int roff, int rincr);
 

--- a/src/synth/fluid_synth_monopoly.c
+++ b/src/synth/fluid_synth_monopoly.c
@@ -290,11 +290,6 @@ static char fluid_synth_get_fromkey_portamento_legato(fluid_channel_t *chan,
  *  Sust.on/off  >------------------------->|_______________|
  *  Sost.on/off
 ------------------------------------------------------------------------------*/
-int fluid_synth_noteoff_monopoly(fluid_synth_t *synth, int chan, int key,
-                                 char Mono);
-
-int fluid_synth_noteon_monopoly_legato(fluid_synth_t *synth, int chan,
-                                       int fromkey, int tokey, int vel);
 
 /**
  * Plays a noteon event for a Synth instance in "monophonic playing" state.

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -1733,7 +1733,6 @@ fluid_settings_option_concat(fluid_settings_t *settings, const char *name,
                              const char *separator)
 {
     fluid_setting_node_t *node;
-    fluid_str_setting_t *setting;
     fluid_list_t *p, *newlist = NULL;
     size_t count, len;
     char *str, *option;
@@ -1756,10 +1755,8 @@ fluid_settings_option_concat(fluid_settings_t *settings, const char *name,
         return (NULL);
     }
 
-    setting = &node->str;
-
     /* Duplicate option list, count options and get total string length */
-    for(p = setting->options, count = 0, len = 0; p; p = p->next, count++)
+    for(p = node->str.options, count = 0, len = 0; p; p = p->next)
     {
         option = fluid_list_get(p);
 
@@ -1767,6 +1764,7 @@ fluid_settings_option_concat(fluid_settings_t *settings, const char *name,
         {
             newlist = fluid_list_append(newlist, option);
             len += FLUID_STRLEN(option);
+            count++;
         }
     }
 


### PR DESCRIPTION
`clang-tidy` raises a few complaints, not all of them make sense. But those few did.