### PR TITLE
Add SonarQube static code analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 os: linux
 dist: focal
 git:
-  depth: false
+  depth: false # disable shallow fetch, history is needed by SonarQube
 addons:
   apt:
     update: true
@@ -107,3 +107,7 @@ script:
     - make install
     - cd ..
     - ${SONARSC}
+
+cache:
+  directories:
+    - '$HOME/.sonar/cache'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ matrix:
   include:
     - dist: trusty
       env:
-        - SONARSC="build-wrapper-linux-x86-64 --out-dir bw-output"
+        - BW="build-wrapper-linux-x86-64 --out-dir bw-output"
+        - SONARSC="sonar-scanner -Dsonar.cfamily.build-wrapper-output=build/bw-output"
 
     - arch: arm64
       env:
@@ -100,9 +101,9 @@ before_script:
 
 script:
     - cmake -Werror=dev -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} -Denable-portaudio=1 -Denable-ladspa=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
-    - ${SONARSC} make -j4
+    - ${BW} make -j4
     - ls -la
     - make check
     - make install
     - cd ..
-    - sonar-scanner -Dsonar.cfamily.build-wrapper-output=build/bw-output
+    - ${SONARSC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,4 +104,5 @@ script:
     - ls -la
     - make check
     - make install
-    - sonar-scanner -X -Dsonar.cfamily.build-wrapper-output=bw-output
+    - cd ..
+    - sonar-scanner -X -Dsonar.cfamily.build-wrapper-output=build/bw-output

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: c
 sudo: false
 os: linux
 dist: focal
+git:
+  depth: false
 addons:
+  sonarcloud:
+    organization: "fluidsynth"
   apt:
     update: true
     sources:
@@ -37,6 +41,10 @@ env:
 
 matrix:
   include:
+    - dist: trusty
+      env:
+        - SONARSC="build-wrapper-linux-x86-64 --out-dir bw-output"
+
     - arch: arm64
       env:
         - CC="gcc-7"
@@ -91,6 +99,7 @@ before_script:
 
 script:
     - cmake -Werror=dev -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} -Denable-portaudio=1 -Denable-ladspa=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
-    - make -j4
+    - ${SONARSC} make -j4
     - make check
-    - make install # install only on linux, as CMAKE_INSTALL_PREFIX is ignored for frameworks on macosx and I cant tell whether that's correct or a bug.
+    - make install
+    - sonar-scanner -Dsonar.cfamily.build-wrapper-output=bw-output

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,4 +105,4 @@ script:
     - make check
     - make install
     - cd ..
-    - sonar-scanner -X -Dsonar.cfamily.build-wrapper-output=build/bw-output
+    - sonar-scanner -Dsonar.cfamily.build-wrapper-output=build/bw-output

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ dist: focal
 git:
   depth: false
 addons:
-  sonarcloud:
-    organization: "fluidsynth"
   apt:
     update: true
     sources:
@@ -41,7 +39,9 @@ env:
 
 matrix:
   include:
-    - dist: trusty
+    - addons:
+        sonarcloud:
+          organization: "fluidsynth"
       env:
         - BW="build-wrapper-linux-x86-64 --out-dir bw-output"
         - SONARSC="sonar-scanner -Dsonar.cfamily.build-wrapper-output=build/bw-output"

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ before_install:
     - echo $PATH
     - echo $MATRIX_EVAL
     - eval "${MATRIX_EVAL}"
+    - echo $SONARSC
 
 before_script:
     - mkdir $HOME/fluidsynth_install/
@@ -100,6 +101,7 @@ before_script:
 script:
     - cmake -Werror=dev -DCMAKE_INSTALL_PREFIX=$HOME/fluidsynth_install ${CMAKE_FLAGS} -Denable-portaudio=1 -Denable-ladspa=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
     - ${SONARSC} make -j4
+    - ls -la
     - make check
     - make install
-    - sonar-scanner -Dsonar.cfamily.build-wrapper-output=bw-output
+    - sonar-scanner -X -Dsonar.cfamily.build-wrapper-output=bw-output

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+sonar.projectKey=FluidSynth_fluidsynth
+sonar.organization=fluidsynth
+
+sonar.cfamily.threads=4
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=fluidsynth
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=FluidSynth_fluidsynth
 sonar.organization=fluidsynth
 
 sonar.cfamily.threads=4
+sonar.cfamily.cache.enabled=false
 
 
 # This is the name and version displayed in the SonarCloud UI.


### PR DESCRIPTION
Add an additional TravisCI job that executes SonarQube's static code analysis. The result will be published here: https://sonarcloud.io/dashboard?id=FluidSynth_fluidsynth