### PR TITLE
Make winmidi driver multi devices capable.

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -683,7 +683,7 @@ Developers: Settings can be deprecated by adding: <deprecated>SOME TEXT</depreca
             <name>winmidi.device</name>
             <type>str</type>
             <def>default</def>
-            <desc>The hardware device to use for Windows MIDI driver (not to be confused with the MIDI port).</desc>
+            <desc>The hardware device to use for Windows MIDI driver (not to be confused with the MIDI port). Multiple devices can be specified by a list of devices index separated by a semicolon (e.g "2;0", which is equivalent to one device with 32 MIDI channels).</desc>
         </setting>
     </midi>
     

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -77,10 +77,10 @@
 #define MIDI_SYSEX_MAX_SIZE     512
 #define MIDI_SYSEX_BUF_COUNT    16
 
-typedef struct fluid_winmidi_driver_s fluid_winmidi_driver_t;
+typedef struct fluid_winmidi_driver fluid_winmidi_driver_t;
 
 /* device infos structure for only one midi device */
-typedef struct device_infos_t
+typedef struct device_infos
 {
     fluid_winmidi_driver_t *dev; /* driver structure*/
     unsigned char midi_num;      /* device order number */
@@ -91,10 +91,10 @@ typedef struct device_infos_t
     MIDIHDR sysExHdrs[MIDI_SYSEX_BUF_COUNT];
     /* Sysex data buffer */
     unsigned char sysExBuf[MIDI_SYSEX_BUF_COUNT * MIDI_SYSEX_MAX_SIZE];
-}device_infos;
+}device_infos_t;
 
 /* driver structure */
-struct fluid_winmidi_driver_s
+struct fluid_winmidi_driver
 {
     fluid_midi_driver_t driver;
 
@@ -104,7 +104,7 @@ struct fluid_winmidi_driver_s
 
     /* devices informations table */
     int dev_count;   /* device informations count in dev_infos[] table */
-    device_infos dev_infos[1];
+    device_infos_t dev_infos[1];
 };
 
 #define msg_type(_m)  ((unsigned char)(_m & 0xf0))
@@ -136,7 +136,7 @@ static void CALLBACK
 fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
                        DWORD_PTR dwParam1, DWORD_PTR dwParam2)
 {
-    device_infos *dev_infos = (device_infos *) dwInstance;
+    device_infos_t *dev_infos = (device_infos_t *) dwInstance;
     fluid_winmidi_driver_t *dev = dev_infos->dev;
     fluid_midi_event_t event;
     LPMIDIHDR pMidiHdr;
@@ -386,7 +386,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     }
 
     /* allocation of driver structure size dependant of max_devices */
-    i = sizeof(fluid_winmidi_driver_t) + (max_devices - 1) * sizeof(device_infos);
+    i = sizeof(fluid_winmidi_driver_t) + (max_devices - 1) * sizeof(device_infos_t);
     dev = FLUID_MALLOC(i);
 
     if(dev == NULL)
@@ -405,7 +405,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     }
 
     /* look if the device name contains a semicolon (;) */
