### PR TITLE
Allow the MIDI file player restart on-demand

### DIFF
--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -544,7 +544,7 @@ fluid_sample_timer_t *new_fluid_sample_timer(fluid_synth_t *synth, fluid_timer_c
     }
 
     fluid_sample_timer_reset(synth, result);
-    result->isfinished = 0;
+//  result->isfinished = 0;
     result->data = data;
     result->callback = callback;
     result->next = synth->sample_timers;
@@ -576,6 +576,7 @@ void delete_fluid_sample_timer(fluid_synth_t *synth, fluid_sample_timer_t *timer
 void fluid_sample_timer_reset(fluid_synth_t *synth, fluid_sample_timer_t *timer)
 {
     timer->starttick = fluid_synth_get_ticks(synth);
+    timer->isfinished = 0;
 }
 
 /***************************************************************


### PR DESCRIPTION
Resets the default sample timer properly, allowing the internal
MIDI file player to restart its playlist on any other time but
the initial first.

Lets Qsynth play any MIDI files that are drag-n-dropped, anytime
after the first, following synth engine initialization.