### PR TITLE
Generate pow lookup tables with higher precision

### DIFF
--- a/src/gentables/gen_conv.c
+++ b/src/gentables/gen_conv.c
@@ -22,7 +22,7 @@ static void fluid_conversion_config(void)
 
     for(i = 0; i < FLUID_CENTS_HZ_SIZE; i++)
     {
-        fluid_ct2hz_tab[i] = pow(2.0, (double) i / 1200.0);
+        fluid_ct2hz_tab[i] = powl(2.0, (double) i / 1200.0);
     }
 
     /* centibels to amplitude conversion
@@ -32,7 +32,7 @@ static void fluid_conversion_config(void)
      */
     for(i = 0; i < FLUID_CB_AMP_SIZE; i++)
     {
-        fluid_cb2amp_tab[i] = pow(10.0, (double) i / -200.0);
+        fluid_cb2amp_tab[i] = powl(10.0, (double) i / -200.0);
     }
 
     /* initialize the conversion tables (see fluid_mod.c


### PR DESCRIPTION
possibly due to glibc-2.29 [commit 424c4f60ed6190e2ea0e72e0873bf3ebcbbf5448](https://sourceware.org/git/?p=glibc.git;a=commit;h=424c4f60ed6190e2ea0e72e0873bf3ebcbbf5448)
pow is using fused-multiply-add (fma) if available.
That caused the fluidsynth binaries to differ depending on
the build machine's CPU.

This was visible among others in
grep '7.58577575029183[56]e-04' fluidsynth-2.0.3/build/fluid_conv_tables.c

See https://reproducible-builds.org/ for why this is matters.