-    if(FLUID_STRCHR(dev_name, '\;'))
+    if(FLUID_STRCHR(dev_name, ';'))
     {
         /* multi devices name "x;[y;..]". parse devices index: x;y;..
           Each ascii index are separated by semicolon caracter.
@@ -496,7 +496,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     /* try opening the devices */
     for(i = 0; i < dev->dev_count; i++)
     {
-        device_infos *dev_infos = &dev->dev_infos[i];
+        device_infos_t *dev_infos = &dev->dev_infos[i];
         dev_infos->dev = dev;            /* driver structure */
         dev_infos->midi_num = i;         /* device order number */
         dev_infos->channel_map = i * 16; /* map from input to output */
@@ -600,7 +600,7 @@ delete_fluid_winmidi_driver(fluid_midi_driver_t *p)
     /* stop MIDI in devices and free allocated buffers */
     for(i = 0; i < dev->dev_count; i++)
     {
-        device_infos *dev_infos = &dev->dev_infos[i];
+        device_infos_t *dev_infos = &dev->dev_infos[i];
         if(dev_infos->hmidiin != NULL)
         {
             /* stop the device and mark any pending data blocks as being done */

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -63,9 +63,6 @@
 
 #if WINMIDI_SUPPORT
 
-/* define PRINTF_MSG macro to enable printf message */
-#define PRINTF_MSG
-
 #include "fluid_midi.h"
 #include "fluid_mdriver.h"
 #include "fluid_settings.h"
@@ -151,10 +148,8 @@ fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
         event.type = msg_type(msg_param);
         event.channel = msg_chan(msg_param) + dev_infos->channel_map;
 
-#ifdef PRINTF_MSG
-        printf("\ndev_idx:%d, channel in:%d,out: %d\n",
-               dev_infos->dev_idx, msg_chan(msg_param) , event.channel);
-#endif
+        FLUID_LOG(FLUID_DBG, "\ndevice at index %d sending MIDI message on channel %d, forwarded on channel: %d",
+                  dev_infos->dev_idx, msg_chan(msg_param) , event.channel);
         if(event.type != PITCH_BEND)
         {
             event.param1 = msg_p1(msg_param);
@@ -170,9 +165,8 @@ fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
         break;
 
     case MIM_LONGDATA:    /* SYSEX data */
-#ifdef PRINTF_MSG
-        printf("\ndev_idx:%d, sysex\n", dev_infos->dev_idx);
-#endif
+        FLUID_LOG(FLUID_DBG, "\ndevice at index %d sending MIDI sysex message",
+                  dev_infos->dev_idx);
         if(dev->hThread == NULL)
         {
             break;
@@ -520,9 +514,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
         dev_infos->dev = dev;            /* driver structure */
         dev_infos->midi_num = i;         /* device order number */
         dev_infos->channel_map = i * 16; /* map from input to output */
-#ifdef PRINTF_MSG
-        printf("open:%d dev_idx=%d\n",  i, dev->dev_infos[i].dev_idx);
-#endif
+        FLUID_LOG(FLUID_DBG, "opening device at index %d", dev_infos->dev_idx);
         res = midiInOpen(&dev_infos->hmidiin, dev_infos->dev_idx,
                          (DWORD_PTR) fluid_winmidi_callback,
                          (DWORD_PTR) dev_infos, CALLBACK_FUNCTION);

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -52,8 +52,8 @@
  * - MIDI messages from real device 1 are output to MIDI channels set 0 to 15.
  * - MIDI messages from real device 0 are output to MIDI channels set 15 to 31.
  * So, the device order specified in the setting allows the user to choose the
- * MIDI channel set associated with this real device at the driver output 
- * according the formula: output_channel = input_channel + device_order * 16.
+ * MIDI channel set associated with this real device at the driver output
+ * according this formula: output_channel = input_channel + device_order * 16.
  *
  * 2)Note also that the driver handles single device by putting the device name
  * in midi.winmidi.device setting.

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -31,32 +31,33 @@
  * Multiple/single devices handling capabilities:
  * This driver is able to handle multiple devices chosen by the user trough
  * the settings midi.winmidi.maxdevices and midi.winmidi.device.
+ * For example, let the following device names:
+ * 0:Port MIDI SB Live! [CE00], 1:SB PCI External MIDI, default, multi:x[ y z ..]
  * The setting midi.winmidi.maxdevices must be set to the number of devices to
  * work with. This allows the driver to check if the real devices number exist
- * and allocate the necessary memory.
+ * and allocate only the necessary memory.
  * Then the driver is able receive MIDI messages comming from distinct devices
  * and forward these messages on distinct MIDI channels set.
- * 1)For example, if the user chooses 2 devices at index 0 and 1, the user must
- * specify this by putting the name "multi:0 1" in midi.winmidi.device setting.
+ * 1.1)For example, if the user chooses 2 devices at index 0 and 1, the user
+ * must specify this by midi.winmidi.maxdevices set to 2 and putting the name
+ * "multi:0 1" in midi.winmidi.device setting.
  * We get a fictif device composed of real devices (0,1). This fictif device
  * behaves like a device with 32 MIDI channels whose messages are forwarded to
  * driver output as this:
  * - MIDI messages from real device 0 are output to MIDI channels set 0 to 15.
  * - MIDI messages from real device 1 are output to MIDI channels set 15 to 31.
  *
- * 2)Now another example with the name "multi:1 0" in midi.winmidi.device setting.
- * The driver will forward MIDI messages as this:
+ * 1.2)Now another example with the name "multi:1 0". The driver will forward
+ * MIDI messages as this:
  * - MIDI messages from real device 1 are output to MIDI channels set 0 to 15.
  * - MIDI messages from real device 0 are output to MIDI channels set 15 to 31.
  * So, the device order specified in the setting allows the user to choose the
- * MIDI channel set associated with this real device at the driver output:
- * output_channel = input_channel + device_order * 16.
+ * MIDI channel set associated with this real device at the driver output 
+ * according the formula: output_channel = input_channel + device_order * 16.
  *
- * Note also that the driver handles single device by putting the device name
+ * 2)Note also that the driver handles single device by putting the device name
  * in midi.winmidi.device setting.
