### PR TITLE
Allow the reverb to pre allocate delay lines.

### DIFF
--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -971,6 +971,8 @@ static int create_mod_delay_lines(fluid_late *late, fluid_real_t sample_rate)
     }
 #endif
 
+    late->samplerate = sample_rate;
+
     for(i = 0; i < NBR_DELAYS; i++) /* for each delay line */
     {
         /* allocate delay line and set local delay lines's parameters */
@@ -991,30 +993,6 @@ static int create_mod_delay_lines(fluid_late *late, fluid_real_t sample_rate)
                           late->samplerate,
                           (float)(MOD_PHASE * i));
     }
-    return FLUID_OK;
-}
-
-/*-----------------------------------------------------------------------------
- Creates the fdn reverb.
- @param late, pointer on the fnd late reverb to initialize.
- @param sample_rate the sample rate.
- @return FLUID_OK if success, FLUID_FAILED otherwise.
------------------------------------------------------------------------------*/
-static int create_fluid_rev_late(fluid_late *late, fluid_real_t sample_rate)
-{
-    FLUID_MEMSET(late, 0,  sizeof(fluid_late));
-
-    late->samplerate = sample_rate;
-
-    /*--------------------------------------------------------------------------
-      First initialize the modulated delay lines
-    */
-
-    if(create_mod_delay_lines(late, sample_rate) == FLUID_FAILED)
-    {
-        return FLUID_FAILED;
-    }
-
     return FLUID_OK;
 }
 
@@ -1098,8 +1076,13 @@ new_fluid_revmodel(fluid_real_t sample_rate)
         return NULL;
     }
 
