### PR TITLE
AudioObjectGetPropertyDataSize returns the number of buffers

### DIFF
--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -85,8 +85,7 @@ get_num_outputs(AudioDeviceID deviceID)
 
     if(OK(AudioObjectGetPropertyDataSize(deviceID, &pa, 0, 0, &size)))
     {
-        int num = size / (int) sizeof(AudioBufferList);
-        AudioBufferList bufList[num];
+        AudioBufferList bufList[size];
 
         if(OK(AudioObjectGetPropertyData(deviceID, &pa, 0, 0, &size, bufList)))
         {


### PR DESCRIPTION
I found it due to crash in address sanitizer for `num == 0`
Reference usage:
https://github.com/chromium/chromium/blob/master/media/audio/mac/audio_manager_mac.cc#L261

BTW, what happened to the 2.0.x branch?