### PR TITLE
Fix buffering bug in fluid_synth_process().

### DIFF
--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3644,7 +3644,7 @@ fluid_synth_process(fluid_synth_t *synth, int len, int nfx, float *fx[],
     int nfxchan, nfxunits, naudchan;
 
     double time = fluid_utime();
-    int i, f, num, count;
+    int i, f, num, count, buffered_blocks;
 
     float cpu_load;
 
@@ -3668,9 +3668,10 @@ fluid_synth_process(fluid_synth_t *synth, int len, int nfx, float *fx[],
     count = 0;
     num = synth->cur;
 
-    if(synth->cur < FLUID_BUFSIZE)
+    buffered_blocks = (synth->cur + FLUID_BUFSIZE - 1) / FLUID_BUFSIZE;
+    if(synth->cur < buffered_blocks * FLUID_BUFSIZE)
     {
-        int available = FLUID_BUFSIZE - synth->cur;
+        int available = (buffered_blocks * FLUID_BUFSIZE) - synth->cur;
         num = (available > len) ? len : available;
 
         if(nout != 0)


### PR DESCRIPTION
The old buffering code assumes that synth->cur is between 0 and FLUID_BUFSIZE.
However since fluid_synth_process() can render more than one buffer at a time
this isn't always true, and the new code handles other values properly.


I found this bug while porting the deprecated fluid_synth_nwrite_float() calls in BEAST to 
the non-deprecated fluid_synth_process(). However, if I do this, our soundfont unit test fails, and indeed the wave starts sounding somewhat crappy. BEAST will call fluid_synth_process() with arbitary buffer sizes, so for instance it can do

```
...
process() 200
note on
process() 100
note off
process() 200
...
```

So these are note a multiple of FLUID_BUFSIZE (64), with fluid_nwrite_float() it works but with fluid_synth_process() it fails.