- * For example, let the following device names:
- * 0:Port MIDI SB Live! [CE00], 1:SB PCI External MIDI, default, multi:x[ y z ..]
- * The user can set the name "0:Port MIDI SB Live! [CE00]" in the setting.
+ * The user can set the device name "0:Port MIDI SB Live! [CE00]" in the setting.
  * or use the multi device naming "multi:0" (specifying only device index 0).
  * Both naming choice allows the driver to handle the same single device.
  *

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -241,11 +241,6 @@ static char *fluid_winmidi_get_device_name(int dev_idx, char *dev_name)
 }
 
 /*
-  Internal multi device name template.
-*/
-const static char *multi_dev_name = "x[;y;z;..]";
-
-/*
  Add setting midi.winmidi.device in the settings.
 
  MIDI devices names are enumerated and added to midi.winmidi.device setting
@@ -291,9 +286,6 @@ void fluid_winmidi_midi_driver_settings(fluid_settings_t *settings)
                 FLUID_FREE(new_dev_name);
             }
         }
-
-        /* add multi device name template among other real devices names */
-        fluid_settings_add_option(settings, "midi.winmidi.device", multi_dev_name);
     }
 }
 

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -29,8 +29,8 @@
  * pointers to a queue and re-add them in a separate thread.  Lame-o API! :(
  *
  * Multiple/single devices handling capabilities:
- * This driver is able to handle multiple devices choosen by the user trough
- * the setting midi.winmidi.device. This will allow the driver to receive MIDI
+ * This driver is able to handle multiple devices chosen by the user trough
+ * the setting midi.winmidi.device. This allows the driver to receive MIDI
  * messages comming from distinct devices and forward these messages on
  * distinct MIDI channels set.
  * 1)For example, if the user chooses 2 devices at index 0 and 1, the user must
@@ -45,11 +45,11 @@
  * The driver will forward MIDI messages as this:
  * - MIDI messages from real device 1 are output to MIDI channels set 0 to 15.
  * - MIDI messages from real device 0 are output to MIDI channels set 15 to 31.
- * So, the order of real device index specified the setting allows the user to
+ * So, the order of real device index specified in the setting allows the user to
  * choose the MIDI channel set associated with this real device at the driver
  * output.
  *
- * Note also that the driver handles single device choosen by putting the device
+ * Note also that the driver handles single device chosen by putting the device
  * name in midi.winmidi.device setting.
  * For example, let the followings device names:
  * 0:Port MIDI SB Live! [CE00], 1:SB PCI External MIDI, default, multi:0[,1,..]
@@ -86,6 +86,7 @@ typedef struct device_infos_t
     unsigned char sysExBuf[MIDI_SYSEX_BUF_COUNT * MIDI_SYSEX_MAX_SIZE];
 }device_infos;
 
+/* driver structure */
 struct fluid_winmidi_driver_s
 {
     fluid_midi_driver_t driver;
@@ -142,6 +143,11 @@ fluid_winmidi_input_error(char *strError, MMRESULT no)
     return strError;
 }
 
