### PR TITLE
Handle GS SysEx messages for setting whether a channel is used for rhythm part.

### DIFF
--- a/src/midi/fluid_midi.h
+++ b/src/midi/fluid_midi.h
@@ -187,6 +187,7 @@ enum midi_sysex_manuf
 /* SYSEX sub-ID #1 which follows device ID */
 #define MIDI_SYSEX_MIDI_TUNING_ID       0x08    /**< Sysex sub-ID #1 for MIDI tuning messages */
 #define MIDI_SYSEX_GM_ID                0x09    /**< Sysex sub-ID #1 for General MIDI messages */
+#define MIDI_SYSEX_GS_ID                0x42    /**< Model ID (GS) serving as sub-ID #1 for GS messages*/
 
 /**
  * SYSEX tuning message IDs.
@@ -208,6 +209,7 @@ enum midi_sysex_tuning_msg_id
 /* General MIDI sub-ID #2 */
 #define MIDI_SYSEX_GM_ON                0x01    /**< Enable GM mode */
 #define MIDI_SYSEX_GM_OFF               0x02    /**< Disable GM mode */
+#define MIDI_SYSEX_GS_DT1               0x12    /**< GS DT1 command */
 
 enum fluid_driver_status
 {

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -1947,7 +1947,6 @@ fluid_synth_sysex(fluid_synth_t *synth, const char *data, int len,
 
     /* GS DT1 message */
     if((synth->bank_select == FLUID_BANK_STYLE_GS)
-            && len >= 4
             && data[0] == MIDI_SYSEX_MANUF_ROLAND
             && (data[1] == synth->device_id || data[1] == MIDI_SYSEX_DEVICE_ID_ALL)
             && data[2] == MIDI_SYSEX_GS_ID


### PR DESCRIPTION
Some MIDI files that uses the GS standard uses channels other than channel 10 as percussion channel. Currently FluidSynth ignores the messages setting that up, causing notes meant to be played with a drum instrument played with a melodic instrument or vice versa. This patch will partially fix the issue.

Currently the implementation in this patch doesn't cover a specific "quirk" in Roland GS Modules: they seem to remember the last used instrument in the selected mode. This patch simply sets the instrument number to 0 instead.

A test file is attached. If played correctly (with `-o synth.device-id=16`) no out of place drum or piano sounds should be heard.

[wikipedia_MIDI_sample_gstest.mid.gz](https://github.com/FluidSynth/fluidsynth/files/5610727/wikipedia_MIDI_sample_gstest.mid.gz)
