### PR TITLE
Fix readline

### DIFF
--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -28,11 +28,6 @@
 #include "fluid_sfont.h"
 #include "fluid_chan.h"
 
-#if WITH_READLINE
-#include <readline/readline.h>
-#include <readline/history.h>
-#endif
-
 /* FIXME: LADSPA used to need a lot of parameters on a single line. This is not
  * necessary anymore, so the limits below could probably be reduced */
 #define MAX_TOKENS 100
@@ -521,15 +516,6 @@ fluid_shell_run(void *data)
         {
             break;
         }
-
-#if WITH_READLINE
-
-        if(shell->in == fluid_get_stdin())
-        {
-            add_history(workline);
-        }
-
-#endif
 
         /* handle the command */
         switch(fluid_command(shell->handler, workline, shell->out))

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -1279,6 +1279,7 @@ fluid_istream_readline(fluid_istream_t in, fluid_ostream_t out, char *prompt,
 
         FLUID_SNPRINTF(buf, len, "%s", line);
         buf[len - 1] = 0;
+        add_history(buf);
 
         free(line);
         return 1;


### PR DESCRIPTION
fluid_istream_readline() is also not exported out of the library because it is not prefixed by FLUIDSYNTH_API so I think that it should be ok.