+/*
+  callback function called by any MIDI device sending a MIDI message.
+  @param dwInstance, pointer on device_infos structure of this
+  device.
+*/
 static void CALLBACK
 fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
                        DWORD_PTR dwParam1, DWORD_PTR dwParam2)

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -412,11 +412,13 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
         */
         int dev_idx;               /* device index */
         char *cur_idx, *next_idx;  /* current and next ascii index pointer */
-        cur_idx = next_idx = &dev_name[MULTI_DEV_PREFIX_LEN];
+        next_idx = &dev_name[MULTI_DEV_PREFIX_LEN];
         do
         {
+            /* try to convert next ascii index */
+            cur_idx = next_idx;
             dev_idx = g_ascii_strtoll(cur_idx, &next_idx, 10);
-            if (cur_idx == next_idx                /* not a number */
+            if (cur_idx == next_idx                /* not an integer number */
                 || dev_idx < 0                     /* invalid device index */
                 || dev_idx >= num                  /* invalid device index */
                 || (dev->dev_count >= max_devices) /* exceed max allowed */
@@ -429,9 +431,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
             /* memorize device index in dev_infos table */
             dev->dev_infos[dev->dev_count++].dev_idx = dev_idx;
 
-            /* go to next index */
-            cur_idx = next_idx;
-        }while(*cur_idx);
+        }while(*next_idx);
     }
     else
     {

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -456,7 +456,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
             /* memorize device index in dev_infos table */
             dev->dev_infos[dev->dev_count++].dev_idx = dev_idx;
 
-            /* go to ending delimitor */
+            /* go to ending delimiter */
             beg_idx += size_idx;
         }while(*beg_idx);
     }

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -512,7 +512,6 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
         dev_infos->midi_num = i;         /* device order number */
         dev_infos->channel_map = i * 16; /* map from input to output */
         FLUID_LOG(FLUID_DBG, "opening device at index %d", dev_infos->dev_idx);
-        printf("opening device at index %d\n", dev_infos->dev_idx);
         res = midiInOpen(&dev_infos->hmidiin, dev_infos->dev_idx,
                          (DWORD_PTR) fluid_winmidi_callback,
                          (DWORD_PTR) dev_infos, CALLBACK_FUNCTION);

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -67,7 +67,7 @@
 #if WINMIDI_SUPPORT
 
 /* uncomment this macro to enable printf displayed */
-#define PRINTF_MSG
+//#define PRINTF_MSG
 
 #include "fluid_midi.h"
 #include "fluid_mdriver.h"

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -71,6 +71,8 @@
 #define MIDI_SYSEX_BUF_COUNT    16
 
 typedef struct fluid_winmidi_driver_s fluid_winmidi_driver_t;
+
+/* device infos structure for only one midi device */
 typedef struct device_infos_t
 {
     fluid_winmidi_driver_t *dev; /* driver structure*/

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -84,7 +84,7 @@ typedef struct device_infos
     MIDIHDR sysExHdrs[MIDI_SYSEX_BUF_COUNT];
     /* Sysex data buffer */
     unsigned char sysExBuf[MIDI_SYSEX_BUF_COUNT * MIDI_SYSEX_MAX_SIZE];
-}device_infos_t;
+} device_infos_t;
 
 /* driver structure */
 struct fluid_winmidi_driver
