### PR TITLE
Add ubsan and asan to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
     - CMAKE_FLAGS="-Denable-network=0"
     - CMAKE_FLAGS="-Denable-aufile=0"
     - CMAKE_FLAGS="-DBUILD_SHARED_LIBS=0"
+    - CMAKE_FLAGS="-Denable-ubsan=1"
 
 matrix:
   include:
@@ -44,9 +45,6 @@ matrix:
         - CMAKE_FLAGS="-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
 
     - env:
-        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9 && sudo apt-get install gcc-9"
-
-    - env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7 && sudo apt-get install clang-7"
 
     - env:
@@ -55,7 +53,6 @@ matrix:
 
     - env:
         - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9 && sudo apt-get install clang-9"
-        - CMAKE_FLAGS="-Denable-ubsan=1"
 
     - os: linux-ppc64le
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-bionic-7
     - llvm-toolchain-bionic-8
+    - llvm-toolchain-bionic-9
     packages:
     - cmake-data
     - cmake
@@ -43,11 +44,18 @@ matrix:
         - CMAKE_FLAGS="-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
 
     - env:
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9 && sudo apt-get install gcc-9"
+
+    - env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7 && sudo apt-get install clang-7"
 
     - env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8 && sudo rm -f /usr/local/clang-7.0.0/bin/clang-tidy && sudo ln -s /usr/bin/clang-tidy-8 /usr/bin/clang-tidy && sudo apt-get install clang-8 clang-tidy-8"
         - CMAKE_FLAGS="-Denable-profiling=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold"
+
+    - env:
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9 && sudo apt-get install clang-9"
+        - CMAKE_FLAGS="-Denable-ubsan=1"
 
     - os: linux-ppc64le
       env:


### PR DESCRIPTION
Add a CI job that compiles with `-Denable-ubsan=1`. ASAN will make unit tests fail if it detects memory leaks.