### PR TITLE
Make Fine Tune destination of default modulator Pitch-Wheel-To-pitch

### DIFF
--- a/include/fluidsynth/gen.h
+++ b/include/fluidsynth/gen.h
@@ -95,10 +95,18 @@ enum fluid_gen_type
     GEN_EXCLUSIVECLASS,		/**< Exclusive class number */
     GEN_OVERRIDEROOTKEY,		/**< Sample root note override */
 
-    /* the initial pitch is not a "standard" generator. It is not
-     * mentioned in the list of generator in the SF2 specifications. It
-     * is used, however, as the destination for the default pitch wheel
-     * modulator. */
+    /* The initial pitch is not a "standard" generator. It is not
+       mentioned in the list of generator in the SF2 specifications.
+       It is used to compute the nominal pitch of a note on note-on event.
+       By nature it shouldn't be allowed to be modulated, however
+       the specification define a default modulator having Initial Pitch
+       as destination(SF2.01 page 57 section 8.4.10 MIDI Pitch Wheel to Initial Pitch ...).
+       That means that it is impossible to cancel this default modulator by
+       an identical modulator from a soundfont, in the hope to use MIDI Pitch Wheel
+       to modulate any other modulator. This convention not flexible isn't adopted
+       by FluidSynth that use a default modulator Pitch Wheel to Fine Tune
+       destination instead of Initial Pitch (See fluid_synth_init()).
+     */
     GEN_PITCH,			/**< Pitch @note Not a real SoundFont generator */
 
     GEN_CUSTOM_BALANCE,          /**< Balance @note Not a real SoundFont generator */

--- a/include/fluidsynth/gen.h
+++ b/include/fluidsynth/gen.h
@@ -95,19 +95,21 @@ enum fluid_gen_type
     GEN_EXCLUSIVECLASS,		/**< Exclusive class number */
     GEN_OVERRIDEROOTKEY,		/**< Sample root note override */
 
-    /* The initial pitch is not a "standard" generator. It is not
-       mentioned in the list of generator in the SF2 specifications.
-       It is used to compute the nominal pitch of a note on note-on event.
-       By nature it shouldn't be allowed to be modulated, however
-       the specification define a default modulator having Initial Pitch
-       as destination(SF2.01 page 57 section 8.4.10 MIDI Pitch Wheel to Initial Pitch ...).
-       That means that it is impossible to cancel this default modulator by
-       an identical modulator from a soundfont, in the hope to use MIDI Pitch Wheel
-       to modulate any other modulator. This convention not flexible isn't adopted
-       by FluidSynth that use a default modulator Pitch Wheel to Fine Tune
-       destination instead of Initial Pitch (See fluid_synth_init()).
+    /**
+     * @brief Initial Pitch
+     *
+     * @note This is not "standard" SoundFont generator, because it is not
+     * mentioned in the list of generators in the SF2 specifications.
+     * It is used by FluidSynth internally to compute the nominal pitch of
+     * a note on note-on event. By nature it shouldn't be allowed to be modulated,
+     * however the specification defines a default modulator having "Initial Pitch"
+     * as destination (cf. SF2.01 page 57 section 8.4.10 MIDI Pitch Wheel to Initial Pitch).
+     * Thus it is impossible to cancel this default modulator, which would be required
+     * to let the MIDI Pitch Wheel controller modulate a different generator.
+     * In order to provide this flexibility, FluidSynth >= 2.1.0 uses a default modulator
+     * "Pitch Wheel to Fine Tune", rather than Initial Pitch.
      */
-    GEN_PITCH,			/**< Pitch @note Not a real SoundFont generator */
+    GEN_PITCH,
 
     GEN_CUSTOM_BALANCE,          /**< Balance @note Not a real SoundFont generator */
     /* non-standard generator for an additional custom high- or low-pass filter */

--- a/include/fluidsynth/gen.h
+++ b/include/fluidsynth/gen.h
@@ -107,7 +107,8 @@ enum fluid_gen_type
      * Thus it is impossible to cancel this default modulator, which would be required
      * to let the MIDI Pitch Wheel controller modulate a different generator.
      * In order to provide this flexibility, FluidSynth >= 2.1.0 uses a default modulator
-     * "Pitch Wheel to Fine Tune", rather than Initial Pitch.
+     * "Pitch Wheel to Fine Tune", rather than Initial Pitch. The same "compromise" can
+     * be found on the Audigy 2 ZS for instance.
      */
     GEN_PITCH,
 

