### PR TITLE
Fix linking against libinstpatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,6 +709,7 @@ link_directories (
     ${DBUS_LIBRARY_DIRS}
     ${SDL2_LIBRARY_DIRS}
     ${OBOE_LIBRARY_DIRS}
+    ${LIBINSTPATCH_LIBRARY_DIRS}
 )
 
 # Process subdirectories


### PR DESCRIPTION
This fixes the case where linking fails if libinstpatch is not installed in a system/default location but instead needs to be found through `PKG_CONFIG_PATH`.