### PR TITLE
Add two new tuning shell commands to tune all octaves and all notes

### DIFF
--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -262,11 +262,6 @@ static const fluid_cmd_t fluid_commands[] =
         "                           standard tuning for all 12 notes, starting from C\n"
     },
     {
-        "tuneall", "tuning", fluid_handle_tuneall,
-        "tuneall bank prog offset   Tune all notes with the given cent offset from\n"
-        "                           standard tuning\n"
-    },
-    {
         "settuning", "tuning", fluid_handle_settuning,
         "settuning chan bank prog   Set the tuning for a MIDI channel"
     },
@@ -1689,60 +1684,6 @@ fluid_handle_tuneoctave(void *data, int ac, char **av, fluid_ostream_t out)
     if (fluid_synth_activate_octave_tuning(handler->synth, bank, prog, "tuneoctave", offsets, realtime) == FLUID_FAILED)
     {
         fluid_ostream_printf(out, "tuneoctave: failed to set octave tuning.\n");
-        return FLUID_FAILED;
-    }
-
-    return FLUID_OK;
-}
-
-int
-fluid_handle_tuneall(void *data, int ac, char **av, fluid_ostream_t out)
-{
-    FLUID_ENTRY_COMMAND(data);
-    int i;
-    int bank, prog;
-    int realtime = 0;
-    double offsets[12];
-
-    if(ac < 3)
-    {
-        fluid_ostream_printf(out, "tuneall: too few arguments (bank, prog, cent offset).\n");
-        return FLUID_FAILED;
-    }
-
-    bank = atoi(av[0]);
-    if(!fluid_is_number(av[0]) || (bank < 0) || (bank >= 128))
-    {
-        fluid_ostream_printf(out, "tuneall: invalid bank number.\n");
-        return FLUID_FAILED;
-    };
-
-    prog = atoi(av[1]);
-    if(!fluid_is_number(av[1]) || (prog < 0) || (prog >= 128))
-    {
-        fluid_ostream_printf(out, "tuneall: invalid program number.\n");
-        return FLUID_FAILED;
-    };
-
-    offsets[0] = atof(av[2]);
-    if(!fluid_is_number(av[2]) || (offsets[0] < -100.0) || (offsets[0] > 100.0))
-    {
-        fluid_ostream_printf(out, "tuneall: cent offset should be between -100.0 and 100.0.\n");
-        return FLUID_FAILED;
-    }
-
-    for(i = 1; i < 12; i++) {
-        offsets[i] = offsets[0];
-    }
-
-    if((ac > 3) && (FLUID_STRCMP(av[3], "--realtime") == 0))
-    {
-        realtime = 1;
-    }
-
-    if (fluid_synth_activate_octave_tuning(handler->synth, bank, prog, "tuneall", offsets, realtime) == FLUID_FAILED)
-    {
-        fluid_ostream_printf(out, "tuneall: failed to set tuning.\n");
         return FLUID_FAILED;
     }
 

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -256,6 +256,17 @@ static const fluid_cmd_t fluid_commands[] =
         "tune bank prog key pitch   Tune a key"
     },
     {
+        "tuneoctave", "tuning", fluid_handle_tuneoctave,
+        "tuneoctave bank prog offset1 ... offset12\n"
+        "                           Tune all octaves with the given cent offsets from\n"
+        "                           standard tuning for all 12 notes, starting from C\n"
+    },
+    {
+        "tuneall", "tuning", fluid_handle_tuneall,
+        "tuneall bank prog offset   Tune all notes with the given cent offset from\n"
+        "                           standard tuning\n"
+    },
+    {
         "settuning", "tuning", fluid_handle_settuning,
         "settuning chan bank prog   Set the tuning for a MIDI channel"
     },
@@ -1628,6 +1639,112 @@ fluid_handle_tune(void *data, int ac, char **av, fluid_ostream_t out)
     };
 
     fluid_synth_tune_notes(handler->synth, bank, prog, 1, &key, &pitch, 0);
