### PR TITLE
Document settings changes

### DIFF
--- a/doc/fluidsynth-v20-devdoc.txt
+++ b/doc/fluidsynth-v20-devdoc.txt
@@ -96,6 +96,8 @@ FluidSynths major version was bumped. The API was reworked, deprecated functions
 - fluid_synth_remove_sfont() returns FLUID_OK or FLUID_FAILED
 - introduce a separate data type for sequencer client IDs: #fluid_seq_id_t
 - fluid_get_userconf() has been implemented for Windows
+- fluid_settings_setstr can not be used to set integer (toggle) settings with "yes" or "no" values anymore. Use fluid_settings_setint instead, for example: fluid_settings_setint(settings, "synth.reverb.active", 0) instead of fluid_settings_setstr(settings, "synth.reverb.active", "no").
+- fluid_settings_set* functions no longer silently register unknown settings but return an error instead
 
 <strong>New Features and API additions:</strong>
 

--- a/doc/fluidsynth-v20-devdoc.txt
+++ b/doc/fluidsynth-v20-devdoc.txt
@@ -596,8 +596,8 @@ void createsynth()
 {
     fluid_settings_t* settings;
     settings = new_fluid_settings();
-    fluid_settings_setstr(settings, "synth.reverb.active", "yes");
-    fluid_settings_setstr(settings, "synth.chorus.active", "no");
+    fluid_settings_setint(settings, "synth.reverb.active", 0);
+    fluid_settings_setint(settings, "synth.chorus.active", 0);
     synth = new_fluid_synth(settings);
     adriver = new_fluid_audio_driver(settings, synth);
     sequencer = new_fluid_sequencer2(0);

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -936,6 +936,7 @@ fluid_settings_setstr(fluid_settings_t *settings, const char *name, const char *
     if((fluid_settings_get(settings, name, &node) != FLUID_OK)
             || (node->type != FLUID_STR_TYPE))
     {
+        FLUID_LOG(FLUID_WARN, "Unknown string parameter '%s'", name);
         goto error_recovery;
     }
 
@@ -1313,6 +1314,7 @@ fluid_settings_setnum(fluid_settings_t *settings, const char *name, double val)
     if((fluid_settings_get(settings, name, &node) != FLUID_OK)
             || (node->type != FLUID_NUM_TYPE))
     {
+        FLUID_LOG(FLUID_WARN, "Unknown numeric parameter '%s'", name);
         goto error_recovery;
     }
 
@@ -1497,6 +1499,7 @@ fluid_settings_setint(fluid_settings_t *settings, const char *name, int val)
     if((fluid_settings_get(settings, name, &node) != FLUID_OK)
             || (node->type != FLUID_INT_TYPE))
     {
+        FLUID_LOG(FLUID_WARN, "Unknown integer parameter '%s'", name);
         goto error_recovery;
     }
 


### PR DESCRIPTION
This pull request attempts to document the backward incompatible changes introduced in #293 for version 2.0. It adds a note about the two changes to the 2.0 devdocs and fixes an invalid code example.

It also adds a warning message if trying to set a parameter that doesn't exist or which has an invalid type.