--- a/src/synth/fluid_gen.c
+++ b/src/synth/fluid_gen.c
@@ -26,7 +26,7 @@
 /* See SFSpec21 $8.1.3 */
 static const fluid_gen_info_t fluid_gen_info[] =
 {
-    /* number/name             init  scale         min        max         def */
+    /* number/name             init  nrpn-scale    min        max         def */
     { GEN_STARTADDROFS,           1,     1,       0.0f,     1e10f,       0.0f },
     { GEN_ENDADDROFS,             1,     1,     -1e10f,      0.0f,       0.0f },
     { GEN_STARTLOOPADDROFS,       1,     1,     -1e10f,     1e10f,       0.0f },

--- a/src/synth/fluid_gen.h
+++ b/src/synth/fluid_gen.h
@@ -27,7 +27,7 @@
 typedef struct _fluid_gen_info_t
 {
     char num;		/* Generator number */
-    char init;		/* Does the generator need to be initialized (cfr. fluid_voice_init()) */
+    char init;		/* Does the generator need to be initialized (not used) */
     char nrpn_scale;	/* The scale to convert from NRPN (cfr. fluid_gen_map_nrpn()) */
     float min;		/* The minimum value */
     float max;		/* The maximum value */

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -431,6 +431,10 @@ fluid_synth_init(void)
 
 
     /* SF2.01 page 57 section 8.4.10 MIDI Pitch Wheel to Initial Pitch ... */
+    /* Initial Pitch is not a "standard" generator. It isn't mentioned in the
+       list of generator in the SF2 specifications. Destination Initial Pitch
+       is replaced here by fine tune generator.
+     */
     fluid_mod_set_source1(&default_pitch_bend_mod, FLUID_MOD_PITCHWHEEL, /* Index=14 */
                           FLUID_MOD_GC                              /* CC =0 */
                           | FLUID_MOD_LINEAR                        /* type=0 */
@@ -443,7 +447,9 @@ fluid_synth_init(void)
                           | FLUID_MOD_UNIPOLAR                                /* P=0 */
                           | FLUID_MOD_POSITIVE                                /* D=0 */
                          );
-    fluid_mod_set_dest(&default_pitch_bend_mod, GEN_PITCH);                 /* Destination: Initial pitch */
+    /* Destination Initial Pitch (GEN_PITCH) is replaced by Fine Tune (GEN_FINETUNE) */
+    /* See comment in gen.h about GEN_PITCH */
+    fluid_mod_set_dest(&default_pitch_bend_mod, GEN_FINETUNE);              /* Destination: Fine Tune */
     fluid_mod_set_amount(&default_pitch_bend_mod, 12700.0);                 /* Amount: 12700 cents */
 
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -447,7 +447,6 @@ fluid_synth_init(void)
                           | FLUID_MOD_UNIPOLAR                                /* P=0 */
                           | FLUID_MOD_POSITIVE                                /* D=0 */
                          );
-    /* Destination Initial Pitch (GEN_PITCH) is replaced by Fine Tune (GEN_FINETUNE) */
     /* Also see the comment in gen.h about GEN_PITCH */
     fluid_mod_set_dest(&default_pitch_bend_mod, GEN_FINETUNE);              /* Destination: Fine Tune */
     fluid_mod_set_amount(&default_pitch_bend_mod, 12700.0);                 /* Amount: 12700 cents */

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -431,8 +431,8 @@ fluid_synth_init(void)
 
 
     /* SF2.01 page 57 section 8.4.10 MIDI Pitch Wheel to Initial Pitch ... */
-    /* Initial Pitch is not a "standard" generator. It isn't mentioned in the
-       list of generator in the SF2 specifications. Destination Initial Pitch
+    /* Initial Pitch is not a "standard" generator, because it isn't mentioned in the
+       list of generators in the SF2 specifications. That's why destination Initial Pitch
        is replaced here by fine tune generator.
      */
     fluid_mod_set_source1(&default_pitch_bend_mod, FLUID_MOD_PITCHWHEEL, /* Index=14 */
@@ -448,7 +448,7 @@ fluid_synth_init(void)
                           | FLUID_MOD_POSITIVE                                /* D=0 */
                          );
     /* Destination Initial Pitch (GEN_PITCH) is replaced by Fine Tune (GEN_FINETUNE) */
-    /* See comment in gen.h about GEN_PITCH */
+    /* Also see the comment in gen.h about GEN_PITCH */
     fluid_mod_set_dest(&default_pitch_bend_mod, GEN_FINETUNE);              /* Destination: Fine Tune */
     fluid_mod_set_amount(&default_pitch_bend_mod, 12700.0);                 /* Amount: 12700 cents */
 


### PR DESCRIPTION
This PR change the destination of `Pitch-Wheel-To-pitch default modulator` being `fine tune` instead of `Initial Pitch` generator. Fixes #154
