### PR TITLE
Fix chorus not being rendered when an audio processing callback is used.

### DIFF
--- a/src/rvoice/fluid_chorus.c
+++ b/src/rvoice/fluid_chorus.c
@@ -980,13 +980,13 @@ void fluid_chorus_processmix(fluid_chorus_t *chorus, const fluid_real_t *in,
             d_out[1] +=  out ;
         }
 
+        /* Write the current input sample into the circular buffer */
+        push_in_delay_line(chorus, in[sample_index]);
+
         /* process stereo unit */
         /* Add the chorus stereo unit d_out to left and right output */
         left_out[sample_index]  += d_out[0] * chorus->wet1  + d_out[1] * chorus->wet2;
         right_out[sample_index] += d_out[1] * chorus->wet1  + d_out[0] * chorus->wet2;
-
-        /* Write the current input sample into the circular buffer */
-        push_in_delay_line(chorus, in[sample_index]);
     }
 }
 
@@ -1052,12 +1052,12 @@ void fluid_chorus_processreplace(fluid_chorus_t *chorus, const fluid_real_t *in,
             d_out[1] +=  out ;
         }
 
+        /* Write the current input sample into the circular buffer */
+        push_in_delay_line(chorus, in[sample_index]);
+
         /* process stereo unit */
         /* store the chorus stereo unit d_out to left and right output */
         left_out[sample_index]  = d_out[0] * chorus->wet1  + d_out[1] * chorus->wet2;
         right_out[sample_index] = d_out[1] * chorus->wet1  + d_out[0] * chorus->wet2;
-
-        /* Write the current input sample into the circular buffer */
-        push_in_delay_line(chorus, in[sample_index]);
     }
 }


### PR DESCRIPTION
in `fluid_rvoice_mixer.c`:`fluid_rvoice_mixer_process_fx()`:
```C
    // all dry unprocessed mono input is stored in the left channel
    fluid_real_t *in_rev = fluid_align_ptr(mixer->buffers.fx_left_buf, FLUID_DEFAULT_ALIGNMENT);
    fluid_real_t *in_ch = in_rev;

    fluid_profile_ref_var(prof_ref);


    if(mix_fx_to_out)
    {
        // mix effects to first stereo channel
        out_ch_l = out_rev_l = fluid_align_ptr(mixer->buffers.left_buf, FLUID_DEFAULT_ALIGNMENT);
        out_ch_r = out_rev_r = fluid_align_ptr(mixer->buffers.right_buf, FLUID_DEFAULT_ALIGNMENT);

        reverb_process_func = fluid_revmodel_processmix;
        chorus_process_func = fluid_chorus_processmix;

    }
    else
    {
        // replace effects into respective stereo effects channel
        out_ch_l = out_rev_l = fluid_align_ptr(mixer->buffers.fx_left_buf, FLUID_DEFAULT_ALIGNMENT);
        out_ch_r = out_rev_r = fluid_align_ptr(mixer->buffers.fx_right_buf, FLUID_DEFAULT_ALIGNMENT);

        reverb_process_func = fluid_revmodel_processreplace;
        chorus_process_func = fluid_chorus_processreplace;
    }
```

If an audio processing callback is used, `mix_fx_to_out` would be `FALSE`. As a result, `in_ch` and `out_ch_l` points to the same buffer.

in `fluid_chorus.c`:`fluid_chorus_processreplace()`:
```C
        /* process stereo unit */
        /* store the chorus stereo unit d_out to left and right output */
        left_out[sample_index]  = d_out[0] * chorus->wet1  + d_out[1] * chorus->wet2;
        right_out[sample_index] = d_out[1] * chorus->wet1  + d_out[0] * chorus->wet2;

        /* Write the current input sample into the circular buffer */
        push_in_delay_line(chorus, in[sample_index]);
```

Here the chorus processing code writes to the left output buffer (which will overwrite the input buffer in this case) before the sample from the input buffer is stored into the delay buffer, making the chorus output all zeros. If no audio processing callback is used, `mix_fx_to_out` would be `TRUE` and `in` and `left_out` will not point to the same buffer, therefore the order doesn't matter.

Simply swapping the two steps should be a sufficient fix. This patch also apply the same change to `fluid_chorus_processmix` only for the sake of consistency (since they are almost exact copies of each other).