### PR TITLE
Update Android CircleCI build to use latest orb, Android API, Oboe and Cerbero

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,20 @@
 version: 2.1
 orbs:
-  android: circleci/android@0.2.0
+  android: circleci/android@0.2.1
 jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android:api-30
     environment:
       JVM_OPTS: -Xmx3200m
     steps:
       - run:
           name: Setup Git email and user for Cerbero
           command: git config --global user.email "ci@beatscratch.io" && git config --global user.name "CI testing"
-      - android/install-ndk:
-          ndk-version: android-ndk-r18b
-          ndk-sha: 500679655da3a86aecf67007e8ab230ea9b4dd7b
-      - run:
-          name: Link NDK for Cerbero
-          command: |
-            mkdir -p /home/circleci/android-sdk-linux
-            ln -s /opt/android/android-ndk-r18b /home/circleci/android-sdk-linux/ndk-bundle
+      # - android/install-ndk:
+      #     ndk-version: android-ndk-r18b
+      #     ndk-sha: 500679655da3a86aecf67007e8ab230ea9b4dd7b
       - run:
           name: Install FluidSynth build dependencies
           command: sudo apt-get update && sudo apt-get install autotools-dev automake autoconf libtool g++ autopoint make cmake
@@ -32,14 +27,25 @@ jobs:
             git subversion xutils-dev intltool ccache python3-setuptools autogen maven make
       - checkout
       - run:
-          name: Prepare FluidSynth Android
+          name: Build Cerbero and Oboe
           working_directory: doc/android
           command: |
+            export TERM=dumb
             make -f Makefile.android prepare
+      - run:
+          name: Link Cerbero NDK for build
+          command: |
+            mkdir -p /home/circleci/android-sdk-linux
+            echo "android-ndk-21 content"
+            ls /home/circleci/code/doc/android/external/cerbero/build/android-ndk-21
+            ln -s /home/circleci/code/doc/android/external/cerbero/build/android-ndk-21 /home/circleci/android-sdk-linux/ndk-bundle
+            echo "/home/circleci/android-sdk-linux/ndk-bundle content"
+            ls /home/circleci/android-sdk-linux/ndk-bundle
       - run:
           name: Build FluidSynth Android
           working_directory: doc/android
           command: |
+            export TERM=dumb
             make -f Makefile.android
       - run:
           name: Show directory contents
@@ -47,7 +53,7 @@ jobs:
           command: |
             ls -R
       - run:
-          name: Zip FluidSnyth Android Distribution
+          name: Zip FluidSynth Android Distribution
           working_directory: doc/android
           command: zip -r android-dist.zip dist
       - store_artifacts:

--- a/doc/android/Makefile.android
+++ b/doc/android/Makefile.android
@@ -17,7 +17,7 @@ CERBERO=$(PWD)/external/cerbero
 OBOE=$(PWD)/external/oboe
 CMAKE=cmake
 
-ANDROID_NDK = $(PWD)/external/cerbero/build/android-ndk-18
+ANDROID_NDK = $(PWD)/external/cerbero/build/android-ndk-21
 
 ABIS_SIMPLE = x86 x86-64 armv7 arm64
 
@@ -35,17 +35,17 @@ prepare: checkout-oboe checkout-cerbero
 
 .PHONY: checkout-oboe
 checkout-oboe: $(OBOE)
-	cd $(OBOE) && git checkout 9bf3943
+	cd $(OBOE) && git checkout 395f3d6ac25c2b069d53451b89dff4aa96d26eb8
 
 $(OBOE):
 	git clone https://github.com/Google/oboe.git $(OBOE) 
 
 .PHONY: checkout-cerbero
 checkout-cerbero: $(CERBERO)
-	cd $(CERBERO) && git checkout 0acd9b0
+	cd $(CERBERO) && git checkout e9f18b3b340de1648d885a0542d2f06c3fcfffe8
 
 $(CERBERO):
-	git clone https://github.com/atsushieno/cerbero.git $(CERBERO)
+	git clone https://github.com/falrm/cerbero.git $(CERBERO)
 
 .PHONY: build
 build: build-oboe dist-oboe build-deps-cerbero dist-deps-cerbero build-fluidsynth dist-fluidsynth build-fluidsynth-assetloader dist-fluidsynth-assetloader


### PR DESCRIPTION
This fixes the currently-broken CircleCI build for Android-useable .so files.

Currently the Cerbero build is based off https://github.com/falrm/cerbero until https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/641 is merged and deployed to the GitHub cerbero mirror.

Here is a successful build with the updated CircleCI workflow: https://app.circleci.com/pipelines/github/falrm/fluidsynth-android/31/workflows/0ad3186a-394c-4736-984b-96496b608053/jobs/32

You'll also note the CircleCI build on this PR is fixed. The FreeBSD one is still broken but that's pretty clearly unrelated :)