### PR TITLE
Remove dead code from dsound and waveout drivers

### DIFF
--- a/src/drivers/fluid_dsound.c
+++ b/src/drivers/fluid_dsound.c
@@ -401,7 +401,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t fu
     }
 
     /* fill the buffer with silence */
-    memset(buf1, 0, bytes1);
+    FLUID_MEMSET(buf1, 0, bytes1);
 
     /* Unlock dsound buffer */
     IDirectSoundBuffer_Unlock(dev->sec_buffer, buf1, bytes1, 0, 0);
@@ -490,13 +490,16 @@ void delete_fluid_dsound_audio_driver(fluid_audio_driver_t *d)
         IDirectSound_Release(dev->direct_sound);
     }
 
-    for(i = 0; i < dev->channels_count; ++i)
+    if(dev->drybuf != NULL)
     {
-        FLUID_FREE(dev->drybuf[i]);
+        for(i = 0; i < dev->channels_count; ++i)
+        {
+            FLUID_FREE(dev->drybuf[i]);
+        }
+
+        FLUID_FREE(dev->drybuf);
     }
-
-    FLUID_FREE(dev->drybuf);
-
+    
     FLUID_FREE(dev);
 }
 

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -526,12 +526,15 @@ void delete_fluid_waveout_audio_driver(fluid_audio_driver_t *d)
         CloseHandle(dev->hQuit);
     }
 
-    for(i = 0; i < dev->channels_count; ++i)
+    if(dev->drybuf != NULL)
     {
-        FLUID_FREE(dev->drybuf[i]);
-    }
+        for(i = 0; i < dev->channels_count; ++i)
+        {
+            FLUID_FREE(dev->drybuf[i]);
+        }
 
-    FLUID_FREE(dev->drybuf);
+        FLUID_FREE(dev->drybuf);
+    }
 
     HeapFree(GetProcessHeap(), 0, dev);
 }

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -125,6 +125,25 @@ static void fluid_synth_stop_LOCAL(fluid_synth_t *synth, unsigned int id);
 
 static int fluid_synth_set_important_channels(fluid_synth_t *synth, const char *channels);
 
+static int
+fluid_synth_write_float_channels_LOCAL(fluid_synth_t *synth, int len,
+                                       int channels_count,
+                                       void *channels_out[], int channels_off[],
+                                       int channels_incr[],
+                                       int (*block_render_func)(fluid_synth_t *, int));
+
+static int
+fluid_synth_write_s16_channels(fluid_synth_t *synth, int len,
+                               int channels_count,
+                               void *channels_out[], int channels_off[],
+                               int channels_incr[]);
+
+static int
+fluid_synth_write_float_channels(fluid_synth_t *synth, int len,
+                                 int channels_count,
+                                 void *channels_out[], int channels_off[],
+                                 int channels_incr[]);
+
 
 /* Callback handlers for real-time settings */
 static void fluid_synth_handle_gain(void *data, const char *name, double value);

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -181,29 +181,6 @@ typedef int (*fluid_audio_callback_t)(fluid_synth_t *synth, int len,
                                       void *out1, int loff, int lincr,
                                       void *out2, int roff, int rincr);
 
-typedef int (*fluid_audio_channels_callback_t)(fluid_synth_t *synth, int len,
-                                               int channels_count,
-                                               void *channels_out[], int channels_off[],
-                                               int channels_incr[]);
-
-int
-fluid_synth_write_float_channels_LOCAL(fluid_synth_t *synth, int len,
-                                       int channels_count,
-                                       void *channels_out[], int channels_off[],
-                                       int channels_incr[],
-                                       int (*block_render_func)(fluid_synth_t *, int));
-
-int
-fluid_synth_write_s16_channels(fluid_synth_t *synth, int len,
-                               int channels_count,
-                               void *channels_out[], int channels_off[],
-                               int channels_incr[]);
-int
-fluid_synth_write_float_channels(fluid_synth_t *synth, int len,
-                                 int channels_count,
-                                 void *channels_out[], int channels_off[],
-                                 int channels_incr[]);
-
 fluid_preset_t *fluid_synth_find_preset(fluid_synth_t *synth,
                                         int banknum,
                                         int prognum);


### PR DESCRIPTION
Follow up for #745:

- remove dead code now that `callback` is never NULL
- fix a possible NULL deref in both drivers
- make sure fx are audible in the special case of `callback == fluid_synth_process`