@@ -149,7 +149,8 @@ fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
         event.channel = msg_chan(msg_param) + dev_infos->channel_map;
 
         FLUID_LOG(FLUID_DBG, "\ndevice at index %d sending MIDI message on channel %d, forwarded on channel: %d",
-                  dev_infos->dev_idx, msg_chan(msg_param) , event.channel);
+                  dev_infos->dev_idx, msg_chan(msg_param), event.channel);
+
         if(event.type != PITCH_BEND)
         {
             event.param1 = msg_p1(msg_param);
@@ -167,6 +168,7 @@ fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
     case MIM_LONGDATA:    /* SYSEX data */
         FLUID_LOG(FLUID_DBG, "\ndevice at index %d sending MIDI sysex message",
                   dev_infos->dev_idx);
+
         if(dev->hThread == NULL)
         {
             break;
@@ -228,6 +230,7 @@ static char *fluid_winmidi_get_device_name(int dev_idx, char *dev_name)
 
     /* index size + separator + name length + zero termination */
     new_dev_name = FLUID_MALLOC(size + 2 + FLUID_STRLEN(dev_name));
+
     if(new_dev_name)
     {
         /* the name is filled if allocation is successful */
@@ -237,6 +240,7 @@ static char *fluid_winmidi_get_device_name(int dev_idx, char *dev_name)
     {
         FLUID_LOG(FLUID_ERR, "Out of memory");
     }
+
     return new_dev_name;
 }
 
@@ -277,10 +281,12 @@ void fluid_winmidi_midi_driver_settings(fluid_settings_t *settings)
             {
                 /* add new device name (prefixed by its index) */
                 char *new_dev_name = fluid_winmidi_get_device_name(i, in_caps.szPname);
+
                 if(!new_dev_name)
                 {
                     break;
                 }
+
                 fluid_settings_add_option(settings, "midi.winmidi.device",
                                           new_dev_name);
                 FLUID_FREE(new_dev_name);
@@ -334,7 +340,7 @@ static DWORD WINAPI fluid_winmidi_add_sysex_thread(void *data)
  * @return count of devices parsed or 0 if device name doesn't exist.
  */
 static int
-fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char * dev_name)
+fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char *dev_name)
 {
     int dev_count = 0; /* device count */
     int dev_idx;       /* device index */
@@ -354,15 +360,17 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char * dev_name)
         /* try to convert current ascii index */
         char *end_idx = cur_idx;
         dev_idx = g_ascii_strtoll(cur_idx, &end_idx, 10);
-        if (cur_idx == end_idx     /* not an integer number */
-            || dev_idx < 0         /* invalid device index */
-            || dev_idx >= num      /* invalid device index */
-           )
+
+        if(cur_idx == end_idx      /* not an integer number */
+           || dev_idx < 0          /* invalid device index */
+           || dev_idx >= num       /* invalid device index */
+          )
         {
             if(dev)
             {
-               dev->dev_count = 0;
+                dev->dev_count = 0;
             }
+
             dev_count = 0; /* error, end of parsing */
             break;
         }
@@ -372,6 +380,7 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char * dev_name)
         {
             dev->dev_infos[dev->dev_count++].dev_idx = dev_idx;
         }
+
         dev_count++;
     }
 
@@ -381,10 +390,12 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char * dev_name)
         /* default device index: dev_idx = 0, dev_count = 1 */
         dev_count = 1;
         dev_idx = 0;
+
         if(FLUID_STRCASECMP("default", dev_name) != 0)
         {
             int i;
             dev_count = 0; /* reset count of devices found */
+
             for(i = 0; i < num; i++)
             {
                 char strError[MAXERRORLENGTH];
@@ -396,10 +407,12 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char * dev_name)
                 {
                     int str_cmp_res;
                     char *new_dev_name = fluid_winmidi_get_device_name(i, in_caps.szPname);
+
                     if(!new_dev_name)
                     {
                         break;
                     }
+
 #ifdef _UNICODE
                     WCHAR wDevName[MAXPNAMELEN];
                     MultiByteToWideChar(CP_UTF8, 0, dev_name, -1, wDevName, MAXPNAMELEN);
@@ -427,18 +440,21 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char * dev_name)
                 }
             }
         }
+
         if(dev && dev_count)
         {
             dev->dev_infos[0].dev_idx = dev_idx;
             dev->dev_count = 1;
         }
     }
+
     if(num < dev_count)
     {
         FLUID_LOG(FLUID_ERR, "not enough MIDI in devices found. Expected:%d found:%d",
                   dev_count, num);
         dev_count = 0;
     }
+
     return dev_count;
 }
 
@@ -471,7 +487,8 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     }
 
     /* parse device name, get the maximum number of devices to handle */
