### PR TITLE
Solve the sequencer client unregistering problem - dropped

### DIFF
--- a/src/midi/fluid_seqbind.c
+++ b/src/midi/fluid_seqbind.c
@@ -56,19 +56,27 @@ delete_fluid_seqbind(fluid_seqbind_t *seqbind)
 {
     fluid_return_if_fail(seqbind != NULL);
 
-    if((seqbind->client_id != -1) && (seqbind->seq != NULL))
-    {
-        fluid_sequencer_unregister_client(seqbind->seq, seqbind->client_id);
-        seqbind->client_id = -1;
-    }
-
     if((seqbind->sample_timer != NULL) && (seqbind->synth != NULL))
     {
         delete_fluid_sample_timer(seqbind->synth, seqbind->sample_timer);
         seqbind->sample_timer = NULL;
     }
 
-    FLUID_FREE(seqbind);
+    // conditional free() ahead!
+    // if a previous call to fluid_sequencer_register_fluidsynth() was successful, client_id is guaranteed
+    // to be !=-1
+    if(seqbind->client_id != -1)
+    {
+        if(seqbind->seq != NULL)
+        {
+            fluid_seq_id_t id = seqbind->client_id;
+            // Unregister_client calls the sequencer callback again, causing two calls to free() below.
+            // Setting the client_id to -1 makes sure that there will be only one call to free().
+            seqbind->client_id = -1;
+            fluid_sequencer_unregister_client(seqbind->seq, id);
+        }
+        FLUID_FREE(seqbind);
+    }
 }
 
 /**
@@ -117,6 +125,7 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
 
     FLUID_MEMSET(seqbind, 0, sizeof(*seqbind));
 
+    seqbind->client_id = -1;
     seqbind->synth = synth;
     seqbind->seq = seq;
 
@@ -129,7 +138,7 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
         if(seqbind->sample_timer == NULL)
         {
             FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
-            delete_fluid_seqbind(seqbind);
+            FLUID_FREE(seqbind);
             return FLUID_FAILED;
         }
     }
@@ -140,7 +149,8 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
 
     if(seqbind->client_id == FLUID_FAILED)
     {
-        delete_fluid_seqbind(seqbind);
+        delete_fluid_sample_timer(seqbind->synth, seqbind->sample_timer);
+        FLUID_FREE(seqbind);
         return FLUID_FAILED;
     }
 

--- a/test/test_seq_event_queue_sort.c
+++ b/test/test_seq_event_queue_sort.c
@@ -9,7 +9,7 @@ static short order = 0;
 void callback_stable_sort(unsigned int time, fluid_event_t *event, fluid_sequencer_t *seq, void *data)
 {
     static const enum fluid_seq_event_type expected_type_order[] =
-    { FLUID_SEQ_SYSTEMRESET, FLUID_SEQ_UNREGISTERING, FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON };
+    { FLUID_SEQ_SYSTEMRESET, FLUID_SEQ_UNREGISTERING, FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON, FLUID_SEQ_UNREGISTERING };
 
     TEST_ASSERT(fluid_event_get_type(event) == expected_type_order[order++]);
 }

--- a/test/test_seq_scale.c
+++ b/test/test_seq_scale.c
@@ -42,7 +42,8 @@ static const unsigned int expected_callback_times[] =
     1560, 1560, 1680, 1680, 1800, 1800, 1920, 2700,
     2820, 2820, 2940, 2940, 3060, 3060, 3180, 4275,
     4395, 4395, 4515, 4515, 4635, 4635, 4755,
-    799, 919, 919, 1039, 1039, 1159, 1159, 1279
+    799, 919, 919, 1039, 1039, 1159, 1159, 1279,
+    15999
 };
 
 static void fake_synth_callback(unsigned int time, fluid_event_t *event, fluid_sequencer_t *seq, void *data)
@@ -122,6 +123,10 @@ static void seq_callback(unsigned int time, fluid_event_t *event, fluid_sequence
         sendnoteon(0, 47, 0, 360);
         sendnoteon(0, 47, 100, 360);
         sendnoteon(0, 47, 0, 480);
+        break;
+
+    case 5:
+        // this is the unregistering event, ignore
         break;
 
     default:


### PR DESCRIPTION
The function [fluid_sequencer_register_fluidsynth](http://www.fluidsynth.org/api/seqbind_8h.html#ae18ee23fd409270c9da4f0cd5c557c3d), allocates an internal structure that glues the synth and the sequencer together. The pointer to that structure is kept in the sequencer internally. The user only receives a client id. When the sequencer is deleted, this structure should be freed again. In fluidsynth 1.1.x this was the case. However, under a certain condition, it could have led to a double free. At this time I saw no other option to fix the double free by making users to force unregistering any clients explicitly in their code. 

Today, we have a unit test `test_seqbind_unregister` which tests 3 ways to unregister. None of them ends in a double-free, but two of them leak the internal structure. This is not satisfying, which is I'm now bringing up two solutions which make sure that:

* Explicit client unregistering is not needed anymore (i.e. it is implicitly done when calling `delete_fluid_sequencer()`), and
* explicit client unregistering does not lead to a double free when calling `delete_fluid_sequencer()` afterwards.

This PR is the first proposal how to solve this. (The unit test `test_seq_event_queue_sort` currently fails, don't know why, will investigate if we decide to go with this solution.)

Explicit unregistering may be accomplished by:

1. Calling `fluid_sequencer_unregister_client()`, or
1. Sending a `FLUID_SEQ_UNREGISTERING` event via `fluid_sequencer_send_now()`

With this solution, the callback function passed to `fluid_sequencer_client_register()` must handle `FLUID_SEQ_UNREGISTERING` events by calling `fluid_sequencer_client_unregister()` (see case 2.). Although this only matters for clients that implement their custom callback.

Opinions?