### PR TITLE
Replace FreeBSD 13.0 with 11.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,7 @@ task:
     name: FreeBSD
     freebsd_instance:
         matrix:
-            # There isn't a stable 13.0 image yet (2019-09)
-            image_family: freebsd-13-0-snap
+            image_family: freebsd-11-4
             image_family: freebsd-12-1
 
     install_script: pwd && ls -la && pkg update --force && pkg install -y cmake glib alsa-lib ladspa portaudio pulseaudio pkgconf sdl2


### PR DESCRIPTION
13.0 hasn't been released yet and the CI build keeps failing for long.