### PR TITLE
Solve the sequencer client unregistering problem

### DIFF
--- a/doc/fluidsynth-v20-devdoc.txt
+++ b/doc/fluidsynth-v20-devdoc.txt
@@ -67,6 +67,10 @@ What is FluidSynth?
 
 - FluidSynth is open source, in active development. For more details, take a look at http://www.fluidsynth.org
 
+\section NewIn2_1_1 What's new in 2.1.1?
+
+- requirements for explicit sequencer client unregistering have been relaxed: delete_fluid_sequencer() now correctly frees any registered sequencer clients (clients can still be explicitly unregistered)
+
 \section NewIn2_1_0 What's new in 2.1.0?
 
 - <span style="color:red">refrain from using fluid_synth_set_sample_rate()</span>
@@ -116,7 +120,7 @@ FluidSynths major version was bumped. The API was reworked, deprecated functions
 
 - all public \c fluid_settings_* functions that return an integer which is not meant to be interpreted as bool consistently return either FLUID_OK or FLUID_FAILED
 - fluid_settings_setstr() cannot be used to set integer (toggle) settings with "yes" or "no" values anymore. Use fluid_settings_setint() instead, for example: <br /><code>fluid_settings_setint(settings, "synth.reverb.active", 0)</code> instead of <code>fluid_settings_setstr(settings, "synth.reverb.active", "no")</code>
-- explicit client unregistering is required for fluid_sequencer_register_client() and fluid_sequencer_register_fluidsynth()
+- <span style="text-decoration:line-through;">explicit client unregistering is required for fluid_sequencer_register_client() and fluid_sequencer_register_fluidsynth()</span> (since fluidsynth 2.1.1 not required anymore, but still recommend)
 - all public functions consistently receive signed integers for soundfont ids, bank and program numbers
 - use unique device names for the "audio.portaudio.device" setting
 - fluid_synth_process() received a new more flexible implementation, but now requires zeroed-out sample buffers

