### PR TITLE
Support for FLUID_STRTOL()

### DIFF
--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -359,7 +359,7 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char *dev_name)
     {
         /* try to convert current ascii index */
         char *end_idx = cur_idx;
-        dev_idx = g_ascii_strtoll(cur_idx, &end_idx, 10);
+        dev_idx = FLUID_STRTOL(cur_idx, &end_idx, 10);
 
         if(cur_idx == end_idx      /* not an integer number */
            || dev_idx < 0          /* invalid device index */

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -212,6 +212,7 @@ void* fluid_alloc(size_t len);
 #define FLUID_STRCMP(_s,_t)          strcmp(_s,_t)
 #define FLUID_STRNCMP(_s,_t,_n)      strncmp(_s,_t,_n)
 #define FLUID_STRCPY(_dst,_src)      strcpy(_dst,_src)
+#define FLUID_STRTOL(_s,_e,_b)       strtol(_s,_e,_b)
 
 #define FLUID_STRNCPY(_dst,_src,_n) \
 do { strncpy(_dst,_src,_n-1); \


### PR DESCRIPTION
Since Windows supports up to 32 MIDI devices, I think that FLUID_STRTOL() is more than enough.
In my opinion, it would be also a good idea to not use directly a GLib function, since the source code already wraps all calls to library functions with macros.