### PR TITLE
Fix bugs in fluid_sample_set_sound_data with copy enabled

### DIFF
--- a/src/sfloader/fluid_sfont.c
+++ b/src/sfloader/fluid_sfont.c
@@ -609,7 +609,7 @@ fluid_sample_set_sound_data(fluid_sample_t *sample,
             goto error_rec;
         }
 
-        FLUID_MEMSET(sample->data, 0, storedNbFrames);
+        FLUID_MEMSET(sample->data, 0, storedNbFrames * sizeof(short));
         FLUID_MEMCPY(sample->data + SAMPLE_LOOP_MARGIN, data, nbframes * sizeof(short));
 
         if(data24 != NULL)
@@ -628,7 +628,7 @@ fluid_sample_set_sound_data(fluid_sample_t *sample,
         /* pointers */
         /* all from the start of data */
         sample->start = SAMPLE_LOOP_MARGIN;
-        sample->end = SAMPLE_LOOP_MARGIN + storedNbFrames - 1;
+        sample->end = SAMPLE_LOOP_MARGIN + nbframes - 1;
     }
     else
     {


### PR DESCRIPTION
While developing liquidsfz, I noticed that clicks occurred at the end of samples but this was fixed if I passed false as copy argument. So I think there are two problems in fluid_sample_set_sound_data:

- memset should clear all the memory
- end position should be before the end of the memory
