### PR TITLE
Add support for new_fluid_audio_driver2 to two Windows-specific drivers.

### DIFF
--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -124,7 +124,7 @@ static const fluid_audriver_definition_t fluid_audio_drivers[] =
     {
         "waveout",
         new_fluid_waveout_audio_driver,
-        NULL,
+        new_fluid_waveout_audio_driver2,
         delete_fluid_waveout_audio_driver,
         fluid_waveout_audio_driver_settings
     },

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -114,7 +114,7 @@ static const fluid_audriver_definition_t fluid_audio_drivers[] =
     {
         "dsound",
         new_fluid_dsound_audio_driver,
-        NULL,
+        new_fluid_dsound_audio_driver2,
         delete_fluid_dsound_audio_driver,
         fluid_dsound_audio_driver_settings
     },

--- a/src/drivers/fluid_adriver.h
+++ b/src/drivers/fluid_adriver.h
@@ -105,6 +105,9 @@ void fluid_dsound_audio_driver_settings(fluid_settings_t *settings);
 #if WAVEOUT_SUPPORT
 fluid_audio_driver_t *new_fluid_waveout_audio_driver(fluid_settings_t *settings,
         fluid_synth_t *synth);
+fluid_audio_driver_t *new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
+        fluid_audio_func_t func,
+        void *data);
 void delete_fluid_waveout_audio_driver(fluid_audio_driver_t *p);
 void fluid_waveout_audio_driver_settings(fluid_settings_t *settings);
 #endif

--- a/src/drivers/fluid_adriver.h
+++ b/src/drivers/fluid_adriver.h
@@ -95,6 +95,9 @@ void fluid_core_audio_driver_settings(fluid_settings_t *settings);
 #if DSOUND_SUPPORT
 fluid_audio_driver_t *new_fluid_dsound_audio_driver(fluid_settings_t *settings,
         fluid_synth_t *synth);
+fluid_audio_driver_t *new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
+        fluid_audio_func_t func,
+        void *data);
 void delete_fluid_dsound_audio_driver(fluid_audio_driver_t *p);
 void fluid_dsound_audio_driver_settings(fluid_settings_t *settings);
 #endif

--- a/src/drivers/fluid_dsound.c
+++ b/src/drivers/fluid_dsound.c
@@ -185,7 +185,7 @@ void fluid_dsound_audio_driver_settings(fluid_settings_t *settings)
 fluid_audio_driver_t *
 new_fluid_dsound_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 {
-    return new_fluid_dsound_audio_driver2(settings, NULL, synth);
+    return new_fluid_dsound_audio_driver2(settings, (fluid_audio_func_t)fluid_synth_process, synth);
 }
 
 fluid_audio_driver_t *
@@ -215,8 +215,6 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t fu
     FLUID_MEMSET(dev, 0, sizeof(fluid_dsound_audio_driver_t));
     dev->synth = data;
     dev->func = func;
-    dev->lbuf = NULL;
-    dev->rbuf = NULL;
 
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
     fluid_settings_getint(settings, "audio.periods", &periods);
@@ -508,15 +506,8 @@ void delete_fluid_dsound_audio_driver(fluid_audio_driver_t *d)
         IDirectSound_Release(dev->direct_sound);
     }
 
-    if(dev->lbuf != NULL)
-    {
-        FLUID_FREE(dev->lbuf);
-    }
-
-    if(dev->rbuf != NULL)
-    {
-        FLUID_FREE(dev->rbuf);
-    }
+    FLUID_FREE(dev->lbuf);
+    FLUID_FREE(dev->rbuf);
 
     FLUID_FREE(dev);
 }
@@ -704,8 +695,8 @@ static int fluid_dsound_write_processed_channels(fluid_synth_t *data, int len,
     float *out[2] = {drv->lbuf, drv->rbuf};
     float *lptr;
     float *rptr;
-    memset(drv->lbuf, 0, len * sizeof(float));
-    memset(drv->rbuf, 0, len * sizeof(float));
+    FLUID_MEMSET(drv->lbuf, 0, len * sizeof(float));
+    FLUID_MEMSET(drv->rbuf, 0, len * sizeof(float));
     ret = drv->func(drv->synth, len, 0, NULL, 2, out);
     lptr = (float*)channels_out[0] + channels_off[0];
     rptr = (float*)channels_out[1] + channels_off[1];

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -267,7 +267,7 @@ void fluid_waveout_audio_driver_settings(fluid_settings_t *settings)
 fluid_audio_driver_t *
 new_fluid_waveout_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 {
-    return new_fluid_waveout_audio_driver2(settings, NULL, synth);
+    return new_fluid_waveout_audio_driver2(settings, (fluid_audio_func_t)fluid_synth_process, synth);
 }
 
 fluid_audio_driver_t *
@@ -395,11 +395,6 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t f
             delete_fluid_waveout_audio_driver(&dev->driver);
             return NULL;
         }