-	max_devices = fluid_winmidi_parse_device_name(NULL, dev_name);
+    max_devices = fluid_winmidi_parse_device_name(NULL, dev_name);
+
     /* check if any device has be found	*/
     if(!max_devices)
     {
@@ -533,7 +550,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
                 if(res != MMSYSERR_NOERROR)
                 {
                     FLUID_LOG(FLUID_WARN, "Failed to prepare MIDI SYSEX buffer: %s (error %d)",
-                          fluid_winmidi_input_error(strError, res), res);
+                              fluid_winmidi_input_error(strError, res), res);
                     midiInUnprepareHeader(dev_infos->hmidiin, hdr, sizeof(MIDIHDR));
                 }
             }
@@ -569,6 +586,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
             goto error_recovery;
         }
     }
+
     return (fluid_midi_driver_t *) dev;
 
 error_recovery:
@@ -583,7 +601,7 @@ error_recovery:
 void
 delete_fluid_winmidi_driver(fluid_midi_driver_t *p)
 {
-    int i,j;
+    int i, j;
 
     fluid_winmidi_driver_t *dev = (fluid_winmidi_driver_t *) p;
     fluid_return_if_fail(dev != NULL);
@@ -602,6 +620,7 @@ delete_fluid_winmidi_driver(fluid_midi_driver_t *p)
     for(i = 0; i < dev->dev_count; i++)
     {
         device_infos_t *dev_infos = &dev->dev_infos[i];
+
         if(dev_infos->hmidiin != NULL)
         {
             /* stop the device and mark any pending data blocks as being done */
@@ -612,7 +631,7 @@ delete_fluid_winmidi_driver(fluid_midi_driver_t *p)
             {
                 MIDIHDR *hdr = &dev_infos->sysExHdrs[j];
 
-                if ((hdr->dwFlags & MHDR_PREPARED))
+                if((hdr->dwFlags & MHDR_PREPARED))
                 {
                     midiInUnprepareHeader(dev_infos->hmidiin, hdr, sizeof(MIDIHDR));
                 }
@@ -622,6 +641,7 @@ delete_fluid_winmidi_driver(fluid_midi_driver_t *p)
             midiInClose(dev_infos->hmidiin);
         }
     }
+
     FLUID_FREE(dev);
 }
 

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -54,7 +54,7 @@
  *
  * Note also that the driver handles single device chosen by putting the device
  * name in midi.winmidi.device setting.
- * For example, let the followings device names:
+ * For example, let the following device names:
  * 0:Port MIDI SB Live! [CE00], 1:SB PCI External MIDI, default, multi:0[,1,..]
  * The user can set the name "0:Port MIDI SB Live! [CE00]" in the setting.
  * or use the multi device naming "multi:0" (specifying only device 0 index).

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -66,7 +66,7 @@
 
 #if WINMIDI_SUPPORT
 
-/* uncomment this macro to enable printf message */
+/* define PRINTF_MSG macro to enable printf message */
 //#define PRINTF_MSG
 
 #include "fluid_midi.h"
@@ -438,16 +438,13 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
         /* previous ending index pointer */
         char *beg_idx = &dev_name[MULTI_DEV_PREFIX_LEN];
         int dev_idx;    /* device index */
+        int size_idx;   /* size of ascii index */
         do
         {
             beg_idx = beg_idx + 1; /* beginning position of next ascii index */
-            if(*beg_idx == '\0')
-            {
-                break; /* no more index, end of device index parsing */
-            }
-
             dev_idx = atoi(beg_idx); /* convert */
-            if (!fluid_is_uint(beg_idx, ',')       /* not a number */
+            size_idx = fluid_is_uint(beg_idx, ','); /* check and count caracter */
+            if (!size_idx                          /* not a number */
                 || (UINT)dev_idx >= num            /* invalid device index */
                 || (dev->dev_count >= max_devices) /* exceed max allowed */
                )
@@ -460,8 +457,8 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
             dev->dev_infos[dev->dev_count++].dev_idx = dev_idx;
 
             /* go to ending delimitor */
-            beg_idx = FLUID_STRCHR(beg_idx,',');
-        }while(beg_idx != NULL);
+            beg_idx += size_idx;
+        }while(*beg_idx);
     }
     else
     {

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -601,8 +601,7 @@ delete_fluid_winmidi_driver(fluid_midi_driver_t *p)
         device_infos *dev_infos = &dev->dev_infos[i];
         if(dev_infos->hmidiin != NULL)
         {
-            /* stop the device */
-            midiInStop(dev_infos->hmidiin);
+            /* stop the device and mark any pending data blocks as being done */
             midiInReset(dev_infos->hmidiin);
 
             /* free allocated buffers associated to this device */

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -66,7 +66,7 @@
 
 #if WINMIDI_SUPPORT
 
-/* uncomment this macro to enable printf displayed */
+/* uncomment this macro to enable printf message */
 //#define PRINTF_MSG
 
 #include "fluid_midi.h"
@@ -112,7 +112,7 @@ struct fluid_winmidi_driver_s
 #define msg_p2(_m)    ((_m >> 16) & 0x7f)
 
 /*
-  check if string uanum is an unsigned ascii number
+  check if the string uanum is an unsigned ascii number.
   @param uanum pointer on ascii number.
   @param del ending delimiter caracter.
   @return count of caracter or 0 if not a valid number.
@@ -237,10 +237,10 @@ fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
  * The name returned is convenient for midi.winmidi.device setting.
  * It allows the user to identify a device index through its name or vise
  * versa. This allows the user to specify a multi device name using a list of
- * devices index (see fluid_winmidi_midi_driver_settings'()).
+ * devices index (see fluid_winmidi_midi_driver_settings()).
  *
- * @param dev_idx, device index
- * @param dev_name, name of the device
+ * @param dev_idx, device index.
+ * @param dev_name, name of the device.
  * @return the new device name (that must be freed when finish with it) or
  *  NULL if memory allocation error.
  */
@@ -409,7 +409,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
         return NULL;
     }
 
-    /* allocation of driver sytructure dependant of max_devices */
+    /* allocation of driver structure size dependant of max_devices */
     dev = FLUID_MALLOC(sizeof(fluid_winmidi_driver_t)
                        + (max_devices - 1) * sizeof(device_infos));
 
@@ -429,7 +429,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
         FLUID_STRCPY(dev_name, "default");
     }
 
