### PR TITLE
Fix the fluid_synth_set_sample_rate() change problem for jack driver

### DIFF
--- a/src/drivers/fluid_jack.c
+++ b/src/drivers/fluid_jack.c
@@ -501,9 +501,7 @@ fluid_jack_client_register_ports(void *driver, int isaudio, jack_client_t *clien
         {
             FLUID_LOG(FLUID_INFO, "Jack sample rate mismatch, adjusting."
                   " (synth.sample-rate=%lu, jackd=%lu)", (unsigned long)sample_rate, jack_srate);
-            fluid_synth_set_sample_rate(synth, jack_srate);
-            /* Changing sample rate is non RT, so make sure we process it and/or other things now */
-            fluid_synth_process_event_queue(synth);
+            fluid_synth_set_sample_rate_immediately(synth, jack_srate);
         }
         else
         {

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3252,17 +3252,17 @@ fluid_synth_update_presets(fluid_synth_t *synth)
 }
 
 static void
-fluid_synth_set_sample_rate_LOCAL(fluid_synth_t *synth, float sample_rate)
+fluid_synth_set_sample_rate_LOCAL(fluid_synth_t *synth, float* sample_rate)
 {
     int i;
-    fluid_clip(sample_rate, 8000.0f, 96000.0f);
-    synth->sample_rate = sample_rate;
+    fluid_clip(*sample_rate, 8000.0f, 96000.0f);
+    synth->sample_rate = *sample_rate;
 
     synth->min_note_length_ticks = fluid_synth_get_min_note_length_LOCAL(synth);
 
     for(i = 0; i < synth->polyphony; i++)
     {
-        fluid_voice_set_output_rate(synth->voice[i], sample_rate);
+        fluid_voice_set_output_rate(synth->voice[i], *sample_rate);
     }
 }
 
@@ -3299,7 +3299,7 @@ fluid_synth_set_sample_rate(fluid_synth_t *synth, float sample_rate)
     fluid_return_if_fail(synth != NULL);
     fluid_synth_api_enter(synth);
 
-    fluid_synth_set_sample_rate_LOCAL(synth, sample_rate);
+    fluid_synth_set_sample_rate_LOCAL(synth, &sample_rate);
 
     fluid_synth_update_mixer(synth, fluid_rvoice_mixer_set_samplerate,
                              0, sample_rate);
@@ -3315,7 +3315,7 @@ fluid_synth_set_sample_rate_immediately(fluid_synth_t *synth, float sample_rate)
     fluid_return_if_fail(synth != NULL);
     fluid_synth_api_enter(synth);
     
-    fluid_synth_set_sample_rate_LOCAL(synth, sample_rate);
+    fluid_synth_set_sample_rate_LOCAL(synth, &sample_rate);
 
     param[0].i = 0;
     param[1].real = sample_rate;

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3252,17 +3252,17 @@ fluid_synth_update_presets(fluid_synth_t *synth)
 }
 
 static void
-fluid_synth_set_sample_rate_LOCAL(fluid_synth_t *synth, float* sample_rate)
+fluid_synth_set_sample_rate_LOCAL(fluid_synth_t *synth, float sample_rate)
 {
     int i;
-    fluid_clip(*sample_rate, 8000.0f, 96000.0f);
-    synth->sample_rate = *sample_rate;
+    fluid_clip(sample_rate, 8000.0f, 96000.0f);
+    synth->sample_rate = sample_rate;
 
     synth->min_note_length_ticks = fluid_synth_get_min_note_length_LOCAL(synth);
 
     for(i = 0; i < synth->polyphony; i++)
     {
-        fluid_voice_set_output_rate(synth->voice[i], *sample_rate);
+        fluid_voice_set_output_rate(synth->voice[i], sample_rate);
     }
 }
 
@@ -3299,10 +3299,10 @@ fluid_synth_set_sample_rate(fluid_synth_t *synth, float sample_rate)
     fluid_return_if_fail(synth != NULL);
     fluid_synth_api_enter(synth);
 
