### PR TITLE
Fix lazy soundfont unloading

### DIFF
--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -4813,11 +4813,25 @@ fluid_synth_sfload(fluid_synth_t *synth, const char *filename, int reset_presets
 }
 
 /**
- * Unload a SoundFont.
+ * Schedule a SoundFont for unloading.
+ *
+ * If the SoundFont isn't used anymore by any playing voices, it will be unloaded immediately.
+ *
+ * If any samples of the given SoundFont are still required by active voices,
+ * the SoundFont will be unloaded in a lazy manner, once those voices have finished synthesizing.
+ * If you call delete_fluid_synth(), all voices will be destroyed and the SoundFont
+ * will be unloaded in any case.
+ * Once this function returned, fluid_synth_sfcount() and similar functions will behave as if
+ * the SoundFont has already been unloaded, even though the lazy-unloading is still pending.
+ *
+ * @note This lazy-unloading mechanism was broken between FluidSynth 1.1.4 and 2.1.5 . As a
+ * consequence, SoundFonts scheduled for lazy-unloading may be never freed under certain
+ * conditions. Calling delete_fluid_synth() does not recover this situation either.
+ *
  * @param synth FluidSynth instance
  * @param id ID of SoundFont to unload
  * @param reset_presets TRUE to re-assign presets for all MIDI channels
- * @return #FLUID_OK on success, #FLUID_FAILED on error
+ * @return #FLUID_OK if the given @p id was found, #FLUID_FAILED otherwise.
  */
 int
 fluid_synth_sfunload(fluid_synth_t *synth, int id, int reset_presets)

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -1067,6 +1067,12 @@ delete_fluid_synth(fluid_synth_t *synth)
                 continue;
             }
 
+            /* WARNING: A this point we must ensure that the reference counter
+               of any soundfont sample owned by any rvoice belonging to the voice
+               are correctly decremented. This is the contrary part to
+               to fluid_voice_init() where the sample's reference counter is
+               incremented.
+            */
             fluid_voice_unlock_rvoice(voice);
             fluid_voice_overflow_rvoice_finished(voice);
 
@@ -4289,7 +4295,21 @@ fluid_synth_check_finished_voices(fluid_synth_t *synth)
             }
             else if(synth->voice[j]->overflow_rvoice == fv)
             {
+                /* Unlock the overflow_rvoice of the voice.
+                   Decrement the reference count of the sample owned by this
+                   rvoice.
+                */
                 fluid_voice_overflow_rvoice_finished(synth->voice[j]);
+
+                /* Decrement synth active voice count. Must not be incorporated
+                   in fluid_voice_overflow_rvoice_finished() because
+                   fluid_voice_overflow_rvoice_finished() is called also
+                   at synth destruction and in this case the variable should be
+                   accessed via voice->channel->synth->active_voice_count.
+                   And for certain voices which are not playing, the field
+                   voice->channel is NULL.
+                */
+                synth->active_voice_count--;
                 break;
             }
         }

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -174,6 +174,7 @@ static void fluid_voice_swap_rvoice(fluid_voice_t *voice)
     voice->can_access_rvoice = voice->can_access_overflow_rvoice;
     voice->overflow_rvoice = rtemp;
     voice->can_access_overflow_rvoice = ctemp;
+    voice->overflow_sample = voice->sample;
 }
 
 static void fluid_voice_initialize_rvoice(fluid_voice_t *voice, fluid_real_t output_rate)
@@ -242,6 +243,7 @@ new_fluid_voice(fluid_rvoice_eventhandler_t *handler, fluid_real_t output_rate)
     voice->eventhandler = handler;
     voice->channel = NULL;
     voice->sample = NULL;
+    voice->overflow_sample = NULL;
     voice->output_rate = output_rate;
 
     /* Initialize both the rvoice and overflow_rvoice */
@@ -1420,7 +1422,7 @@ void fluid_voice_overflow_rvoice_finished(fluid_voice_t *voice)
 
     /* Decrement the reference count of the sample to indicate
        that this sample isn't owned by the rvoice anymore */
-    fluid_voice_sample_unref(&voice->overflow_rvoice->dsp.sample);
+    fluid_voice_sample_unref(&voice->overflow_sample);
 }
 
 /*
@@ -1451,12 +1453,7 @@ fluid_voice_stop(fluid_voice_t *voice)
     /* Decrement the reference count of the sample, to indicate
        that this sample isn't owned by the rvoice anymore.
     */
-    if(voice->can_access_rvoice)
-    {
-        fluid_voice_sample_unref(&voice->rvoice->dsp.sample);
-    }
-
-    voice->sample = NULL;
+    fluid_voice_sample_unref(&voice->sample);
 
     voice->status = FLUID_VOICE_OFF;
     voice->has_noteoff = 1;

--- a/src/synth/fluid_voice.h
+++ b/src/synth/fluid_voice.h
@@ -71,7 +71,8 @@ struct _fluid_voice_t
     fluid_channel_t *channel;
     fluid_rvoice_eventhandler_t *eventhandler;
     fluid_zone_range_t *zone_range;  /* instrument zone range*/
-    fluid_sample_t *sample;         /* Pointer to sample (dupe in rvoice) */
+    fluid_sample_t *sample;          /* Pointer to sample (dupe in rvoice) */
+    fluid_sample_t *overflow_sample; /* Pointer to sample (dupe in overflow_rvoice) */
 
     unsigned int start_time;
     int mod_count;


### PR DESCRIPTION
This PR fixes the lazy soundfont unloading mechanism, i.e. fixes #727.

(Regression tests should be merged first to see that CI passes.)