--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -389,15 +389,11 @@ fluid_sequencer_send_now(fluid_sequencer_t *seq, fluid_event_t *evt)
 {
     fluid_seq_id_t destID;
     fluid_list_t *tmp;
-    unsigned int now = fluid_sequencer_get_tick(seq);
 
     fluid_return_if_fail(seq != NULL);
     fluid_return_if_fail(evt != NULL);
 
     destID = fluid_event_get_dest(evt);
-
-    /* time stamp event */
-    fluid_event_set_time(evt, now);
 
     /* find callback */
     tmp = seq->clients;
@@ -416,7 +412,7 @@ fluid_sequencer_send_now(fluid_sequencer_t *seq, fluid_event_t *evt)
             {
                 if(dest->callback)
                 {
-                    (dest->callback)(now, evt, seq, dest->data);
+                    (dest->callback)(fluid_sequencer_get_tick(seq), evt, seq, dest->data);
                 }
             }
             return;

--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -136,7 +136,7 @@ new_fluid_sequencer2(int use_system_timer)
 
 /**
  * Free a sequencer object.
- * @note Registered sequencer clients may not be fully freed by this function. Explicitly unregister them with fluid_sequencer_unregister_client().
+ * @note Before fluidsynth 2.1.1 registered sequencer clients may not be fully freed by this function.
  * @param seq Sequencer to delete
  */
 void
@@ -181,11 +181,10 @@ fluid_sequencer_get_use_system_timer(fluid_sequencer_t *seq)
  * @param data User data to pass to the \a callback
  * @return Unique sequencer ID or #FLUID_FAILED on error
  *
- * Clients can be sources or destinations of events.  Sources don't need to
+ * Clients can be sources or destinations of events. Sources don't need to
  * register a callback.
  *
- * @note The user must explicitly unregister any registered client with fluid_sequencer_unregister_client()
- * before deleting the sequencer!
+ * @note Implementations are encouraged to explicitly unregister any registered client with fluid_sequencer_unregister_client() before deleting the sequencer.
  */
 fluid_seq_id_t
 fluid_sequencer_register_client(fluid_sequencer_t *seq, const char *name,

--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -408,11 +408,17 @@ fluid_sequencer_send_now(fluid_sequencer_t *seq, fluid_event_t *evt)
 
         if(dest->id == destID)
         {
-            if(dest->callback)
+            if(fluid_event_get_type(evt) == FLUID_SEQ_UNREGISTERING)
             {
-                (dest->callback)(now, evt, seq, dest->data);
+                fluid_sequencer_unregister_client(seq, destID);
             }
-
+            else
+            {
+                if(dest->callback)
+                {
+                    (dest->callback)(now, evt, seq, dest->data);
+                }
+            }
             return;
         }
 

--- a/src/midi/fluid_seqbind.c
+++ b/src/midi/fluid_seqbind.c
@@ -56,27 +56,19 @@ delete_fluid_seqbind(fluid_seqbind_t *seqbind)
 {
     fluid_return_if_fail(seqbind != NULL);
 
+    if((seqbind->client_id != -1) && (seqbind->seq != NULL))
+    {
+        fluid_sequencer_unregister_client(seqbind->seq, seqbind->client_id);
+        seqbind->client_id = -1;
+    }
+
     if((seqbind->sample_timer != NULL) && (seqbind->synth != NULL))
     {
         delete_fluid_sample_timer(seqbind->synth, seqbind->sample_timer);
         seqbind->sample_timer = NULL;
     }
 
-    // conditional free() ahead!
-    // if a previous call to fluid_sequencer_register_fluidsynth() was successful, client_id is guaranteed
-    // to be !=-1
-    if(seqbind->client_id != -1)
-    {
-        if(seqbind->seq != NULL)
-        {
-            fluid_seq_id_t id = seqbind->client_id;
-            // Unregister_client calls the sequencer callback again, causing two calls to free() below.
-            // Setting the client_id to -1 makes sure that there will be only one call to free().
-            seqbind->client_id = -1;
-            fluid_sequencer_unregister_client(seqbind->seq, id);
-        }
-        FLUID_FREE(seqbind);
-    }
+    FLUID_FREE(seqbind);
 }
 
 /**

--- a/src/midi/fluid_seqbind.c
+++ b/src/midi/fluid_seqbind.c
@@ -75,9 +75,9 @@ delete_fluid_seqbind(fluid_seqbind_t *seqbind)
  * Registers a synthesizer as a destination client of the given sequencer.
  * The \a synth is registered with the name "fluidsynth".
  *
- * @warning Due to internal memory allocation, the user must explicitly unregister
- * the client by sending a fluid_event_unregistering(). Otherwise the behaviour is
- * undefined after either \p seq or \p synth is destroyed.
+ * @note Implementations are encouraged to explicitly unregister this client either by calling
+ * fluid_sequencer_unregister_client() or by sending an unregistering event to the sequencer. Before
+ * fluidsynth 2.1.1 this was mandatory to avoid memory leaks.
 @code{.cpp}
 fluid_seq_id_t seqid = fluid_sequencer_register_fluidsynth(seq, synth);
 

--- a/src/midi/fluid_seqbind.c
+++ b/src/midi/fluid_seqbind.c
@@ -56,19 +56,27 @@ delete_fluid_seqbind(fluid_seqbind_t *seqbind)
 {
     fluid_return_if_fail(seqbind != NULL);
 
-    if((seqbind->client_id != -1) && (seqbind->seq != NULL))
-    {
-        fluid_sequencer_unregister_client(seqbind->seq, seqbind->client_id);
-        seqbind->client_id = -1;
-    }
-
     if((seqbind->sample_timer != NULL) && (seqbind->synth != NULL))
     {
         delete_fluid_sample_timer(seqbind->synth, seqbind->sample_timer);
         seqbind->sample_timer = NULL;
     }
 
-    FLUID_FREE(seqbind);
+    // conditional free() ahead!
+    // if a previous call to fluid_sequencer_register_fluidsynth() was successful, client_id is guaranteed
+    // to be !=-1
+    if(seqbind->client_id != -1)
+    {
+        if(seqbind->seq != NULL)
+        {
+            fluid_seq_id_t id = seqbind->client_id;
+            // Unregister_client calls the sequencer callback again, causing two calls to free() below.
+            // Setting the client_id to -1 makes sure that there will be only one call to free().
+            seqbind->client_id = -1;
+            fluid_sequencer_unregister_client(seqbind->seq, id);
+        }
+        FLUID_FREE(seqbind);
+    }
 }
 
 /**
@@ -117,6 +125,7 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
 
     FLUID_MEMSET(seqbind, 0, sizeof(*seqbind));
 
+    seqbind->client_id = -1;
     seqbind->synth = synth;
     seqbind->seq = seq;
 
@@ -129,7 +138,7 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
         if(seqbind->sample_timer == NULL)
         {
             FLUID_LOG(FLUID_PANIC, "sequencer: Out of memory\n");
-            delete_fluid_seqbind(seqbind);
+            FLUID_FREE(seqbind);
             return FLUID_FAILED;
         }
     }
@@ -140,7 +149,8 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
 
     if(seqbind->client_id == FLUID_FAILED)
     {
-        delete_fluid_seqbind(seqbind);
+        delete_fluid_sample_timer(seqbind->synth, seqbind->sample_timer);
+        FLUID_FREE(seqbind);
         return FLUID_FAILED;
     }
 

--- a/test/test_seq_event_queue_sort.c
+++ b/test/test_seq_event_queue_sort.c
@@ -9,7 +9,7 @@ static short order = 0;
 void callback_stable_sort(unsigned int time, fluid_event_t *event, fluid_sequencer_t *seq, void *data)
 {
     static const enum fluid_seq_event_type expected_type_order[] =
-    { FLUID_SEQ_SYSTEMRESET, FLUID_SEQ_UNREGISTERING, FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON, FLUID_SEQ_UNREGISTERING };
+    { FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON, FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON, FLUID_SEQ_SYSTEMRESET, FLUID_SEQ_UNREGISTERING };
 
     TEST_ASSERT(fluid_event_get_type(event) == expected_type_order[order++]);
 }
@@ -26,31 +26,34 @@ void test_order_same_tick(fluid_sequencer_t *seq, fluid_event_t *evt)
 
     for(i = 1; i <= 2; i++)
     {
-        fluid_event_system_reset(evt);
-        TEST_SUCCESS(fluid_sequencer_send_at(seq, evt, i, 1));
-        fluid_event_unregistering(evt);
-        TEST_SUCCESS(fluid_sequencer_send_at(seq, evt, i, 1));
         fluid_event_noteoff(evt, 0, 64);
         TEST_SUCCESS(fluid_sequencer_send_at(seq, evt, i, 1));
         fluid_event_noteon(evt, 0, 64, 127);
         TEST_SUCCESS(fluid_sequencer_send_at(seq, evt, i, 1));
     }
 
-    fluid_sequencer_process(seq, 1);
-    TEST_ASSERT(order == 4);
+    fluid_event_system_reset(evt);
+    TEST_SUCCESS(fluid_sequencer_send_at(seq, evt, 2, 1));
+    fluid_event_unregistering(evt);
+    TEST_SUCCESS(fluid_sequencer_send_at(seq, evt, 2, 1));
 
-    order = 0;
+    fluid_sequencer_process(seq, 1);
+    TEST_ASSERT(order == 2);
 
     fluid_sequencer_process(seq, 2);
-    TEST_ASSERT(order == 4);
+    TEST_ASSERT(order == 6);
 
     fluid_sequencer_unregister_client(seq, seqid);
     TEST_ASSERT(fluid_sequencer_count_clients(seq) == 0);
 }
 
-static unsigned int prev_time;
+static unsigned int prev_time, done = FALSE;
 void callback_correct_order(unsigned int time, fluid_event_t *event, fluid_sequencer_t *seq, void *data)
 {
+    if(done)
+    {
+        return;
+    }
     TEST_ASSERT(fluid_event_get_type(event) == FLUID_SEQ_CONTROLCHANGE);
     TEST_ASSERT(prev_time <= fluid_event_get_time(event) && fluid_event_get_time(event) <= prev_time + 1);
     prev_time = fluid_event_get_time(event);
@@ -91,6 +94,7 @@ void test_correct_order(fluid_sequencer_t *seq, fluid_event_t *evt)
     fluid_sequencer_process(seq, i + offset);
     TEST_ASSERT(prev_time == (i - 1) + offset);
 
+    done = TRUE;
     fluid_sequencer_unregister_client(seq, seqid);
 }
 

--- a/test/test_seq_event_queue_sort.c
+++ b/test/test_seq_event_queue_sort.c
@@ -8,7 +8,7 @@
 static short order = 0;
 void callback_stable_sort(unsigned int time, fluid_event_t *event, fluid_sequencer_t *seq, void *data)
 {
-    static const enum fluid_seq_event_type expected_type_order[] =
+    static const int expected_type_order[] =
     { FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON, FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON, FLUID_SEQ_SYSTEMRESET, FLUID_SEQ_UNREGISTERING };
 
     TEST_ASSERT(fluid_event_get_type(event) == expected_type_order[order++]);
@@ -52,9 +52,12 @@ void callback_correct_order(unsigned int time, fluid_event_t *event, fluid_seque
 {
     if(done)
     {
-        return;
+        TEST_ASSERT(fluid_event_get_type(event) == FLUID_SEQ_UNREGISTERING);
     }
-    TEST_ASSERT(fluid_event_get_type(event) == FLUID_SEQ_CONTROLCHANGE);
+    else
+    {
+        TEST_ASSERT(fluid_event_get_type(event) == FLUID_SEQ_CONTROLCHANGE);
+    }
     TEST_ASSERT(prev_time <= fluid_event_get_time(event) && fluid_event_get_time(event) <= prev_time + 1);
     prev_time = fluid_event_get_time(event);
 }

--- a/test/test_seq_event_queue_sort.c
+++ b/test/test_seq_event_queue_sort.c
@@ -9,7 +9,7 @@ static short order = 0;
 void callback_stable_sort(unsigned int time, fluid_event_t *event, fluid_sequencer_t *seq, void *data)
 {
     static const enum fluid_seq_event_type expected_type_order[] =
-    { FLUID_SEQ_SYSTEMRESET, FLUID_SEQ_UNREGISTERING, FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON };
+    { FLUID_SEQ_SYSTEMRESET, FLUID_SEQ_UNREGISTERING, FLUID_SEQ_NOTEOFF, FLUID_SEQ_NOTEON, FLUID_SEQ_UNREGISTERING };
 
     TEST_ASSERT(fluid_event_get_type(event) == expected_type_order[order++]);
 }

--- a/test/test_seq_scale.c
+++ b/test/test_seq_scale.c
@@ -42,7 +42,8 @@ static const unsigned int expected_callback_times[] =
     1560, 1560, 1680, 1680, 1800, 1800, 1920, 2700,
     2820, 2820, 2940, 2940, 3060, 3060, 3180, 4275,
     4395, 4395, 4515, 4515, 4635, 4635, 4755,
-    799, 919, 919, 1039, 1039, 1159, 1159, 1279
+    799, 919, 919, 1039, 1039, 1159, 1159, 1279,
+    15999
 };
 
 static void fake_synth_callback(unsigned int time, fluid_event_t *event, fluid_sequencer_t *seq, void *data)
@@ -122,6 +123,10 @@ static void seq_callback(unsigned int time, fluid_event_t *event, fluid_sequence
         sendnoteon(0, 47, 0, 360);
         sendnoteon(0, 47, 100, 360);
         sendnoteon(0, 47, 0, 480);
+        break;
+
+    case 5:
+        // this is the unregistering event, ignore
         break;
 
     default:


### PR DESCRIPTION
This is the second solution to the problem of #609.

The difference is that responsibility for calling `fluid_sequencer_unregister_client()` in case of `FLUID_SEQ_UNREGISTERING` events has been moved to `fluid_sequencer_send_now()`. In other words, a `FLUID_SEQ_UNREGISTERING` event now really unregisters the client, no matter how the client's  callback function looks like. I'm afraid that technically this is a breaking change. This is also the reason why the unit test `test_seq_event_queue_sort` currently fails. (I'll fix the test if we decide to move forward with this approach.)

Opinions?