-    fluid_synth_set_sample_rate_LOCAL(synth, &sample_rate);
+    fluid_synth_set_sample_rate_LOCAL(synth, sample_rate);
 
     fluid_synth_update_mixer(synth, fluid_rvoice_mixer_set_samplerate,
-                             0, sample_rate);
+                             0, synth->sample_rate);
     fluid_synth_api_exit(synth);
 }
 
@@ -3315,10 +3315,10 @@ fluid_synth_set_sample_rate_immediately(fluid_synth_t *synth, float sample_rate)
     fluid_return_if_fail(synth != NULL);
     fluid_synth_api_enter(synth);
     
-    fluid_synth_set_sample_rate_LOCAL(synth, &sample_rate);
+    fluid_synth_set_sample_rate_LOCAL(synth, sample_rate);
 
     param[0].i = 0;
-    param[1].real = sample_rate;
+    param[1].real = synth->sample_rate;
     fluid_rvoice_mixer_set_samplerate(synth->eventhandler->mixer, param);
     
     fluid_synth_api_exit(synth);

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3251,6 +3251,21 @@ fluid_synth_update_presets(fluid_synth_t *synth)
     }
 }
 
+static void
+fluid_synth_set_sample_rate_LOCAL(fluid_synth_t *synth, float sample_rate)
+{
+    int i;
+    fluid_clip(sample_rate, 8000.0f, 96000.0f);
+    synth->sample_rate = sample_rate;
+
+    synth->min_note_length_ticks = fluid_synth_get_min_note_length_LOCAL(synth);
+
+    for(i = 0; i < synth->polyphony; i++)
+    {
+        fluid_voice_set_output_rate(synth->voice[i], sample_rate);
+    }
+}
+
 /**
  * Set up an event to change the sample-rate of the synth during the next rendering call.
  * @warning This function is broken-by-design! Don't use it! Instead, specify the sample-rate when creating the synth.
@@ -3281,21 +3296,31 @@ fluid_synth_update_presets(fluid_synth_t *synth)
 void
 fluid_synth_set_sample_rate(fluid_synth_t *synth, float sample_rate)
 {
-    int i;
     fluid_return_if_fail(synth != NULL);
     fluid_synth_api_enter(synth);
-    fluid_clip(sample_rate, 8000.0f, 96000.0f);
-    synth->sample_rate = sample_rate;
 
-    synth->min_note_length_ticks = fluid_synth_get_min_note_length_LOCAL(synth);
-
-    for(i = 0; i < synth->polyphony; i++)
-    {
-        fluid_voice_set_output_rate(synth->voice[i], sample_rate);
-    }
+    fluid_synth_set_sample_rate_LOCAL(synth, sample_rate);
 
     fluid_synth_update_mixer(synth, fluid_rvoice_mixer_set_samplerate,
                              0, sample_rate);
+    fluid_synth_api_exit(synth);
+}
+
+// internal sample rate change function for the jack driver
+// executes immediately, therefore, make sure no rendering call is running!
+void
+fluid_synth_set_sample_rate_immediately(fluid_synth_t *synth, float sample_rate)
+{
+    fluid_rvoice_param_t param[MAX_EVENT_PARAMS];
+    fluid_return_if_fail(synth != NULL);
+    fluid_synth_api_enter(synth);
+    
+    fluid_synth_set_sample_rate_LOCAL(synth, sample_rate);
+
+    param[0].i = 0;
+    param[1].real = sample_rate;
+    fluid_rvoice_mixer_set_samplerate(synth->eventhandler->mixer, param);
+    
     fluid_synth_api_exit(synth);
 }
 

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -248,6 +248,7 @@ fluid_synth_write_float_LOCAL(fluid_synth_t *synth, int len,
  * misc
  */
 void fluid_synth_settings(fluid_settings_t *settings);
+void fluid_synth_set_sample_rate_immediately(fluid_synth_t *synth, float sample_rate);
 
 
 /* extern declared in fluid_synth_monopoly.c */


### PR DESCRIPTION
This PR adds a new sample rate change function, which executes the change immediately. For internal use only.

Resolves #608.