### PR TITLE
CMakeLists.txt: make positional code (-fPIC) customizible.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,9 @@ set(CMAKE_C_STANDARD 90)
 # Compile with position independent code if the user requested a shared lib, i.e. no PIC if static requested.
 # This is cmakes default behavior, but here it's explicitly required due to the use of libfluidsynth-OBJ as object library,
 # which would otherwise always be compiled without PIC.
-set ( CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS} )
+if ( NOT CMAKE_POSITION_INDEPENDENT_CODE )
+    set ( CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS} )
+endif ( CMAKE_POSITION_INDEPENDENT_CODE )
 
 # the default global visibility level for all target
 # no visibility support on OS2


### PR DESCRIPTION
For some use cases it is necessary to specify -fPIC even if we build
static library e.g. building vst plugins (*.so) which may not load
shared libraries from outside the system paths (depends on DAWs).
For such environment we would like to build the final shared library
without depending on `libfluidsynth.so(.*)` but if we build libfluidsynth.a
it always comes without -fPIC. This change makes it optional.