### PR TITLE
[Android] remove extra cmake args with proper use of  PKG_CONFIG_PATH and PKG_CONFIG_LIBDIR.

### DIFF
--- a/doc/android/Makefile.android
+++ b/doc/android/Makefile.android
@@ -94,8 +94,15 @@ build-fluidsynth:
 
 build-fluidsynth-one:
 	mkdir -p build/$(A_ABI) && cd build/$(A_ABI) && \
-	LD_RUN_PATH=$(DIST_PATH)/android-$(BUILD_ABI)/lib:$(OBOE_BUILD_PATH)/$(A_ABI) LD_LIBRARY_PATH=$(DIST_PATH)/android_$(BUILD_ABI)/lib PKG_CONFIG_PATH=$(DIST_PATH)/android_$(BUILD_ABI)/lib/pkgconfig/:$(OBOE_BUILD_PATH)/$(A_ABI) \
-	$(CMAKE) -DCMAKE_INSTALL_PREFIX=$(PWD)/dist/$(A_ABI) -DCMAKE_TOOLCHAIN_FILE=$(ANDROID_NDK)/build/cmake/android.toolchain.cmake -Denable-opensles=on -Denable-oboe=on -Denable-sdl2=off -Denable-jack=off -Denable-oss=off -Denable-pulseaudio=off -Denable-libsndfile=on -Denable-dbus=off -Denable-debug=on -DANDROID_NATIVE_API_LEVEL=android-27 -DANDROID_PLATFORM=android-27 -DANDROID_ABI=$(A_ABI) ../../../.. && make
+	LD_RUN_PATH=$(DIST_PATH)/android-$(BUILD_ABI)/lib:$(OBOE_BUILD_PATH)/$(A_ABI) \
+	LD_LIBRARY_PATH=$(DIST_PATH)/android_$(BUILD_ABI)/lib \
+	PKG_CONFIG_PATH=$(DIST_PATH)/android_$(BUILD_ABI)/lib/pkgconfig/:$(OBOE_BUILD_PATH)/$(A_ABI) \
+	PKG_CONFIG_LIBDIR=$(DIST_PATH)/android_$(BUILD_ABI)/lib/pkgconfig/:$(OBOE_BUILD_PATH)/$(A_ABI) \
+	$(CMAKE) -Denable-debug=on -DCMAKE_INSTALL_PREFIX=$(PWD)/dist/$(A_ABI) \
+		-DCMAKE_TOOLCHAIN_FILE=$(ANDROID_NDK)/build/cmake/android.toolchain.cmake \
+		-Denable-opensles=on -Denable-oboe=on -Denable-oss=off -Denable-libsndfile=on \
+		-DANDROID_NATIVE_API_LEVEL=android-27 -DANDROID_PLATFORM=android-27 -DANDROID_ABI=$(A_ABI) ../../../.. && \
+	make
 
 build-oboe-one:
 	mkdir -p $(OBOE)/build/$(A_ABI) && cd $(OBOE)/build/$(A_ABI) && \


### PR DESCRIPTION
Reflecting hints at https://github.com/FluidSynth/fluidsynth/pull/533#issuecomment-485269117