### PR TITLE
fix NULL permitted for out and fx pointer buffer in fluid_synth_process_LOCAL()

### DIFF
--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3699,6 +3699,7 @@ fluid_synth_process(fluid_synth_t *synth, int len, int nfx, float *fx[],
     return fluid_synth_process_LOCAL(synth, len, nfx, fx, nout, out, fluid_synth_render_blocks);
 }
 
+/* declared public (instead of static) for testing purpose */
 int
 fluid_synth_process_LOCAL(fluid_synth_t *synth, int len, int nfx, float *fx[],
                     int nout, float *out[], int (*block_render_func)(fluid_synth_t *, int))

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3654,22 +3654,21 @@ fx[ ((k * fluid_synth_count_effects_channels() + j) * 2 + 1) % nfx ]  = right_bu
  * @param len Count of audio frames to synthesize and store in every single buffer provided by \p out and \p fx.
  *  Zero value is permitted, the function does nothing and return FLUID_OK.
  * @param nfx Count of arrays in \c fx. Must be a multiple of 2 (because of stereo).
- * and in the range <code>0 <= nfx/2 <= (fluid_synth_count_effects_channels() * fluid_synth_count_effects_groups()).
-  Note that zero value is valid and allows to skip mixing effects in all fx output buffers.</code>.
+ * and in the range <code>0 <= nfx/2 <= (fluid_synth_count_effects_channels() * fluid_synth_count_effects_groups())</code>.
+  Note that zero value is valid and allows to skip mixing effects in all fx output buffers.
  * @param fx Array of buffers to store effects audio to. Buffers may
 alias with buffers of \c out. Individual NULL buffers are permitted and will cause to skip mixing any audio into that buffer.
  * @param nout Count of arrays in \c out. Must be a multiple of 2
-(because of stereo) and in the range <code>0 <= nout/2 <= fluid_synth_count_audio_channels().
- Note that zero value is valid and allows to skip mixing dry audio in all out output buffers.</code>.
+(because of stereo) and in the range <code>0 <= nout/2 <= fluid_synth_count_audio_channels()</code>.
+ Note that zero value is valid and allows to skip mixing dry audio in all out output buffers.
  * @param out Array of buffers to store (dry) audio to. Buffers may
 alias with buffers of \c fx. Individual NULL buffers are permitted and will cause to skip mixing any audio into that buffer.
  * @return #FLUID_OK on success,
  * #FLUID_FAILED otherwise,
- *  - fx NULL while nfx > 0, or out NULL while nout > 0.
- *  - nfx or nout not multiple of 2.
- *  - len < 0.
- *  - both nfx and nout set to 0 while len > 0
- *  - nfx or nout greater than respective internal mixer buffer count.
+ *  - <code>fx == NULL</code> while <code>nfx > 0</code>, or <code>out == NULL</code> while <code>nout > 0</code>.
+ *  - \c nfx or \c nout not multiple of 2.
+ *  - <code>len < 0</code>.
+ *  - \c nfx or \c nout exceed the range explained above.
  *
  * @parblock
  * @note The owner of the sample buffers must zero them out before calling this
