### PR TITLE
limiting audio-channels to audio-groups

### DIFF
--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -51,7 +51,7 @@ struct _fluid_mixer_buffers_t
 
     /** buffer to store the left part of a stereo channel to.
      * Specifically a two dimensional array, containing \c buf_count sample buffers
-     * (i.e. for each synth.audio-channels), of which each contains
+     * (i.e. for each synth.audio-groups), of which each contains
      * FLUID_BUFSIZE * FLUID_MIXER_MAX_BUFFERS_DEFAULT audio items (=samples)
      * @note Each sample buffer is aligned to the FLUID_DEFAULT_ALIGNMENT
      * boundary provided that this pointer points to an aligned buffer.


### PR DESCRIPTION
This addresses some comments in https://github.com/FluidSynth/fluidsynth/issues/660.
This will avoid waste of allocated buffers in the case of `audio-channels` is greater then `audio-groups`.