### PR TITLE
Change owner of the SoundFont registered trademark.

### DIFF
--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -1112,7 +1112,7 @@ print_welcome()
     printf("FluidSynth runtime version %s\n"
            "Copyright (C) 2000-2020 Peter Hanappe and others.\n"
            "Distributed under the LGPL license.\n"
-           "SoundFont(R) is a registered trademark of E-mu Systems, Inc.\n\n",
+           "SoundFont(R) is a registered trademark of Creative Technology, Ltd.\n\n",
            fluid_version_str());
 }
 

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -1112,7 +1112,7 @@ print_welcome()
     printf("FluidSynth runtime version %s\n"
            "Copyright (C) 2000-2020 Peter Hanappe and others.\n"
            "Distributed under the LGPL license.\n"
-           "SoundFont(R) is a registered trademark of Creative Technology, Ltd.\n\n",
+           "SoundFont(R) is a registered trademark of E-mu Systems, Inc.\n\n",
            fluid_version_str());
 }
 

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -1112,7 +1112,7 @@ print_welcome()
     printf("FluidSynth runtime version %s\n"
            "Copyright (C) 2000-2020 Peter Hanappe and others.\n"
            "Distributed under the LGPL license.\n"
-           "SoundFont(R) is a registered trademark of E-mu Systems, Inc.\n\n",
+           "SoundFont(R) is a registered trademark of Creative Technology Ltd.\n\n",
            fluid_version_str());
 }
 


### PR DESCRIPTION
As of the time of this PR, the SoundFont registered trademark is owned by Creative Technology Ltd.
( http://tmsearch.uspto.gov/bin/showfield?f=doc&state=4803:rj74xq.2.1 )