+
+    return FLUID_OK;
+}
+
+int
+fluid_handle_tuneoctave(void *data, int ac, char **av, fluid_ostream_t out)
+{
+    FLUID_ENTRY_COMMAND(data);
+    int i;
+    int realtime = 0;
+    int bank, prog;
+    double offsets[12];
+
+    if(ac < 14)
+    {
+        fluid_ostream_printf(out, "tuneoctave: too few arguments (bank, prog and 12 cent offsets).\n");
+        return FLUID_FAILED;
+    }
+
+    bank = atoi(av[0]);
+    if(!fluid_is_number(av[0]) || (bank < 0) || (bank >= 128))
+    {
+        fluid_ostream_printf(out, "tuneoctave: invalid bank number.\n");
+        return FLUID_FAILED;
+    };
+
+    prog = atoi(av[1]);
+    if(!fluid_is_number(av[1]) || (prog < 0) || (prog >= 128))
+    {
+        fluid_ostream_printf(out, "tuneoctave: invalid program number.\n");
+        return FLUID_FAILED;
+    };
+
+    for(i = 0; i < 12; i++) {
+        offsets[i] = atof(av[i + 2]);
+        if(!fluid_is_number(av[i + 2]) || (offsets[i] < -100.0) || (offsets[i] > 100.0))
+        {
+            fluid_ostream_printf(out, "tuneoctave: last 12 arguments should be cent offsets between -100.0 and 100.0\n");
+            return FLUID_FAILED;
+        }
+    }
+
+    if((ac > 14) && (FLUID_STRCMP(av[14], "--realtime") == 0))
+    {
+        realtime = 1;
+    }
+
+    if (fluid_synth_activate_octave_tuning(handler->synth, bank, prog, "tuneoctave", offsets, realtime) == FLUID_FAILED)
+    {
+        fluid_ostream_printf(out, "tuneoctave: failed to set octave tuning.\n");
+        return FLUID_FAILED;
+    }
+
+    return FLUID_OK;
+}
+
+int
+fluid_handle_tuneall(void *data, int ac, char **av, fluid_ostream_t out)
+{
+    FLUID_ENTRY_COMMAND(data);
+    int i;
+    int bank, prog;
+    int realtime = 0;
+    double offsets[12];
+
+    if(ac < 3)
+    {
+        fluid_ostream_printf(out, "tuneall: too few arguments (bank, prog, cent offset).\n");
+        return FLUID_FAILED;
+    }
+
+    bank = atoi(av[0]);
+    if(!fluid_is_number(av[0]) || (bank < 0) || (bank >= 128))
+    {
+        fluid_ostream_printf(out, "tuneall: invalid bank number.\n");
+        return FLUID_FAILED;
+    };
+
+    prog = atoi(av[1]);
+    if(!fluid_is_number(av[1]) || (prog < 0) || (prog >= 128))
+    {
+        fluid_ostream_printf(out, "tuneall: invalid program number.\n");
+        return FLUID_FAILED;
+    };
+
+    offsets[0] = atof(av[2]);
+    if(!fluid_is_number(av[2]) || (offsets[0] < -100.0) || (offsets[0] > 100.0))
+    {
+        fluid_ostream_printf(out, "tuneall: cent offset should be between -100.0 and 100.0.\n");
+        return FLUID_FAILED;
+    }
+
+    for(i = 1; i < 12; i++) {
+        offsets[i] = offsets[0];
+    }
+
+    if((ac > 3) && (FLUID_STRCMP(av[3], "--realtime") == 0))
+    {
+        realtime = 1;
+    }
+
+    if (fluid_synth_activate_octave_tuning(handler->synth, bank, prog, "tuneall", offsets, realtime) == FLUID_FAILED)
+    {
+        fluid_ostream_printf(out, "tuneall: failed to set tuning.\n");
+        return FLUID_FAILED;
+    }
 
     return FLUID_OK;
 }

--- a/src/bindings/fluid_cmd.h
+++ b/src/bindings/fluid_cmd.h
@@ -63,6 +63,8 @@ int fluid_handle_interp(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_interpc(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_tuning(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_tune(void *data, int ac, char **av, fluid_ostream_t out);
+int fluid_handle_tuneoctave(void *data, int ac, char **av, fluid_ostream_t out);
+int fluid_handle_tuneall(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_settuning(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_resettuning(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_tunings(void *data, int ac, char **av, fluid_ostream_t out);

--- a/src/bindings/fluid_cmd.h
+++ b/src/bindings/fluid_cmd.h
@@ -64,7 +64,6 @@ int fluid_handle_interpc(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_tuning(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_tune(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_tuneoctave(void *data, int ac, char **av, fluid_ostream_t out);
-int fluid_handle_tuneall(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_settuning(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_resettuning(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_tunings(void *data, int ac, char **av, fluid_ostream_t out);


### PR DESCRIPTION
While FluidSynth supports the Midi Tuning Standard and reacts to single note and octave tuning SysEx messages, the shell currently only supports single note tunings. This pull requests adds a new tuning command to tune the 12 notes of all octaves simultaneously with a given cent offset from the standard tuning.

In contrast to the existing tuning command, there is also the option to apply the tuning in real-time, i.e. to also affect sounding notes immediately via the "--realtime" argument.

Edit: previously there were two new commands. But the "tuneall" command duplicates existing functionality as there is already a RPN for channel wide fine tuning.