### PR TITLE
Remove fluid_event_any_control_change() from public API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,3 @@ script:
     - make install
     - cd ..
     - ${SONARSC}
-
-cache:
-  directories:
-    - '$HOME/.sonar/cache'

--- a/doc/fluidsynth-v20-devdoc.txt
+++ b/doc/fluidsynth-v20-devdoc.txt
@@ -74,6 +74,7 @@ What is FluidSynth?
 \section NewIn2_2_0 What's new in 2.2.0?
 
 - #fluid_file_callbacks_t now uses <code>long long</code> as file-offset type (see #fluid_long_long_t). This is a breaking change, which allows to load SoundFonts bigger than 2GiB on Windows. This change required to bump fluidsynth's SOVERSION.
+- fluid_event_any_control_change() has been removed
 - The sequencer has received a major revisal. For you that means:
   - The sequencer's queue no longer blocks the synthesizer thread, due to being busy arranging its events internally.
   - Events that share the same tick was given a new, documented order, see fluid_sequencer_send_at().

--- a/include/fluidsynth/event.h
+++ b/include/fluidsynth/event.h
@@ -55,7 +55,6 @@ enum fluid_seq_event_type
     FLUID_SEQ_REVERBSEND,		/**< Reverb send set event */
     FLUID_SEQ_CHORUSSEND,		/**< Chorus send set event */
     FLUID_SEQ_TIMER,		/**< Timer event (useful for giving a callback at a certain time) */
-    FLUID_SEQ_ANYCONTROLCHANGE,	/**< Any control change message (only internally used for remove_events) @deprecated As of fluidsynth 2.2.0 this enum value is no longer used internally and has been deprecated. */
     FLUID_SEQ_CHANNELPRESSURE,    /**< Channel aftertouch event @since 1.1.0 */
     FLUID_SEQ_KEYPRESSURE,        /**< Polyphonic aftertouch event @since 2.0.0 */
     FLUID_SEQ_SYSTEMRESET,        /**< System reset event @since 1.1.0 */
@@ -108,10 +107,6 @@ FLUIDSYNTH_API void fluid_event_chorus_send(fluid_event_t *evt, int channel, sho
 FLUIDSYNTH_API void fluid_event_key_pressure(fluid_event_t *evt, int channel, short key, short val);
 FLUIDSYNTH_API void fluid_event_channel_pressure(fluid_event_t *evt, int channel, short val);
 FLUIDSYNTH_API void fluid_event_system_reset(fluid_event_t *evt);
-
-
-/* Only for removing events */
-FLUID_DEPRECATED FLUIDSYNTH_API void fluid_event_any_control_change(fluid_event_t *evt, int channel);
 
 /* Only when unregistering clients */
 FLUIDSYNTH_API void fluid_event_unregistering(fluid_event_t *evt);

--- a/src/synth/fluid_event.c
+++ b/src/synth/fluid_event.c
@@ -263,17 +263,6 @@ fluid_event_program_select(fluid_event_t *evt, int channel,
 }
 
 /**
- * Set a sequencer event to be an any control change event (for internal use).
- * @param evt Sequencer event structure
- * @param channel MIDI channel number
- * @deprecated As of fluidsynth 2.2.0, this function has been deprecated and became a no-op.
- */
-void
-fluid_event_any_control_change(fluid_event_t *evt, int channel)
-{
-}
-
-/**
  * Set a sequencer event to be a pitch bend event.
  * @param evt Sequencer event structure
  * @param channel MIDI channel number

--- a/test/test_seq_event_queue_remove.c
+++ b/test/test_seq_event_queue_remove.c
@@ -46,7 +46,7 @@ void test_remove_events(fluid_sequencer_t *seq, fluid_event_t *evt)
 
     for(i = 0; i < 10000; i++)
     {
-        fluid_event_any_control_change(evt, 0);
+        fluid_event_program_change(evt, 0, 0);
         TEST_SUCCESS(fluid_sequencer_send_at(seq, evt, i, 0));
 
         fluid_event_noteon(evt, 0, 64, 127);


### PR DESCRIPTION
Originally, I have only marked it deprecated. But since we have an SOVERSION bump next release and because this function was only meant for internal usage, I think it's safe to remove it right now.