### PR TITLE
fluidsynth exec: let option -j connect MIDI devices as well

### DIFF
--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -585,6 +585,7 @@ int main(int argc, char **argv)
 
         case 'j':
             fluid_settings_setint(settings, "audio.jack.autoconnect", 1);
+            fluid_settings_setint(settings, "midi.autoconnect", 1);
             break;
 
         case 'K':


### PR DESCRIPTION
When passing `-j` to fluidsynth executable, it currently only connects jack audio devices. Suggesting to connect MIDI devices as well, for convenience.