### PR TITLE
Improve type-checking of fluid_log() format specifiers

### DIFF
--- a/include/fluidsynth/log.h
+++ b/include/fluidsynth/log.h
@@ -77,7 +77,11 @@ fluid_log_function_t fluid_set_log_function(int level, fluid_log_function_t fun,
 
 FLUIDSYNTH_API void fluid_default_log_function(int level, const char *message, void *data);
 
-FLUIDSYNTH_API int fluid_log(int level, const char *fmt, ...);
+FLUIDSYNTH_API int fluid_log(int level, const char *fmt, ...)
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+__attribute__ ((format (printf, 2, 3)))
+#endif
+;
 
 
 #ifdef __cplusplus

--- a/src/drivers/fluid_jack.c
+++ b/src/drivers/fluid_jack.c
@@ -328,7 +328,7 @@ fluid_jack_client_register_ports(void *driver, int isaudio, jack_client_t *clien
     char name[64];
     int multi;
     int i;
-    int jack_srate;
+    unsigned long jack_srate;
     double sample_rate;
 
     if(!isaudio)
@@ -491,10 +491,10 @@ fluid_jack_client_register_ports(void *driver, int isaudio, jack_client_t *clien
 
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
 
-    if((int)sample_rate != jack_srate)
+    if((unsigned long)sample_rate != jack_srate)
     {
         FLUID_LOG(FLUID_INFO, "Jack sample rate mismatch, adjusting."
-                  " (synth.sample-rate=%lu, jackd=%lu)", (int)sample_rate, jack_srate);
+                  " (synth.sample-rate=%lu, jackd=%lu)", (unsigned long)sample_rate, jack_srate);
         fluid_settings_setnum(settings, "synth.sample-rate", jack_srate);
     }
 

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -180,7 +180,7 @@ fluid_file_read_full(fluid_file fp, size_t *length)
         return NULL;
     }
 
-    FLUID_LOG(FLUID_DBG, "File load: Allocating %d bytes", buflen);
+    FLUID_LOG(FLUID_DBG, "File load: Allocating %lu bytes", buflen);
     buffer = FLUID_MALLOC(buflen);
 
     if(buffer == NULL)
@@ -193,7 +193,7 @@ fluid_file_read_full(fluid_file fp, size_t *length)
 
     if(n != buflen)
     {
-        FLUID_LOG(FLUID_ERR, "Only read %d bytes; expected %d", n,
+        FLUID_LOG(FLUID_ERR, "Only read %lu bytes; expected %lu", n,
                   buflen);
         FLUID_FREE(buffer);
         return NULL;

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -796,7 +796,7 @@ static int process_info(SFData *sf, int size)
             if((chunk.id != ICMT_FCC && chunk.size > 256) || (chunk.size > 65536) || (chunk.size % 2))
             {
                 FLUID_LOG(FLUID_ERR, "INFO sub chunk %.4s has invalid chunk size of %d bytes",
-                          &chunk.id, chunk.size);
+                          (char*)&chunk.id, chunk.size);
                 return FALSE;
             }
 
@@ -930,19 +930,19 @@ static int pdtahelper(SFData *sf, unsigned int expid, unsigned int reclen, SFChu
 
     if(chunk->id != expid)
     {
-        FLUID_LOG(FLUID_ERR, "Expected PDTA sub-chunk '%.4s' found invalid id instead", &expid);
+        FLUID_LOG(FLUID_ERR, "Expected PDTA sub-chunk '%.4s' found invalid id instead", (char*)&expid);
         return FALSE;
     }
 
     if(chunk->size % reclen)  /* valid chunk size? */
     {
-        FLUID_LOG(FLUID_ERR, "'%.4s' chunk size is not a multiple of %d bytes", &expid, reclen);
+        FLUID_LOG(FLUID_ERR, "'%.4s' chunk size is not a multiple of %d bytes", (char*)&expid, reclen);
         return FALSE;
     }
 
     if((*size -= chunk->size) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "'%.4s' chunk size exceeds remaining PDTA chunk size", &expid);
+        FLUID_LOG(FLUID_ERR, "'%.4s' chunk size exceeds remaining PDTA chunk size", (char*)&expid);
         return FALSE;
     }
 
@@ -2615,7 +2615,7 @@ static int fluid_sffile_read_vorbis(SFData *sf, unsigned int start_byte, unsigne
 
     if(!sndfile)
     {
-        FLUID_LOG(FLUID_ERR, sf_strerror(sndfile));
+        FLUID_LOG(FLUID_ERR, "%s", sf_strerror(sndfile));
         return -1;
     }
 
@@ -2642,7 +2642,7 @@ static int fluid_sffile_read_vorbis(SFData *sf, unsigned int start_byte, unsigne
     if(sf_readf_short(sndfile, wav_data, sfinfo.frames) < sfinfo.frames)
     {
         FLUID_LOG(FLUID_DBG, "Decompression failed!");
-        FLUID_LOG(FLUID_ERR, sf_strerror(sndfile));
+        FLUID_LOG(FLUID_ERR, "%s", sf_strerror(sndfile));
         goto error_exit;
     }
 

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -1481,7 +1481,7 @@ static fluid_thread_return_t fluid_server_socket_run(void *data)
         {
             if(server_socket->cont)
             {
-                FLUID_LOG(FLUID_ERR, "Failed to accept connection: %ld", fluid_socket_get_error());
+                FLUID_LOG(FLUID_ERR, "Failed to accept connection: %d", fluid_socket_get_error());
             }
 
             server_socket->cont = 0;
@@ -1540,7 +1540,7 @@ new_fluid_server_socket(int port, fluid_server_func_t func, void *data)
 
     if(sock == INVALID_SOCKET)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create server socket: %ld", fluid_socket_get_error());
+        FLUID_LOG(FLUID_ERR, "Failed to create server socket: %d", fluid_socket_get_error());
         fluid_socket_cleanup();
         return NULL;
     }
@@ -1555,7 +1555,7 @@ new_fluid_server_socket(int port, fluid_server_func_t func, void *data)
 
     if(sock == INVALID_SOCKET)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create server socket: %ld", fluid_socket_get_error());
+        FLUID_LOG(FLUID_ERR, "Failed to create server socket: %d", fluid_socket_get_error());
         fluid_socket_cleanup();
         return NULL;
     }
@@ -1568,7 +1568,7 @@ new_fluid_server_socket(int port, fluid_server_func_t func, void *data)
 
     if(bind(sock, (const struct sockaddr *) &addr, sizeof(addr)) == SOCKET_ERROR)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to bind server socket: %ld", fluid_socket_get_error());
+        FLUID_LOG(FLUID_ERR, "Failed to bind server socket: %d", fluid_socket_get_error());
         fluid_socket_close(sock);
         fluid_socket_cleanup();
         return NULL;
@@ -1576,7 +1576,7 @@ new_fluid_server_socket(int port, fluid_server_func_t func, void *data)
 
     if(listen(sock, SOMAXCONN) == SOCKET_ERROR)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to listen on server socket: %ld", fluid_socket_get_error());
+        FLUID_LOG(FLUID_ERR, "Failed to listen on server socket: %d", fluid_socket_get_error());
         fluid_socket_close(sock);
         fluid_socket_cleanup();
         return NULL;


### PR DESCRIPTION
Let gcc and clang know that `fluid_log()` receives a `printf` format string, allowing proper type checking, and fix all format warnings that were brought up.

@mawe42 I'm not sure if it's a good idea to "pollute" a public header with this `__attribute__`. But doing so would also allow type checks in user applications. Note that this `format __attribute__` is very old. [GCC 3.2 definitely supports](https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Function-Attributes.html) it, and this [page claims that it can be found in version 2.3](https://www.ohse.de/uwe/articles/gcc-attributes.html#func-format) as well. So I won't do any version checking here.

Edit: ...Thinking about it, we already make quite a lot use of these attributes in public headers (visibility, deprecation).