### PR TITLE
Make printing debug messages runtime configurable

### DIFF
--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -706,6 +706,7 @@ int main(int argc, char **argv)
 
         case 'v':
             fluid_settings_setint(settings, "synth.verbose", TRUE);
+            fluid_set_log_function(FLUID_DBG, fluid_default_log_function, NULL);
             break;
 
         case 'z':

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -85,7 +85,11 @@ static fluid_log_function_t fluid_log_function[LAST_LOG_LEVEL] =
     fluid_default_log_function,
     fluid_default_log_function,
     fluid_default_log_function,
+#ifdef DEBUG
     fluid_default_log_function
+#else
+    NULL
+#endif
 };
 static void *fluid_log_user_data[LAST_LOG_LEVEL] = { NULL };
 
@@ -149,9 +153,7 @@ fluid_default_log_function(int level, const char *message, void *data)
         break;
 
     case FLUID_DBG:
-#if DEBUG
         FLUID_FPRINTF(out, "%s: debug: %s\n", fluid_libname, message);
-#endif
         break;
 
     default:


### PR DESCRIPTION
Supplying --verbose to the fluidsynth executable now prints debug messages to stdout. Debug messages are still being printed by default when fluidsynth was compiled in debug mode.