-    /* create fdn reverb */
-    if(create_fluid_rev_late(&rev->late, sample_rate) != FLUID_OK)
+    FLUID_MEMSET(&rev->late, 0,  sizeof(fluid_late));
+
+    /*--------------------------------------------------------------------------
+      Create fdn reverb
+      Initialize the modulated delay lines
+    */
+    if(create_mod_delay_lines(&rev->late, sample_rate) == FLUID_FAILED)
     {
         delete_fluid_revmodel(rev);
         return NULL;
@@ -1207,8 +1190,6 @@ fluid_revmodel_set(fluid_revmodel_t *rev, int set, fluid_real_t roomsize,
 int
 fluid_revmodel_samplerate_change(fluid_revmodel_t *rev, fluid_real_t sample_rate)
 {
-    rev->late.samplerate = sample_rate; /* new sample rate value */
-
     /* free all delay lines */
     delete_fluid_rev_late(&rev->late);
 

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -1107,6 +1107,7 @@ new_fluid_revmodel(fluid_real_t sample_rate_max, fluid_real_t sample_rate)
       Create fdn late reverb.
     */
 
+    /* update minimum value for sample_rate_max */
     if(sample_rate > sample_rate_max)
     {
         sample_rate_max = sample_rate;

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -1131,12 +1131,8 @@ fluid_revmodel_update(fluid_revmodel_t *rev)
 * @return pointer on the new reverb or NULL if memory error.
 * Reverb API.
 */
-//#define sample_rate_maximum 96000.0
-//#define sample_rate_maximum 0.0
-
 fluid_revmodel_t *
 new_fluid_revmodel(fluid_real_t sample_rate_max, fluid_real_t sample_rate)
-//new_fluid_revmodel(fluid_real_t sample_rate)
 {
     fluid_revmodel_t *rev;
 

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -1239,8 +1239,8 @@ fluid_revmodel_samplerate_change(fluid_revmodel_t *rev, fluid_real_t sample_rate
 
     if(sample_rate > rev->late.sample_rate_max)
     {
-        FLUID_LOG(FLUID_INFO,
-                  "fdn reverb: cannot apply sample rate: %f Hz, maximum is:%f Hz\n",
+        FLUID_LOG(FLUID_WARN,
+                  "fdn reverb: cannot apply sample rate: %.0f Hz, maximum is:%.0f Hz\n",
                    sample_rate, rev->late.sample_rate_max);
         return FLUID_FAILED;
     }

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -1078,6 +1078,8 @@ void
 fluid_revmodel_set(fluid_revmodel_t *rev, int set, fluid_real_t roomsize,
                    fluid_real_t damping, fluid_real_t width, fluid_real_t level)
 {
+    fluid_return_if_fail(rev != NULL);
+
     /*-----------------------------------*/
     if(set & FLUID_REVMODEL_SET_ROOMSIZE)
     {
@@ -1135,6 +1137,8 @@ fluid_revmodel_samplerate_change(fluid_revmodel_t *rev, fluid_real_t sample_rate
 {
     fluid_real_t mod_depth, length_factor;
     int i;
+
+    fluid_return_val_if_fail(rev != NULL, FLUID_FAILED);
 
     if(sample_rate > rev->late.sample_rate_max)
     {
@@ -1242,6 +1246,8 @@ fluid_revmodel_samplerate_change(fluid_revmodel_t *rev, fluid_real_t sample_rate
 void
 fluid_revmodel_reset(fluid_revmodel_t *rev)
 {
+    fluid_return_if_fail(rev != NULL);
+
     fluid_revmodel_init(rev);
 }
 

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -130,7 +130,7 @@
  * Note:
  * Values in this column is the memory consumption for sample rate <= 44100Hz.
  * For sample rate > 44100Hz , multiply these values by (sample rate / 44100Hz).
- *
+ * For example: for sample rate 96000Hz, the memory consumed is 244760 bytes
  *
  *----------------------------------------------------------------------------
  * 'Denormalise' method to avoid loss of performance.

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -920,7 +920,7 @@ static int create_mod_delay_lines(fluid_late *late,
 /*-----------------------------------------------------------------------------
  Initialize all modulated lines.
  @param late, pointer on the fnd late reverb to initialize.
- @param sample_max, the audio sample rate.
+ @param sample_rate, the audio sample rate.
  @return FLUID_OK if success, FLUID_FAILED otherwise.
 -----------------------------------------------------------------------------*/
 void initialize_mod_delay_lines(fluid_late *late, fluid_real_t sample_rate)

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -923,7 +923,7 @@ static int create_mod_delay_lines(fluid_late *late,
  @param sample_rate, the audio sample rate.
  @return FLUID_OK if success, FLUID_FAILED otherwise.
 -----------------------------------------------------------------------------*/
-void initialize_mod_delay_lines(fluid_late *late, fluid_real_t sample_rate)
+static void initialize_mod_delay_lines(fluid_late *late, fluid_real_t sample_rate)
 {
     int i;
     fluid_real_t mod_depth, length_factor;
@@ -1240,7 +1240,6 @@ fluid_revmodel_set(fluid_revmodel_t *rev, int set, fluid_real_t roomsize,
 int
 fluid_revmodel_samplerate_change(fluid_revmodel_t *rev, fluid_real_t sample_rate)
 {
-    int i;
     int status = FLUID_OK;
 
     fluid_return_val_if_fail(rev != NULL, FLUID_FAILED);

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -851,7 +851,6 @@ static void compensate_from_sample_rate(fluid_real_t sample_rate,
 static int create_mod_delay_lines(fluid_late *late,
                                   fluid_real_t sample_rate_max)
 {
-    int result; /* return value */
     int i;
 
     fluid_real_t mod_depth, length_factor;

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -901,8 +901,7 @@ static int create_mod_delay_lines(fluid_late *late,
         }
 
         /*---------------------------------------------------------------------
-         allocates delay_line and initialize members:
-         - line, size, line_in, line_out...
+         allocates delay lines
         */
 
         /* real size of the line in use (in samples):

--- a/src/rvoice/fluid_rev.h
+++ b/src/rvoice/fluid_rev.h
@@ -58,7 +58,9 @@ typedef struct _fluid_revmodel_presets_t
 /*
  * reverb
  */
-fluid_revmodel_t *new_fluid_revmodel(fluid_real_t sample_rate);
+fluid_revmodel_t *
+new_fluid_revmodel(fluid_real_t sample_rate_max, fluid_real_t sample_rate);
+
 void delete_fluid_revmodel(fluid_revmodel_t *rev);
 
 void fluid_revmodel_processmix(fluid_revmodel_t *rev, const fluid_real_t *in,

--- a/src/rvoice/fluid_rvoice_event.c
+++ b/src/rvoice/fluid_rvoice_event.c
@@ -114,7 +114,9 @@ fluid_rvoice_eventhandler_finished_voice_callback(fluid_rvoice_eventhandler_t *e
 
 fluid_rvoice_eventhandler_t *
 new_fluid_rvoice_eventhandler(int queuesize,
-                              int finished_voices_size, int bufs, int fx_bufs, int fx_units, fluid_real_t sample_rate, int extra_threads, int prio)
+                              int finished_voices_size, int bufs, int fx_bufs, int fx_units,
+                              fluid_real_t sample_rate_max, fluid_real_t sample_rate,
+                              int extra_threads, int prio)
 {
     fluid_rvoice_eventhandler_t *eventhandler = FLUID_NEW(fluid_rvoice_eventhandler_t);
 
@@ -145,7 +147,8 @@ new_fluid_rvoice_eventhandler(int queuesize,
         goto error_recovery;
     }
 
-    eventhandler->mixer = new_fluid_rvoice_mixer(bufs, fx_bufs, fx_units, sample_rate, eventhandler, extra_threads, prio);
+    eventhandler->mixer = new_fluid_rvoice_mixer(bufs, fx_bufs, fx_units,
+                          sample_rate_max, sample_rate, eventhandler, extra_threads, prio);
 
     if(eventhandler->mixer == NULL)
     {

--- a/src/rvoice/fluid_rvoice_event.h
+++ b/src/rvoice/fluid_rvoice_event.h
@@ -50,7 +50,7 @@ struct _fluid_rvoice_eventhandler_t
 
 fluid_rvoice_eventhandler_t *new_fluid_rvoice_eventhandler(
     int queuesize, int finished_voices_size, int bufs,
-    int fx_bufs, int fx_units, fluid_real_t sample_rate, int, int);
+    int fx_bufs, int fx_units, fluid_real_t sample_rate_max, fluid_real_t sample_rate, int, int);
 
 void delete_fluid_rvoice_eventhandler(fluid_rvoice_eventhandler_t *);
 

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -715,7 +715,11 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_samplerate)
  * @param fx_buf_count number of stereo effect buffers
  */
 fluid_rvoice_mixer_t *
-new_fluid_rvoice_mixer(int buf_count, int fx_buf_count, int fx_units, fluid_real_t sample_rate, fluid_rvoice_eventhandler_t *evthandler, int extra_threads, int prio)
+new_fluid_rvoice_mixer(int buf_count, int fx_buf_count, int fx_units,
+                       fluid_real_t sample_rate_max,
+                       fluid_real_t sample_rate,
+                       fluid_rvoice_eventhandler_t *evthandler,
+                       int extra_threads, int prio)
 {
     int i;
     fluid_rvoice_mixer_t *mixer = FLUID_NEW(fluid_rvoice_mixer_t);
@@ -744,10 +748,8 @@ new_fluid_rvoice_mixer(int buf_count, int fx_buf_count, int fx_units, fluid_real
     
     for(i = 0; i < fx_units; i++)
     {
-        /* cannot access to the maximum sample rate value indicated by the
-           settings. So the the value is hard coded here: 96000Hz
-        */
-        mixer->fx[i].reverb = new_fluid_revmodel(96000.0, sample_rate);
+        /* create reverb and chorus units */
+        mixer->fx[i].reverb = new_fluid_revmodel(sample_rate_max, sample_rate);
         mixer->fx[i].chorus = new_fluid_chorus(sample_rate);
 
         if(mixer->fx[i].reverb == NULL || mixer->fx[i].chorus == NULL)

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -686,7 +686,16 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_samplerate)
 
         if(mixer->fx[i].reverb)
         {
-            fluid_revmodel_samplerate_change(mixer->fx[i].reverb, samplerate);
+            if(fluid_revmodel_samplerate_change(mixer->fx[i].reverb, samplerate) == FLUID_FAILED)
+            {
+                /* this should not occur if the reverb was created with sample_rate_max set
+                   to the maximum sample rate indicated in the settings.
+                   If this condition isn't respected, it is safe to delete the reverb to be sure
+                   that it will not called on next rendering call.
+                */
+                delete_fluid_revmodel(mixer->fx[i].reverb);
+                mixer->fx[i].reverb = NULL;
+            }
         }
     }
 

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -735,7 +735,10 @@ new_fluid_rvoice_mixer(int buf_count, int fx_buf_count, int fx_units, fluid_real
     
     for(i = 0; i < fx_units; i++)
     {
-        mixer->fx[i].reverb = new_fluid_revmodel(sample_rate);
+        /* cannot access to the maximum sample rate value indicated by the
+           settings. So the the value is hard coded here: 96000Hz
+        */
+        mixer->fx[i].reverb = new_fluid_revmodel(96000.0, sample_rate);
         mixer->fx[i].chorus = new_fluid_chorus(sample_rate);
 
         if(mixer->fx[i].reverb == NULL || mixer->fx[i].chorus == NULL)

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -686,16 +686,14 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_mixer_set_samplerate)
 
         if(mixer->fx[i].reverb)
         {
-            if(fluid_revmodel_samplerate_change(mixer->fx[i].reverb, samplerate) == FLUID_FAILED)
-            {
-                /* this should not occur if the reverb was created with sample_rate_max set
-                   to the maximum sample rate indicated in the settings.
-                   If this condition isn't respected, it is safe to delete the reverb to be sure
-                   that it will not called on next rendering call.
-                */
-                delete_fluid_revmodel(mixer->fx[i].reverb);
-                mixer->fx[i].reverb = NULL;
-            }
+            fluid_revmodel_samplerate_change(mixer->fx[i].reverb, samplerate);
+
+            /*
+              fluid_revmodel_samplerate_change() shouldn't fail if the reverb was created
+              with sample_rate_max set to the maximum sample rate indicated in the settings.
+              If this condition isn't respected, the reverb will continue to work but with
+              lost of quality.
+            */
         }
     }
 

--- a/src/rvoice/fluid_rvoice_mixer.h
+++ b/src/rvoice/fluid_rvoice_mixer.h
@@ -38,7 +38,8 @@ int fluid_rvoice_mixer_get_bufcount(fluid_rvoice_mixer_t *mixer);
 int fluid_rvoice_mixer_get_active_voices(fluid_rvoice_mixer_t *mixer);
 #endif
 fluid_rvoice_mixer_t *new_fluid_rvoice_mixer(int buf_count, int fx_buf_count, int fx_units,
-        fluid_real_t sample_rate, fluid_rvoice_eventhandler_t *, int, int);
+        fluid_real_t sample_rate_max, fluid_real_t sample_rate,
+        fluid_rvoice_eventhandler_t *, int, int);
 
 void delete_fluid_rvoice_mixer(fluid_rvoice_mixer_t *);
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -607,6 +607,7 @@ new_fluid_synth(fluid_settings_t *settings)
     char *important_channels;
     int i, nbuf, prio_level = 0;
     int with_ladspa = 0;
+    fluid_real_t sample_rate_min, sample_rate_max;
 
     /* initialize all the conversion tables and other stuff */
     if(fluid_atomic_int_compare_and_exchange(&fluid_synth_initialized, 0, 1))
@@ -637,6 +638,7 @@ new_fluid_synth(fluid_settings_t *settings)
 
     fluid_settings_getint(settings, "synth.polyphony", &synth->polyphony);
     fluid_settings_getnum(settings, "synth.sample-rate", &synth->sample_rate);
+    fluid_settings_getnum_range(settings, "synth.sample-rate", &sample_rate_min, &sample_rate_max);
     fluid_settings_getint(settings, "synth.midi-channels", &synth->midi_channels);
     fluid_settings_getint(settings, "synth.audio-channels", &synth->audio_channels);
     fluid_settings_getint(settings, "synth.audio-groups", &synth->audio_groups);
@@ -778,7 +780,9 @@ new_fluid_synth(fluid_settings_t *settings)
     /* Allocate event queue for rvoice mixer */
     /* In an overflow situation, a new voice takes about 50 spaces in the queue! */
     synth->eventhandler = new_fluid_rvoice_eventhandler(synth->polyphony * 64,
-                          synth->polyphony, nbuf, synth->effects_channels, synth->effects_groups, synth->sample_rate, synth->cores - 1, prio_level);
+                          synth->polyphony, nbuf, synth->effects_channels, synth->effects_groups,
+                          sample_rate_max, synth->sample_rate,
+                          synth->cores - 1, prio_level);
 
     if(synth->eventhandler == NULL)
     {


### PR DESCRIPTION
This PR allows the reverb to pre-allocate the memory needed for the `maximun sample-rate `of the synth. That means that on sample rate change there are no memory allocation and the function `fluid_revmodel_samplerate_change()` should always return FLUID_OK.
The PR addresses discussion in https://github.com/FluidSynth/fluidsynth/issues/608.