### PR TITLE
Deprecate usage of the system timer for the sequencer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,6 @@ task:
             # There isn't a stable 13.0 image yet (2019-09)
             image_family: freebsd-13-0-snap
             image_family: freebsd-12-0
-            image_family: freebsd-10-4
 
     install_script: pwd && ls -la && pkg install -y cmake glib alsa-lib ladspa portaudio pulseaudio pkgconf sdl2
     

--- a/doc/fluidsynth-v20-devdoc.txt
+++ b/doc/fluidsynth-v20-devdoc.txt
@@ -21,6 +21,7 @@ All the source code examples in this document are in the public domain; you can 
 
 - \ref Disclaimer
 - \ref Introduction
+- \ref NewIn2_1_1
 - \ref NewIn2_1_0
 - \ref NewIn2_0_8
 - \ref NewIn2_0_7
@@ -66,6 +67,10 @@ What is FluidSynth?
 - FluidSynth can easily be embedded in an application. It has a main header file, fluidsynth.h, and one dynamically linkable library. FluidSynth runs on Linux, Mac OS X, and the Windows platforms, and support for OS/2 and OpenSolaris is experimental. It has audio and midi drivers for all mentioned platforms but you can use it with your own drivers if your application already handles MIDI and audio input/output. This document explains the basic usage of FluidSynth and provides examples that you can reuse. 
 
 - FluidSynth is open source, in active development. For more details, take a look at http://www.fluidsynth.org
+
+\section NewIn2_1_1 Whats new in 2.1.1?
+
+- using the sequencer with the system timer as timing source has been deprecated
 
 \section NewIn2_1_0 Whats new in 2.1.0?
 

--- a/doc/fluidsynth_arpeggio.c
+++ b/doc/fluidsynth_arpeggio.c
@@ -57,7 +57,7 @@ schedule_noteoff(int chan, short key, unsigned int ticks)
 
 /* schedule a timer event (shall trigger the callback) */
 void
-schedule_timer_event()
+schedule_timer_event(void)
 {
     fluid_event_t *ev = new_fluid_event();
     fluid_event_set_source(ev, -1);
@@ -69,7 +69,7 @@ schedule_timer_event()
 
 /* schedule the arpeggio's notes */
 void
-schedule_pattern()
+schedule_pattern(void)
 {
     int i, note_time, note_duration;
     note_time = time_marker;
@@ -124,7 +124,7 @@ main(int argc, char *argv[])
 
         if(n != -1)
         {
-            sequencer = new_fluid_sequencer();
+            sequencer = new_fluid_sequencer2(0);
             /* register the synth with the sequencer */
             synth_destination = fluid_sequencer_register_fluidsynth(sequencer,
                                 synth);

--- a/doc/fluidsynth_metronome.c
+++ b/doc/fluidsynth_metronome.c
@@ -47,7 +47,7 @@ schedule_noteon(int chan, short key, unsigned int ticks)
 
 /* schedule a timer event (shall trigger the callback) */
 void
-schedule_timer_event()
+schedule_timer_event(void)
 {
     fluid_event_t *ev = new_fluid_event();
     fluid_event_set_source(ev, -1);
@@ -59,7 +59,7 @@ schedule_timer_event()
 
 /* schedule the metronome pattern */
 void
-schedule_pattern()
+schedule_pattern(void)
 {
     int i, note_time;
     note_time = time_marker;
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
 
         if(n != -1)
         {
-            sequencer = new_fluid_sequencer();
+            sequencer = new_fluid_sequencer2(0);
             /* register the synth with the sequencer */
             synth_destination = fluid_sequencer_register_fluidsynth(sequencer,
                                 synth);

--- a/include/fluidsynth/seq.h
+++ b/include/fluidsynth/seq.h
@@ -41,7 +41,7 @@ typedef void (*fluid_event_callback_t)(unsigned int time, fluid_event_t *event,
                                        fluid_sequencer_t *seq, void *data);
 
 
-FLUIDSYNTH_API fluid_sequencer_t *new_fluid_sequencer(void);
+FLUID_DEPRECATED FLUIDSYNTH_API fluid_sequencer_t *new_fluid_sequencer(void);
 FLUIDSYNTH_API fluid_sequencer_t *new_fluid_sequencer2(int use_system_timer);
 FLUIDSYNTH_API void delete_fluid_sequencer(fluid_sequencer_t *seq);
 FLUIDSYNTH_API int fluid_sequencer_get_use_system_timer(fluid_sequencer_t *seq);

--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -93,6 +93,7 @@ static void _fluid_free_evt_queue(fluid_evt_entry **first, fluid_evt_entry **las
  * new_fluid_sequencer2() to specify whether the system timer or
  * fluid_sequencer_process() is used to advance the sequencer.
  * @return New sequencer instance
+ * @deprecated As of fluidsynth 2.1.1 the use of the system timer has been deprecated.
  */
 fluid_sequencer_t *
 new_fluid_sequencer(void)
@@ -107,6 +108,7 @@ new_fluid_sequencer(void)
  *   the sequencer.
  * @return New sequencer instance
  * @since 1.1.0
+ * @note As of fluidsynth 2.1.1 the use of the system timer has been deprecated.
  */
 fluid_sequencer_t *
 new_fluid_sequencer2(int use_system_timer)
@@ -202,6 +204,7 @@ delete_fluid_sequencer(fluid_sequencer_t *seq)
  * @param seq Sequencer object
  * @return TRUE if system timer is being used, FALSE otherwise.
  * @since 1.1.0
+ * @deprecated As of fluidsynth 2.1.1 the usage of the system timer has been deprecated.
  */
 int
 fluid_sequencer_get_use_system_timer(fluid_sequencer_t *seq)
@@ -903,7 +906,11 @@ _fluid_seq_queue_process(void *data, unsigned int msec)
 }
 
 /**
- * Advance a sequencer that isn't using the system timer.
+ * Advance a sequencer.
+ *
+ * If you have registered the synthesizer as client (fluid_sequencer_register_fluidsynth()), the synth
+ * will take care of calling fluid_sequencer_process(). Otherwise it is up to the user to
+ * advance the sequencer manually.
  * @param seq Sequencer object
  * @param msec Time to advance sequencer to (absolute time since sequencer start).
  * @since 1.1.0

--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -115,6 +115,11 @@ new_fluid_sequencer2(int use_system_timer)
 {
     fluid_sequencer_t *seq;
 
+    if(use_system_timer)
+    {
+        FLUID_LOG(FLUID_WARN, "sequencer: Usage of the system timer has been deprecated!");
+    }
+
     seq = FLUID_NEW(fluid_sequencer_t);
 
     if(seq == NULL)


### PR DESCRIPTION
See https://lists.nongnu.org/archive/html/fluid-dev/2019-12/msg00010.html