### PR TITLE
fix ordering of operations

### DIFF
--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -554,14 +554,14 @@ int fluid_defsfont_add_preset(fluid_defsfont_t *defsfont, fluid_defpreset_t *def
                               fluid_defpreset_preset_noteon,
                               fluid_defpreset_preset_delete);
 
-    if(defsfont->dynamic_samples)
-    {
-        preset->notify = dynamic_samples_preset_notify;
-    }
-
     if(preset == NULL)
     {
         return FLUID_FAILED;
+    }
+
+    if(defsfont->dynamic_samples)
+    {
+        preset->notify = dynamic_samples_preset_notify;
     }
 
     fluid_preset_set_data(preset, defpreset);


### PR DESCRIPTION
This should avoid an unlikely memory violation if `new_fluid_preset()` fails.