### PR TITLE
Zone names

### DIFF
--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -1015,7 +1015,7 @@ fluid_defpreset_import_sfont(fluid_defpreset_t *defpreset,
     while(p != NULL)
     {
         sfzone = (SFZone *)fluid_list_get(p);
-        FLUID_SNPRINTF(zone_name, sizeof(zone_name), "%s/%d", defpreset->name, count);
+        FLUID_SNPRINTF(zone_name, sizeof(zone_name), "pz:%s/%d", defpreset->name, count);
         zone = new_fluid_preset_zone(zone_name);
 
         if(zone == NULL)
@@ -1733,9 +1733,8 @@ fluid_inst_import_sfont(fluid_preset_zone_t *preset_zone, SFInst *sfinst, fluid_
     {
 
         sfzone = (SFZone *)fluid_list_get(p);
-        /* integrates preset zone name in instrument zone name */
-        FLUID_SNPRINTF(zone_name, sizeof(zone_name), "%s/%s/%d", preset_zone->name,
-                       inst->name, count);
+        /* instrument zone name */
+        FLUID_SNPRINTF(zone_name, sizeof(zone_name), "iz:%s/%d", inst->name, count);
 
         inst_zone = new_fluid_inst_zone(zone_name);
 

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -1605,7 +1605,7 @@ fluid_preset_zone_import_sfont(fluid_preset_zone_t *zone, SFZone *sfzone, fluid_
 
         if(zone->inst == NULL)
         {
-            zone->inst = fluid_inst_import_sfont(zone, sfinst, defsfont);
+            zone->inst = fluid_inst_import_sfont(sfinst, defsfont);
         }
 
         if(zone->inst == NULL)
@@ -1697,7 +1697,7 @@ fluid_inst_set_global_zone(fluid_inst_t *inst, fluid_inst_zone_t *zone)
  * fluid_inst_import_sfont
  */
 fluid_inst_t *
-fluid_inst_import_sfont(fluid_preset_zone_t *preset_zone, SFInst *sfinst, fluid_defsfont_t *defsfont)
+fluid_inst_import_sfont(SFInst *sfinst, fluid_defsfont_t *defsfont)
 {
     fluid_list_t *p;
     fluid_inst_t *inst;

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -196,7 +196,7 @@ struct _fluid_inst_t
 };
 
 fluid_inst_t *new_fluid_inst(void);
-fluid_inst_t *fluid_inst_import_sfont(fluid_preset_zone_t *preset_zone, SFInst *sfinst, fluid_defsfont_t *defsfont);
+fluid_inst_t *fluid_inst_import_sfont(SFInst *sfinst, fluid_defsfont_t *defsfont);
 void delete_fluid_inst(fluid_inst_t *inst);
 int fluid_inst_set_global_zone(fluid_inst_t *inst, fluid_inst_zone_t *zone);
 int fluid_inst_add_zone(fluid_inst_t *inst, fluid_inst_zone_t *zone);


### PR DESCRIPTION
As instrument zone are common to all preset zones, an instrument zone cannot uniquely identified by a preset zone name.
Note: instrument zone name and preset zone name are used in warning about invalid modulators.