### PR TITLE
Fix math 1

### DIFF
--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -773,7 +773,7 @@ static void update_rev_time_damping(fluid_late *late,
             /* gi = f(roomsize, gi_max, gi_min) */
             gi_tmp = gi_min + roomsize * (gi_max - gi_min);
             /* Computes T60DC from gi using inverse of relation E2.*/
-            dc_rev_time = -3 * delay_length[NBR_DELAYS - 1] * sample_period / log10(gi_tmp);
+            dc_rev_time = -3 * M_LN10 * delay_length[NBR_DELAYS - 1] * sample_period / log(gi_tmp);
         }
 #endif /* ROOMSIZE_RESPONSE_LINEAR */
         /*--------------------------------------------
@@ -782,7 +782,7 @@ static void update_rev_time_damping(fluid_late *late,
         /* Computes alpha from damp,ai_tmp,gi_tmp using relation R */
         /* - damp (0 to 1) controls concave reverb time for fs/2 frequency (T60DC to 0) */
         ai_tmp = 1.0 * damp;
-        alpha = sqrt(1 / (1 - ai_tmp / (20 * log10(gi_tmp) * log(10) / 80))); /* R */
+        alpha = sqrt(1 / (1 - ai_tmp / (20 * log(gi_tmp) / 80))); /* R */
     }
 
     /* updates tone corrector coefficients b1,b2 from alpha */
@@ -806,7 +806,7 @@ static void update_rev_time_damping(fluid_late *late,
                                             sample_period / dc_rev_time);
 
         /* iir low pass filter feedback gain */
-        fluid_real_t ai = (fluid_real_t)(20 * log10(gi) * log(10) / 80 *
+        fluid_real_t ai = (fluid_real_t)(20 * log(gi) / 80 *
                                          (1 -  1 / pow(alpha, 2)));
         /* b0 = gi * (1 - ai),  a1 = - ai */
         set_fdn_delay_lpf(&late->mod_delay_lines[i].dl.damping,

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -334,21 +334,21 @@ fluid_mod_transform_source_value(fluid_real_t val, unsigned char mod_flags, cons
      * is close enough.
      */
     case FLUID_MOD_SIN | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE: /* custom sin(x) */
-        val = sin(M_PI / 2 * val_norm * 0.87);
+        val = sin(M_PI_2 * val_norm * 0.87);
         break;
 
     case FLUID_MOD_SIN | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* custom */
-        val = sin(M_PI / 2 * (1.0f - val_norm) * 0.87);
+        val = sin(M_PI_2 * (1.0f - val_norm) * 0.87);
         break;
 
     case FLUID_MOD_SIN | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* custom */
-        val = (val_norm > 0.5f) ?  sin(M_PI / 2 * 2 * (val_norm - 0.5f))
-              : -sin(M_PI / 2 * 2 * (0.5f - val_norm));
+        val = (val_norm > 0.5f) ?  sin(M_PI * (val_norm - 0.5f))
+              : -sin(M_PI * (0.5f - val_norm));
         break;
 
     case FLUID_MOD_SIN | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* custom */
-        val = (val_norm > 0.5f) ? -sin(M_PI / 2 * 2 * (val_norm - 0.5f))
-              :  sin(M_PI / 2 * 2 * (0.5f - val_norm));
+        val = (val_norm > 0.5f) ? -sin(M_PI * (val_norm - 0.5f))
+              :  sin(M_PI * (0.5f - val_norm));
         break;
 
     default:

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -216,6 +216,10 @@ do { strncpy(_dst,_src,_n); \
 #define M_PI 3.1415926535897932384626433832795
 #endif
 
+#ifndef M_PI_2
+#define M_PI_2 1.5707963267948966192313216916398
+#endif
+
 #ifndef M_LN2
 #define M_LN2 0.69314718055994530941723212145818
 #endif


### PR DESCRIPTION
These fix are preliminar before fixing #537.

1) Since `log(x)=log10(x)*log(10)`, it seems absolutely redundant and harmful that code to me.
2) math.h should also provide M_PI_2 macro, which is M_PI/2. I added the test for its presence and used it in few points.
