### PR TITLE
Fix FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
         matrix:
             # There isn't a stable 13.0 image yet (2019-09)
             image_family: freebsd-13-0-snap
-            image_family: freebsd-12-0
+            image_family: freebsd-12-1
 
     install_script: pwd && ls -la && pkg update --force && pkg install -y cmake glib alsa-lib ladspa portaudio pulseaudio pkgconf sdl2
     


### PR DESCRIPTION
Switch to FreeBSD 12.1-RELEASE.  12.0-RELEASE is no longer supported.