-    }
-    else
-    {
-        dev->lbuf = NULL;
-        dev->rbuf = NULL;
     }
 
     /* get the selected device name. if none is specified, use default device. */
@@ -543,15 +538,8 @@ void delete_fluid_waveout_audio_driver(fluid_audio_driver_t *d)
         CloseHandle(dev->hQuit);
     }
 
-    if(dev->lbuf != NULL)
-    {
-        FLUID_FREE(dev->lbuf);
-    }
-
-    if(dev->rbuf != NULL)
-    {
-        FLUID_FREE(dev->rbuf);
-    }
+    FLUID_FREE(dev->lbuf);
+    FLUID_FREE(dev->rbuf);
 
     HeapFree(GetProcessHeap(), 0, dev);
 }
@@ -567,8 +555,8 @@ static int fluid_waveout_write_processed_channels(fluid_synth_t *data, int len,
     float *out[2] = {drv->lbuf, drv->rbuf};
     float *lptr;
     float *rptr;
-    memset(drv->lbuf, 0, len * sizeof(float));
-    memset(drv->rbuf, 0, len * sizeof(float));
+    FLUID_MEMSET(drv->lbuf, 0, len * sizeof(float));
+    FLUID_MEMSET(drv->rbuf, 0, len * sizeof(float));
     ret = drv->func(drv->synth, len, 0, NULL, 2, out);
     lptr = (float*)channels_out[0] + channels_off[0];
     rptr = (float*)channels_out[1] + channels_off[1];

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -88,8 +88,8 @@ typedef struct
     void *synth;
     fluid_audio_func_t func;
     fluid_audio_channels_callback_t write_ptr;
-    float *lbuf;
-    float *rbuf;
+    float **drybuf;
+    float **efxbuf;
 
     HWAVEOUT hWaveOut;
     WAVEHDR  waveHeader[NB_SOUND_BUFFERS];
@@ -387,13 +387,26 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t f
 
     if(func)
     {
-        dev->lbuf = FLUID_ARRAY(float, periods * period_size);
-        dev->rbuf = FLUID_ARRAY(float, periods * period_size);
-        if (dev->lbuf == NULL || dev->rbuf == NULL)
+        dev->drybuf = FLUID_ARRAY(float*, audio_channels * 2);
+        dev->efxbuf = FLUID_ARRAY(float*, audio_channels * 2);
+        if(dev->drybuf == NULL || dev->efxbuf == NULL)
         {
             FLUID_LOG(FLUID_ERR, "Out of memory");
             delete_fluid_waveout_audio_driver(&dev->driver);
             return NULL;
+        }
+        FLUID_MEMSET(dev->drybuf, 0, sizeof(float*) * audio_channels * 2);
+        FLUID_MEMSET(dev->efxbuf, 0, sizeof(float*) * audio_channels * 2);
+        for(i = 0; i < audio_channels * 2; ++i)
+        {
+            dev->drybuf[i] = FLUID_ARRAY(float, periods * period_size);
+            dev->efxbuf[i] = FLUID_ARRAY(float, periods * period_size);
+            if(dev->drybuf[i] == NULL || dev->efxbuf[i] == NULL)
+            {
+                FLUID_LOG(FLUID_ERR, "Out of memory");
+                delete_fluid_waveout_audio_driver(&dev->driver);
+                return NULL;
+            }
         }
     }
 
@@ -513,6 +526,8 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t f
 
 void delete_fluid_waveout_audio_driver(fluid_audio_driver_t *d)
 {
+    int i;
+
     fluid_waveout_audio_driver_t *dev = (fluid_waveout_audio_driver_t *) d;
     fluid_return_if_fail(dev != NULL);
 
@@ -538,8 +553,17 @@ void delete_fluid_waveout_audio_driver(fluid_audio_driver_t *d)
         CloseHandle(dev->hQuit);
     }
 
-    FLUID_FREE(dev->lbuf);
-    FLUID_FREE(dev->rbuf);
+    if(dev->func)
+    {
+        for(i = 0; i < dev->channels_count; ++i)
+        {
+            FLUID_FREE(dev->drybuf[i]);
+            FLUID_FREE(dev->efxbuf[i]);
+        }
+    }
+
+    FLUID_FREE(dev->drybuf);
+    FLUID_FREE(dev->efxbuf);
 
     HeapFree(GetProcessHeap(), 0, dev);
 }
