### PR TITLE
Fix memory-leak with SF3 samples when dynamic-sample-loading is not active

### DIFF
--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -246,7 +246,18 @@ int delete_fluid_defsfont(fluid_defsfont_t *defsfont)
 
     for(list = defsfont->sample; list; list = fluid_list_next(list))
     {
-        delete_fluid_sample((fluid_sample_t *) fluid_list_get(list));
+        sample = (fluid_sample_t *) fluid_list_get(list);
+
+        /* If the sample data pointer is different to the sampledata chunk of
+         * the soundfont, then the sample has been loaded individually (SF3)
+         * and needs to be unloaded explicitly. This is safe even if using
+         * dynamic sample loading, as the sample_unload mechanism sets
+         * sample->data to NULL after unload. */
+        if ((sample->data != NULL) && (sample->data != defsfont->sampledata))
+        {
+            fluid_samplecache_unload(sample->data);
+        }
+        delete_fluid_sample(sample);
     }
 
     if(defsfont->sample)


### PR DESCRIPTION
Vorbis compressed SF3 samples are always loaded individually and stored
in the sample cache in uncompressed form. When dynamic-sample-loading is
not active (the default), then the uncompressed samples did not get
unloaded when unloading the SF3 font.

This fix makes sure that those samples are also freed. For bulk loaded
samples, the sample->data pointer is always the same as the
font->sampledata pointer. For individually loaded samples, the sample->data
pointer always points to a different memory region. So we can use that
information to determine if and when to unload the samples one by one.

Fixes #528 