### PR TITLE
Fix broken voice mixing

### DIFF
--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -421,11 +421,11 @@ fluid_mixer_buffers_render_one(fluid_mixer_buffers_t *buffers,
 
     for(i = 0; i < blockcount; i++)
     {
-        int s = fluid_rvoice_write(rvoice, src_buf);
-
+        int s = fluid_rvoice_write(rvoice, &src_buf[FLUID_BUFSIZE * i]);
         if(s == -1)
         {
-            fluid_rvoice_buffers_mix(&rvoice->buffers, src_buf, last_block_mixed, unmixed_samples, dest_bufs, dest_bufcount);
+            // the voice is silent, mix back all the previously rendered sound
+            fluid_rvoice_buffers_mix(&rvoice->buffers, src_buf, last_block_mixed, total_samples - (last_block_mixed*FLUID_BUFSIZE), dest_bufs, dest_bufcount);
 
             unmixed_samples = 0;
             last_block_mixed = i+1;
@@ -442,7 +442,7 @@ fluid_mixer_buffers_render_one(fluid_mixer_buffers_t *buffers,
         }
     }
 
-    fluid_rvoice_buffers_mix(&rvoice->buffers, src_buf, last_block_mixed, unmixed_samples, dest_bufs, dest_bufcount);
+    fluid_rvoice_buffers_mix(&rvoice->buffers, src_buf, last_block_mixed, total_samples - (last_block_mixed*FLUID_BUFSIZE), dest_bufs, dest_bufcount);
 
     if(total_samples < blockcount * FLUID_BUFSIZE)
     {

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -371,7 +371,7 @@ get_dest_buf(fluid_rvoice_buffers_t *buffers, int index,
 static void
 fluid_rvoice_buffers_mix(fluid_rvoice_buffers_t *buffers,
                          const fluid_real_t *FLUID_RESTRICT dsp_buf,
-                         int offset_block,
+                         int offset,
                          fluid_real_t **dest_bufs, int dest_bufcount)
 {
     int bufcount = buffers->count;
@@ -400,7 +400,7 @@ fluid_rvoice_buffers_mix(fluid_rvoice_buffers_t *buffers,
 
         for(dsp_i = 0; dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
-            buf[offset_block + dsp_i] += amp * dsp_buf[dsp_i];
+            buf[offset + dsp_i] += amp * dsp_buf[dsp_i];
         }
     }
 }

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -417,7 +417,7 @@ fluid_mixer_buffers_render_one(fluid_mixer_buffers_t *buffers,
                                fluid_rvoice_t *rvoice, fluid_real_t **dest_bufs,
                                unsigned int dest_bufcount, fluid_real_t *src_buf, int blockcount)
 {
-    int i, total_samples = 0, unmixed_samples = 0, last_block_mixed = 0;
+    int i, total_samples = 0, last_block_mixed = 0;
 
     for(i = 0; i < blockcount; i++)
     {
@@ -427,13 +427,11 @@ fluid_mixer_buffers_render_one(fluid_mixer_buffers_t *buffers,
             // the voice is silent, mix back all the previously rendered sound
             fluid_rvoice_buffers_mix(&rvoice->buffers, src_buf, last_block_mixed, total_samples - (last_block_mixed*FLUID_BUFSIZE), dest_bufs, dest_bufcount);
 
-            unmixed_samples = 0;
             last_block_mixed = i+1;
             total_samples += FLUID_BUFSIZE;
         }
         else
         {
-            unmixed_samples += s;
             total_samples += s;
             if(s < FLUID_BUFSIZE)
             {


### PR DESCRIPTION
When rendering a voice, there are 3 cases to consider: silence, playing and finished. When optimizing away the `memset`, I incorrectly assumed that a voice cannot switch between playing and silence (like crazy) while rendering `FLUID_MIXER_MAX_BUFFERS_DEFAULT` . Apparently this does not hold true, esp. for percussion instrument while rendering at 96kHz. ~Thus, render one single block and immediately mix it into the destination buffer(s). (Rather than rendering all the `FLUID_MIXER_MAX_BUFFERS_DEFAULT` blocks and then do the mixing once).~

Fixes #580.