@@ -549,23 +573,24 @@ static int fluid_waveout_write_processed_channels(fluid_synth_t *data, int len,
                                void *channels_out[], int channels_off[],
                                int channels_incr[])
 {
-    int i;
+    int i, ch;
     int ret;
     fluid_waveout_audio_driver_t *drv = (fluid_waveout_audio_driver_t*) data;
-    float *out[2] = {drv->lbuf, drv->rbuf};
-    float *lptr;
-    float *rptr;
-    FLUID_MEMSET(drv->lbuf, 0, len * sizeof(float));
-    FLUID_MEMSET(drv->rbuf, 0, len * sizeof(float));
-    ret = drv->func(drv->synth, len, 0, NULL, 2, out);
-    lptr = (float*)channels_out[0] + channels_off[0];
-    rptr = (float*)channels_out[1] + channels_off[1];
-    for (i = 0; i < len; ++i)
+    float *optr[WAVEOUT_MAX_STEREO_CHANNELS * 2];
+    for(ch = 0; ch < drv->channels_count; ++ch)
     {
-        *lptr = drv->lbuf[i];
-        *rptr = drv->rbuf[i];
-        lptr += channels_incr[0];
-        rptr += channels_incr[1];
+        FLUID_MEMSET(drv->drybuf[ch], 0, len * sizeof(float));
+        FLUID_MEMSET(drv->efxbuf[ch], 0, len * sizeof(float));
+        optr[ch] = (float*)channels_out[ch] + channels_off[ch];
+    }
+    ret = drv->func(drv->synth, len, drv->channels_count, drv->efxbuf, drv->channels_count, drv->drybuf);
+    for(ch = 0; ch < drv->channels_count; ++ch)
+    {
+        for(i = 0; i < len; ++i)
+        {
+            *optr[ch] = drv->drybuf[ch][i] + drv->efxbuf[ch][i];
+            optr[ch] += channels_incr[ch];
+        }
     }
     return ret;
 }

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -49,6 +49,10 @@
 #define WAVEOUT_MAX_STEREO_CHANNELS 4
 
 static char *fluid_waveout_error(MMRESULT hr);
+static int fluid_waveout_write_processed_channels(fluid_synth_t *data, int len,
+                               int channels_count,
+                               void *channels_out[], int channels_off[],
+                               int channels_incr[]);
 
 /* speakers mapping */
 const static DWORD channel_mask_speakers[WAVEOUT_MAX_STEREO_CHANNELS] =
@@ -81,8 +85,11 @@ typedef struct
 {
     fluid_audio_driver_t driver;
 
-    fluid_synth_t *synth;
+    void *synth;
+    fluid_audio_func_t func;
     fluid_audio_channels_callback_t write_ptr;
+    float *lbuf;
+    float *rbuf;
 
     HWAVEOUT hWaveOut;
     WAVEHDR  waveHeader[NB_SOUND_BUFFERS];
@@ -191,7 +198,7 @@ static DWORD WINAPI fluid_waveout_synth_thread(void *data)
                 }
                 while(i);
 
-                dev->write_ptr(dev->synth, dev->num_frames, dev->channels_count,
+                dev->write_ptr(dev->func ? (fluid_synth_t*)dev : dev->synth, dev->num_frames, dev->channels_count,
                                channels_out, channels_off, channels_incr);
 
                 waveOutWrite((HWAVEOUT)msg.wParam, pWave, sizeof(WAVEHDR));
@@ -260,10 +267,18 @@ void fluid_waveout_audio_driver_settings(fluid_settings_t *settings)
 fluid_audio_driver_t *
 new_fluid_waveout_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 {
+    return new_fluid_waveout_audio_driver2(settings, NULL, synth);
+}
+
+fluid_audio_driver_t *
+new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
+{
     fluid_waveout_audio_driver_t *dev = NULL;
     fluid_audio_channels_callback_t write_ptr;
     double sample_rate;
     int frequency, sample_size;
+    int periods, period_size;
+    int audio_channels;
     LPSTR ptrBuffer;
     int lenBuffer;
     int device;
@@ -274,18 +289,21 @@ new_fluid_waveout_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 
     /* Retrieve the settings */
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
+    fluid_settings_getint(settings, "audio.periods", &periods);
+    fluid_settings_getint(settings, "audio.period-size", &period_size);
+    fluid_settings_getint(settings, "synth.audio-channels", &audio_channels);
 
     /* Clear format structure */
     ZeroMemory(&wfx, sizeof(WAVEFORMATEXTENSIBLE));
 
     /* check the format */
-    if(fluid_settings_str_equal(settings, "audio.sample-format", "float"))
+    if(fluid_settings_str_equal(settings, "audio.sample-format", "float") || func)
     {
         GUID guid_float = {DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_IEEE_FLOAT)};
         FLUID_LOG(FLUID_DBG, "Selected 32 bit sample format");
 
         sample_size = sizeof(float);
-        write_ptr = fluid_synth_write_float_channels;
+        write_ptr = func ? fluid_waveout_write_processed_channels : fluid_synth_write_float_channels;
         wfx.SubFormat = guid_float;
         wfx.Format.wFormatTag = WAVE_FORMAT_IEEE_FLOAT;
     }
@@ -309,9 +327,9 @@ new_fluid_waveout_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
     frequency = (int)sample_rate;
 
     /* Initialize the format structure */
-    wfx.Format.nChannels  = synth->audio_channels * 2;
+    wfx.Format.nChannels  = audio_channels * 2;
 
-    if(synth->audio_channels > WAVEOUT_MAX_STEREO_CHANNELS)
+    if(audio_channels > WAVEOUT_MAX_STEREO_CHANNELS)
     {
         FLUID_LOG(FLUID_ERR, "Channels number %d exceed internal limit %d",
                   wfx.Format.nChannels, WAVEOUT_MAX_STEREO_CHANNELS * 2);
@@ -335,7 +353,7 @@ new_fluid_waveout_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
         wfx.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
         wfx.Format.cbSize = 22;
         wfx.Samples.wValidBitsPerSample = wfx.Format.wBitsPerSample;
-        wfx.dwChannelMask = channel_mask_speakers[synth->audio_channels - 1];
+        wfx.dwChannelMask = channel_mask_speakers[audio_channels - 1];
     }
 
     /* Calculate the length of a single buffer */
@@ -353,7 +371,8 @@ new_fluid_waveout_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
     }
 
     /* Save copy of synth */
