### PR TITLE
Avoid useless dsp parameters update upon modulation.

### DIFF
--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -1244,44 +1244,41 @@ int fluid_voice_modulate(fluid_voice_t *voice, int cc, int ctrl)
  * Update all the modulators. This function is called after a
  * ALL_CTRL_OFF MIDI message has been received (CC 121).
  *
+ * step 1: All generators should be modulated by all modulators.
+ *  This is done using the same code then when the voice was started 
+ *  (see fluid_voice_calculate_runtime_synthesis_parameters).
+ *  This code avoid the risk to call 'fluid_voice_update_param'
+ *  several times for the same generator if several modulators have
+ *  that generator as destination.
+ *
+ * step 2: for every generator, convert its value to the correct unit of the
+ * corresponding DSP parameter (fluid_voice_update_param()).
+ *
  */
 int fluid_voice_modulate_all(fluid_voice_t *voice)
 {
+    int i;
     fluid_mod_t *mod;
-    int i, k, gen;
-    fluid_real_t modval;
 
-    /* Loop through all the modulators.
-
-       FIXME: we should loop through the set of generators instead of
-       the set of modulators. We risk to call 'fluid_voice_update_param'
-       several times for the same generator if several modulators have
-       that generator as destination. It's not an error, just a wast of
-       energy (think polution, global warming, unhappy musicians,
-       ...) */
-
+    /* Step 1: All generators should be modulated by all modulators. */
+    /* First clear generators's modulation input node */
     for(i = 0; i < voice->mod_count; i++)
     {
+        voice->gen[voice->mod[i].dest].mod = 0.0f;
+    }
 
+    /* Then calculate each generators's modulation input node */
+    for(i = 0; i < voice->mod_count; i++)
+    {
         mod = &voice->mod[i];
-        gen = fluid_mod_get_dest(mod);
-        modval = 0.0;
+        voice->gen[mod->dest].mod += fluid_mod_get_value(mod, voice);
+    }
 
-        /* Accumulate the modulation values of all the modulators with
-         * destination generator 'gen' */
-        for(k = 0; k < voice->mod_count; k++)
-        {
-            if(fluid_mod_has_dest(&voice->mod[k], gen))
-            {
-                modval += fluid_mod_get_value(&voice->mod[k], voice);
-            }
-        }
-
-        fluid_gen_set_mod(&voice->gen[gen], modval);
-
-        /* Update the parameter values that are depend on the generator
-         * 'gen' */
-        fluid_voice_update_param(voice, gen);
+    /* step 2: for every generator, convert its value to the correct unit of the
+      corresponding DSP parameter (fluid_voice_update_param()). */
+    for(i = 0; i < voice->mod_count; i++)
+    {
+        fluid_voice_update_param(voice, voice->mod[i].dest);
     }
 
     return FLUID_OK;


### PR DESCRIPTION
Actually on a single CC change, both 'fluid_voice_modulate()' and 'fluid_voice_modulate_all()' have the risk to call 'fluid_voice_update_param()'  several times for the same generator if several modulators have that generator as destination. 

Example:
-------------
  CCx --> mod 1 --> gen y
  CCx --> mod 2 -->Gen y
Both modulators (mod 1 and 2) have the same destination generator (gen y). On a simple CCx change, gen y will be updated twice (instead of only one).

This is not a bug, but only a risk of lost of performance particularly on intensive modulation situation. This PR avoid this risk.