### PR TITLE
Add a public wrapper function for free()

### DIFF
--- a/include/fluidsynth/misc.h
+++ b/include/fluidsynth/misc.h
@@ -62,6 +62,7 @@ extern "C" {
 
 FLUIDSYNTH_API int fluid_is_soundfont(const char *filename);
 FLUIDSYNTH_API int fluid_is_midifile(const char *filename);
+FLUIDSYNTH_API void fluid_free(void* ptr);
 
 
 #ifdef __cplusplus

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -1048,7 +1048,7 @@ fluid_settings_copystr(fluid_settings_t *settings, const char *name,
  * @since 1.1.0
  *
  * Like fluid_settings_copystr() but allocates a new copy of the string.  Caller
- * owns the string and should free it with free() when done using it.
+ * owns the string and should free it with fluid_free() when done using it.
  */
 int
 fluid_settings_dupstr(fluid_settings_t *settings, const char *name, char **str)
@@ -1117,7 +1117,7 @@ fluid_settings_dupstr(fluid_settings_t *settings, const char *name, char **str)
  * @param settings a settings object
  * @param name a setting's name
  * @param s a string to be tested
- * @return TRUE if the value exists and is equal to 's', FALSE otherwise
+ * @return TRUE if the value exists and is equal to \c s, FALSE otherwise
  */
 int
 fluid_settings_str_equal(fluid_settings_t *settings, const char *name, const char *s)
@@ -1645,7 +1645,7 @@ int fluid_settings_getint_default(fluid_settings_t *settings, const char *name, 
  * @param data any user provided pointer
  * @param func callback function to be called on each iteration
  *
- * @note Starting with FluidSynth 1.1.0 the \a func callback is called for each
+ * @note Starting with FluidSynth 1.1.0 the \p func callback is called for each
  * option in alphabetical order.  Sort order was undefined in previous versions.
  */
 void
@@ -1728,7 +1728,7 @@ fluid_settings_option_count(fluid_settings_t *settings, const char *name)
  * @param name Settings name
  * @param separator String to use between options (NULL to use ", ")
  * @return Newly allocated string or NULL on error (out of memory, not a valid
- *   setting \a name or not a string setting).  Free the string when finished with it.
+ *   setting \p name or not a string setting). Free the string when finished with it by using fluid_free().
  * @since 1.1.0
  */
 char *
@@ -1870,7 +1870,7 @@ fluid_settings_foreach_iter(void *key, void *value, void *data)
  * @param data any user provided pointer
  * @param func callback function to be called on each iteration
  *
- * @note Starting with FluidSynth 1.1.0 the \a func callback is called for each
+ * @note Starting with FluidSynth 1.1.0 the \p func callback is called for each
  * setting in alphabetical order.  Sort order was undefined in previous versions.
  */
 void

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -196,6 +196,17 @@ fluid_log(int level, const char *fmt, ...)
 }
 
 /**
+ * Convenience wrapper for free() that satisfies at least C90 requirements.
+ * Especially useful when using fluidsynth with programming languages that do not provide malloc() and free().
+ * @note Only use this function when the API documentation explicitly says so. Otherwise use adequate \c delete_fluid_* functions.
+ * @since 2.0.7
+ */
+void fluid_free(void* ptr)
+{
+    free(ptr);
+}
+
+/**
  * An improved strtok, still trashes the input string, but is portable and
  * thread safe.  Also skips token chars at beginning of token string and never
  * returns an empty token (will return NULL if source ends in token chars though).

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -131,7 +131,7 @@ typedef void (*fluid_rvoice_function_t)(void *obj, const fluid_rvoice_param_t pa
 #define FLUID_NEW(_t)                (_t*)malloc(sizeof(_t))
 #define FLUID_ARRAY_ALIGNED(_t,_n,_a) (_t*)malloc((_n)*sizeof(_t) + ((unsigned int)_a - 1u))
 #define FLUID_ARRAY(_t,_n)           FLUID_ARRAY_ALIGNED(_t,_n,1u)
-#define FLUID_FREE(_p)               free(_p)
+#define FLUID_FREE(_p)               fluid_free(_p)
 #define FLUID_FOPEN(_f,_m)           fopen(_f,_m)
 #define FLUID_FCLOSE(_f)             fclose(_f)
 #define FLUID_FREAD(_p,_s,_n,_f)     fread(_p,_s,_n,_f)


### PR DESCRIPTION
to allow proper deallocation for programming languages other than C/C++.