-    dev->synth = synth;
+    dev->synth = data;
+    dev->func = func;
 
     /* Save copy of other variables */
     dev->write_ptr = write_ptr;
@@ -365,6 +384,23 @@ new_fluid_waveout_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
 
     /* Set default device to use */
     device = WAVE_MAPPER;
+
+    if(func)
+    {
+        dev->lbuf = FLUID_ARRAY(float, periods * period_size);
+        dev->rbuf = FLUID_ARRAY(float, periods * period_size);
+        if (dev->lbuf == NULL || dev->rbuf == NULL)
+        {
+            FLUID_LOG(FLUID_ERR, "Out of memory");
+            delete_fluid_waveout_audio_driver(&dev->driver);
+            return NULL;
+        }
+    }
+    else
+    {
+        dev->lbuf = NULL;
+        dev->rbuf = NULL;
+    }
 
     /* get the selected device name. if none is specified, use default device. */
     if(fluid_settings_copystr(settings, "audio.waveout.device", dev_name, MAXPNAMELEN) == FLUID_OK
@@ -507,7 +543,43 @@ void delete_fluid_waveout_audio_driver(fluid_audio_driver_t *d)
         CloseHandle(dev->hQuit);
     }
 
+    if(dev->lbuf != NULL)
+    {
+        FLUID_FREE(dev->lbuf);
+    }
+
+    if(dev->rbuf != NULL)
+    {
+        FLUID_FREE(dev->rbuf);
+    }
+
     HeapFree(GetProcessHeap(), 0, dev);
+}
+
+static int fluid_waveout_write_processed_channels(fluid_synth_t *data, int len,
+                               int channels_count,
+                               void *channels_out[], int channels_off[],
+                               int channels_incr[])
+{
+    int i;
+    int ret;
+    fluid_waveout_audio_driver_t *drv = (fluid_waveout_audio_driver_t*) data;
+    float *out[2] = {drv->lbuf, drv->rbuf};
+    float *lptr;
+    float *rptr;
+    memset(drv->lbuf, 0, len * sizeof(float));
+    memset(drv->rbuf, 0, len * sizeof(float));
+    ret = drv->func(drv->synth, len, 0, NULL, 2, out);
+    lptr = (float*)channels_out[0] + channels_off[0];
+    rptr = (float*)channels_out[1] + channels_off[1];
+    for (i = 0; i < len; ++i)
+    {
+        *lptr = drv->lbuf[i];
+        *rptr = drv->rbuf[i];
+        lptr += channels_incr[0];
+        rptr += channels_incr[1];
+    }
+    return ret;
 }
 
 static char *fluid_waveout_error(MMRESULT hr)


### PR DESCRIPTION
This patch is largely based around the ideas in fluid_pulse.c: no fx buffers for the callback, `new_fluid_audio_driver` becomes a call to `new_fluid_audio_driver2`, etc.

I haven't done win32 programming for years... so there could be hidden issues in these patches. Tested on Wine (64-bit wine prefix), Windows 7 and Windows 10 VMs, plus an old Windows 7 box, all using a mingw build (x86_64-w64-mingw32).