-    /* look if the device name start with the prefix 'multi'. */
+    /* look if the device name starts with the prefix 'multi'. */
     if( FLUID_STRNCASECMP(multi_dev_name, dev_name, MULTI_DEV_PREFIX_LEN) == 0)
     {
         /* multi devices name "multi:x,y,z". parse devices index: x,y,..

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -30,9 +30,12 @@
  *
  * Multiple/single devices handling capabilities:
  * This driver is able to handle multiple devices chosen by the user trough
- * the setting midi.winmidi.device. This allows the driver to receive MIDI
- * messages comming from distinct devices and forward these messages on
- * distinct MIDI channels set.
+ * the settings midi.winmidi.maxdevices and midi.winmidi.device.
+ * The setting midi.winmidi.maxdevices must be set to the number of devices to
+ * work with. This allows the driver to check if the real devices number exist
+ * and allocate the necessary memory.
+ * Then the driver is able receive MIDI messages comming from distinct devices
+ * and forward these messages on distinct MIDI channels set.
  * 1)For example, if the user chooses 2 devices at index 0 and 1, the user must
  * specify this by putting the name "multi:0,1" in midi.winmidi.device setting.
  * We get a fictif device composed of real devices (0,1). This fictif device


### PR DESCRIPTION
This PR allows `winmidi` driver to open multiple `midi devices` and forward MIDI messages on distinct consecutive MIDI channels to the output.
For example, this allows to use 2 MIDI controllers connected to a single `synth instance` with `synth.midi-channels` setting set to 32. 
The `synth` instance will receive messages from the `first MIDI controller` on MIDI channel 0 to 15,
and messages from the `second MIDI controller` on MIDI channels 16 to 31.

Please see more information in fluid_winmidi.c header.
