### PR TITLE
Use a runtime check to detect version of libinstpatch

### DIFF
--- a/src/sfloader/fluid_instpatch.c
+++ b/src/sfloader/fluid_instpatch.c
@@ -44,6 +44,15 @@ enum
     MAX_INST_VOICES = 128,
 };
 
+int fluid_instpatch_supports_multi_init()
+{
+    guint major, minor, patch;
+    ipatch_version(&major, &minor, &patch);
+
+    /* libinstpatch <= 1.1.4 only supports calling ipatch_init() once */
+    return FLUID_VERSION_CHECK(major, minor, patch) > FLUID_VERSION_CHECK(1, 1, 4)
+}
+
 void fluid_instpatch_init(void)
 {
     ipatch_init();

--- a/src/sfloader/fluid_instpatch.c
+++ b/src/sfloader/fluid_instpatch.c
@@ -44,13 +44,13 @@ enum
     MAX_INST_VOICES = 128,
 };
 
-int fluid_instpatch_supports_multi_init()
+int fluid_instpatch_supports_multi_init(void)
 {
     guint major, minor, patch;
     ipatch_version(&major, &minor, &patch);
 
     /* libinstpatch <= 1.1.4 only supports calling ipatch_init() once */
-    return FLUID_VERSION_CHECK(major, minor, patch) > FLUID_VERSION_CHECK(1, 1, 4)
+    return FLUID_VERSION_CHECK(major, minor, patch) > FLUID_VERSION_CHECK(1, 1, 4);
 }
 
 void fluid_instpatch_init(void)

--- a/src/sfloader/fluid_instpatch.h
+++ b/src/sfloader/fluid_instpatch.h
@@ -9,6 +9,6 @@ void fluid_instpatch_init(void);
 void fluid_instpatch_deinit(void);
 fluid_sfloader_t *new_fluid_instpatch_loader(fluid_settings_t *settings);
 
-int fluid_instpatch_supports_multi_init();
+int fluid_instpatch_supports_multi_init(void);
 
 #endif // _FLUID_INSTPATCH_H

--- a/src/sfloader/fluid_instpatch.h
+++ b/src/sfloader/fluid_instpatch.h
@@ -9,4 +9,6 @@ void fluid_instpatch_init(void);
 void fluid_instpatch_deinit(void);
 fluid_sfloader_t *new_fluid_instpatch_loader(fluid_settings_t *settings);
 
+int fluid_instpatch_supports_multi_init();
+
 #endif // _FLUID_INSTPATCH_H

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -464,11 +464,12 @@ fluid_synth_init(void)
     /* Amount: 96 dB of attenuation (on the opposite channel) */
     fluid_mod_set_amount(&custom_balance_mod, FLUID_PEAK_ATTENUATION); /* Amount: 960 */
 
-    /* libinstpatch <= 1.1.4 only supports calling init() once */
-#if defined(LIBINSTPATCH_SUPPORT) && \
-    FLUID_VERSION_CHECK(IPATCH_VERSION_MAJOR,IPATCH_VERSION_MINOR,IPATCH_VERSION_PATCH) <= FLUID_VERSION_CHECK(1,1,4)
+#if defined(LIBINSTPATCH_SUPPORT)
     /* defer libinstpatch init to fluid_instpatch.c to avoid #include "libinstpatch.h" */
-    fluid_instpatch_init();
+    if(!fluid_instpatch_supports_multi_init())
+    {
+        fluid_instpatch_init();
+    }
 #endif
 }
 
@@ -628,10 +629,11 @@ new_fluid_synth(fluid_settings_t *settings)
 
     FLUID_MEMSET(synth, 0, sizeof(fluid_synth_t));
 
-#if defined(LIBINSTPATCH_SUPPORT) && \
-    FLUID_VERSION_CHECK(IPATCH_VERSION_MAJOR,IPATCH_VERSION_MINOR,IPATCH_VERSION_PATCH) > FLUID_VERSION_CHECK(1,1,4)
-    /* defer libinstpatch init to fluid_instpatch.c to avoid #include "libinstpatch.h" */
-    fluid_instpatch_init();
+#if defined(LIBINSTPATCH_SUPPORT)
+    if(fluid_instpatch_supports_multi_init())
+    {
+        fluid_instpatch_init();
+    }
 #endif
 
     fluid_rec_mutex_init(synth->mutex);
@@ -1125,10 +1127,11 @@ delete_fluid_synth(fluid_synth_t *synth)
 
     FLUID_FREE(synth);
 
-#if defined(LIBINSTPATCH_SUPPORT) && \
-    FLUID_VERSION_CHECK(IPATCH_VERSION_MAJOR,IPATCH_VERSION_MINOR,IPATCH_VERSION_PATCH) > FLUID_VERSION_CHECK(1,1,4)
-    /* defer libinstpatch deinit to fluid_instpatch.c to avoid #include "libinstpatch.h" */
-    fluid_instpatch_deinit();
+#if defined(LIBINSTPATCH_SUPPORT)
+    if(fluid_instpatch_supports_multi_init())
+    {
+        fluid_instpatch_deinit();
+    }
 #endif
 }
 


### PR DESCRIPTION
It could be that during runtime an older version of libinstpatch is used than the one fluidsynth was compiled against. In this case, libinstpatch will fail to load DLS fonts, because libinstpatch's initialization semantics don't match those compiled into fluidsynth.