@@ -3723,7 +3722,7 @@ fluid_synth_process_LOCAL(fluid_synth_t *synth, int len, int nfx, float *fx[],
     fluid_return_val_if_fail(nfx % 2 == 0, FLUID_FAILED);
 
     /* out NULL while nout > 0 is invalid */
-    fluid_return_val_if_fail((fx != NULL) || (nfx == 0), FLUID_FAILED);
+    fluid_return_val_if_fail((out != NULL) || (nout == 0), FLUID_FAILED);
     /* nout must be multiple of 2. Note that 0 value is valid and
        allows to skip mixing in out output buffers
     */
@@ -3734,13 +3733,6 @@ fluid_synth_process_LOCAL(fluid_synth_t *synth, int len, int nfx, float *fx[],
     */
     fluid_return_val_if_fail(len >= 0, FLUID_FAILED);
     fluid_return_val_if_fail(len != 0, FLUID_OK); // to avoid raising FE_DIVBYZERO below
-
-    /*
-      Now len is > 0. This will lead in rendering in internal mixer buffer.
-      However this rendering must not occur if both nfx and nout are set to 0.
-      So now we check that both nfx and nout set to 0 while len > 0, is invalid.
-    */
-    fluid_return_val_if_fail(nfx || nout, FLUID_FAILED);
 
     nfxchan = synth->effects_channels;
     nfxunits = synth->effects_groups;

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3652,6 +3652,7 @@ fx[ ((k * fluid_synth_count_effects_channels() + j) * 2 + 1) % nfx ]  = right_bu
  *
  * @param synth FluidSynth instance
  * @param len Count of audio frames to synthesize and store in every single buffer provided by \p out and \p fx.
+ *  Zero value is permitted, the function does nothing and return FLUID_OK.
  * @param nfx Count of arrays in \c fx. Must be a multiple of 2 (because of stereo).
  * and in the range <code>0 <= nfx/2 <= (fluid_synth_count_effects_channels() * fluid_synth_count_effects_groups()).
   Note that zero value is valid and allows to skip mixing effects in all fx output buffers.</code>.
@@ -3662,7 +3663,13 @@ alias with buffers of \c out. Individual NULL buffers are permitted and will cau
  Note that zero value is valid and allows to skip mixing dry audio in all out output buffers.</code>.
  * @param out Array of buffers to store (dry) audio to. Buffers may
 alias with buffers of \c fx. Individual NULL buffers are permitted and will cause to skip mixing any audio into that buffer.
- * @return #FLUID_OK on success, #FLUID_FAILED otherwise.
+ * @return #FLUID_OK on success,
+ * #FLUID_FAILED otherwise,
+ *  - fx NULL while nfx > 0, or out NULL while nout > 0.
+ *  - nfx or nout not multiple of 2.
+ *  - len < 0.
+ *  - both nfx and nout set to 0 while len > 0
+ *  - nfx or nout greater than respective internal mixer buffer count.
  *
  * @parblock
  * @note The owner of the sample buffers must zero them out before calling this

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3925,11 +3925,11 @@ fluid_synth_write_float_LOCAL(fluid_synth_t *synth, int len,
 
     /* Conversely to fluid_synth_process() (which handle possible multiple stereo output),
        we want rendered audio effect mixed in internal audio dry buffers.
-       TRUE instructs the mixer that internal audio effects will be mixed in internal
+       TRUE instructs the mixer that internal audio effects will be mixed in first internal
        audio dry buffers.
     */
     fluid_rvoice_mixer_set_mix_fx(synth->eventhandler->mixer, TRUE);
-    /* get internal mixer audio dry buffer's pointer (left and right channel) */
+    /* get first internal mixer audio dry buffer's pointer (left and right channel) */
     fluid_rvoice_mixer_get_bufs(synth->eventhandler->mixer, &left_in, &right_in);
 
     size = len;
@@ -4090,11 +4090,11 @@ fluid_synth_write_s16(fluid_synth_t *synth, int len,
 
     /* Conversely to fluid_synth_process() (which handle possible multiple stereo output),
        we want rendered audio effect mixed in internal audio dry buffers.
-       TRUE instructs the mixer that internal audio effects will be mixed in internal
+       TRUE instructs the mixer that internal audio effects will be mixed in first internal
        audio dry buffers.
     */
     fluid_rvoice_mixer_set_mix_fx(synth->eventhandler->mixer, TRUE);
-    /* get internal mixer audio dry buffer's pointer (left and right channel) */
+    /* get first internal mixer audio dry buffer's pointer (left and right channel) */
     fluid_rvoice_mixer_get_bufs(synth->eventhandler->mixer, &left_in, &right_in);
 
     size = len;

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3720,8 +3720,19 @@ fluid_synth_process_LOCAL(fluid_synth_t *synth, int len, int nfx, float *fx[],
        allows to skip mixing in out output buffers
     */
     fluid_return_val_if_fail(nout % 2 == 0, FLUID_FAILED);
+
+    /* check len value. Note than 0 value is valid, the function does nothing and
+       return FLUID_OK.
+    */
     fluid_return_val_if_fail(len >= 0, FLUID_FAILED);
     fluid_return_val_if_fail(len != 0, FLUID_OK); // to avoid raising FE_DIVBYZERO below
+
+    /*
+      Now len is > 0. This will lead in rendering in internal mixer buffer.
+      However this rendering must not occur if both nfx and nout are set to 0.
+      So now we check that both nfx and nout set to 0 while len > 0, is invalid.
+    */
+    fluid_return_val_if_fail(nfx || nout, FLUID_FAILED);
 
     nfxchan = synth->effects_channels;
     nfxunits = synth->effects_groups;


### PR DESCRIPTION
This should avoid a segmentation fault if one pass NULL value for fx or out parameters.
