### PR TITLE
Handle early the "set" commands from the configuration file.

### DIFF
--- a/include/fluidsynth/shell.h
+++ b/include/fluidsynth/shell.h
@@ -67,6 +67,9 @@ void delete_fluid_cmd_handler(fluid_cmd_handler_t *handler);
 /** @endlifecycle */
 
 FLUIDSYNTH_API
+int parse_fluid_cmd_set(fluid_settings_t *settings, char *config_file);
+
+FLUIDSYNTH_API
 void fluid_cmd_handler_set_synth(fluid_cmd_handler_t *handler, fluid_synth_t *synth);
 
 FLUIDSYNTH_API

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -1938,6 +1938,11 @@ fluid_handle_set(void *data, int ac, char **av, fluid_ostream_t out)
         return ret;
     }
 
+    /* Only handle early non-realtime settings */
+    if(!handler->router && fluid_settings_is_realtime(handler->synth->settings, av[0])) {
+        return FLUID_OK;
+    }
+
     switch(fluid_settings_get_type(handler->synth->settings, av[0]))
     {
     case FLUID_NO_TYPE:

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -1915,7 +1915,9 @@ fluid_handle_set(void *data, int ac, char **av, fluid_ostream_t out)
 {
     FLUID_ENTRY_COMMAND(data);
     int hints;
-    int ival;
+    int ival, icur;
+    double fval, fcur;
+    char *scur;
     int ret = FLUID_FAILED;
 
     if(ac < 2)
@@ -1950,15 +1952,37 @@ fluid_handle_set(void *data, int ac, char **av, fluid_ostream_t out)
             ival = atoi(av[1]);
         }
 
+        fluid_settings_getint(handler->synth->settings, av[0], &icur);
+        if (icur == ival) {
+            return FLUID_OK;
+        }
+
         ret = fluid_settings_setint(handler->synth->settings, av[0], ival);
         break;
 
     case FLUID_NUM_TYPE:
-        ret = fluid_settings_setnum(handler->synth->settings, av[0], atof(av[1]));
+        fval = atof(av[1]);
+        fluid_settings_getnum(handler->synth->settings, av[0], &fcur);
+        if (fcur == fval) {
+            return FLUID_OK;
+        }
+
+        ret = fluid_settings_setnum(handler->synth->settings, av[0], fval);
         break;
 
     case FLUID_STR_TYPE:
+        fluid_settings_dupstr(handler->synth->settings, av[0], &scur);
+
+        if(scur && !FLUID_STRCMP(scur, av[1]))
+        {
+            FLUID_FREE(scur);
+            return FLUID_OK;
+        }
         ret = fluid_settings_setstr(handler->synth->settings, av[0], av[1]);
+        if(scur)
+        {
+            FLUID_FREE(scur);
+        }
         break;
 
     case FLUID_SET_TYPE:

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -548,7 +548,10 @@ fluid_shell_run(void *data)
 
         if(n == 0)
         {
-            FLUID_LOG(FLUID_INFO, "Received EOF while reading commands, exiting the shell.");
+            if(shell->settings)
+            {
+                FLUID_LOG(FLUID_INFO, "Received EOF while reading commands, exiting the shell.");
+	    }
             break;
         }
     }


### PR DESCRIPTION
As discussed at issue #724, if no-realtime set commands are used inside
a configuration file, fluidsynth can be on an invalid state, where the synth will be using a different setting than the modules that are initialized after parsing the command.

In order to solve it, parse earlier the set commands.

There are 4 patches on this series.

Patch 1 changes the function which handles the `set` command: it will now verify if the value actually changed. That prevents printing realtime warnings when the value was not changed;

Patch 2 adds a new CMD parser that handles only `set` commands, and is called before initializing the synth;

Patch 3 avoid prints a warning when the commands from config files are parsed.

Patch 4 ensures that the new early parsing logic is only used for settings that can't be changed in real time. I'm not sure if this is needed, but it should prevent backward-compatibility issues, if some config file was using `set` for realtime parameters, and are relying on them being processed only after other commands. Probably overkill, but it shouldn't hurt to add this one to the series.

This solves issue #724. This replaces the approach taken at PR #725.