### PR TITLE
Add --quiet option to fluidsynth binary

### DIFF
--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -646,6 +646,15 @@ int main(int argc, char **argv)
 
         case 'q':
             quiet = 1;
+
+#if defined(WIN32)
+            /* Windows logs to stdout by default, so make sure anything
+             * lower than PANIC is not printed either */
+            fluid_set_log_function(FLUID_ERR, NULL, NULL);
+            fluid_set_log_function(FLUID_WARN, NULL, NULL);
+            fluid_set_log_function(FLUID_INFO, NULL, NULL);
+            fluid_set_log_function(FLUID_DBG, NULL, NULL);
+#endif
             break;
 
         case 'R':
@@ -1170,7 +1179,8 @@ print_help(fluid_settings_t *settings)
     printf(" -p, --portname=[label]\n"
            "    Set MIDI port name (alsa_seq, coremidi drivers)\n");
     printf(" -q, --quiet\n"
-           "    Do not print welcome message or other informational output\n");
+           "    Do not print welcome message or other informational output\n"
+           "    (Windows only: also suppress all log messages lower than PANIC\n");
     printf(" -r, --sample-rate\n"
            "    Set the sample rate\n");
     printf(" -R, --reverb\n"

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -345,6 +345,7 @@ int main(int argc, char **argv)
     char buf[512];
     int c, i;
     int interactive = 1;
+    int quiet = 0;
     int midi_in = 1;
     fluid_player_t *player = NULL;
     fluid_midi_router_t *router = NULL;
@@ -361,7 +362,7 @@ int main(int argc, char **argv)
     int audio_channels = 0;
     int dump = 0;
     int fast_render = 0;
-    static const char optchars[] = "a:C:c:dE:f:F:G:g:hijK:L:lm:nO:o:p:R:r:sT:Vvz:";
+    static const char optchars[] = "a:C:c:dE:f:F:G:g:hijK:L:lm:nO:o:p:qR:r:sT:Vvz:";
 #ifdef LASH_ENABLED
     int connect_lash = 1;
     int enabled_lash = 0;		/* set to TRUE if lash gets enabled */
@@ -383,8 +384,6 @@ int main(int argc, char **argv)
 
 #endif
 
-
-    print_welcome();
 
     /* create the settings */
     settings = new_fluid_settings();
@@ -421,6 +420,7 @@ int main(int argc, char **argv)
             {"no-shell", 0, 0, 'i'},
             {"option", 1, 0, 'o'},
             {"portname", 1, 0, 'p'},
+            {"quiet", 0, 0, 'q'},
             {"reverb", 1, 0, 'R'},
             {"sample-rate", 1, 0, 'r'},
             {"server", 0, 0, 's'},
@@ -569,6 +569,7 @@ int main(int argc, char **argv)
             break;
 
         case 'h':
+            print_welcome();
             print_help(settings);
             break;
 
@@ -643,6 +644,10 @@ int main(int argc, char **argv)
             fluid_settings_setstr(settings, "midi.portname", optarg);
             break;
 
+        case 'q':
+            quiet = 1;
+            break;
+
         case 'R':
             if((optarg != NULL) && ((FLUID_STRCMP(optarg, "0") == 0) || (FLUID_STRCMP(optarg, "no") == 0)))
             {
@@ -688,6 +693,7 @@ int main(int argc, char **argv)
             break;
 
         case 'V':
+            print_welcome();
             print_configure();
             exit(0);
             break;
@@ -726,6 +732,10 @@ int main(int argc, char **argv)
 #else
     arg1 = i;
 #endif
+
+    if (!quiet) {
+        print_welcome();
+    }
 
     /* option help requested?  "-o help" */
     if(option_help)
@@ -981,7 +991,9 @@ int main(int argc, char **argv)
         }
 
         fluid_settings_dupstr(settings, "audio.file.name", &filename);
-        printf("Rendering audio to file '%s'..\n", filename);
+        if (!quiet) {
+            printf("Rendering audio to file '%s'..\n", filename);
+        }
 
         if(filename)
         {
@@ -1157,6 +1169,8 @@ print_help(fluid_settings_t *settings)
            "    Audio file format for fast rendering or aufile driver (\"help\" for list)\n");
     printf(" -p, --portname=[label]\n"
            "    Set MIDI port name (alsa_seq, coremidi drivers)\n");
+    printf(" -q, --quiet\n"
+           "    Do not print welcome message or other informational output\n");
     printf(" -r, --sample-rate\n"
            "    Set the sample rate\n");
     printf(" -R, --reverb\n"


### PR DESCRIPTION
People have asked about piping the output of the file renderer to stdout a few times now. See #553 for the latest example. In principle this works quite well for certain formats (au, flac, raw), but the fluidsynth binary currently always prints a welcome message and a "Rendering to ..." line to stdout as well.

This PR adds a new command line option to silence those messages. To do that, the welcome_message printing had to be moved after the optarg parsing. With the side effect that errors in any arguments or options will now be printed without a leading welcome message.

I quite like this, as it makes the error messages more visible and less likely to be overlooked by users.

The second commit is just for consistency and cleanup.