### PR TITLE
GitHub Action to build the API docs from master branch

### DIFF
--- a/.github/workflows/api_doc_build.yml
+++ b/.github/workflows/api_doc_build.yml
@@ -1,0 +1,38 @@
+name: API Doc Build
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Install Dependencies
+      run: sudo apt-get install doxygen xsltproc
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake --build . --config $BUILD_TYPE --target doxygen
+    
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: api_docs
+        path: ${{runner.workspace}}/build/doc/api/html


### PR DESCRIPTION
This is the first part of the new way we want to build the API docs for fluidsynth.org as discussed in #703.

It currently reacts to pushes on the master branch only and uploads the HTML doc files as a single artifact called `api_docs.zip`. We could also remove the branch restriction and have it build on every PR and branch push, of course. I just didn't think that would be necessary at the moment.