### PR TITLE
Fixes waveout driver crash

### DIFF
--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -90,7 +90,6 @@ typedef struct
     HWAVEOUT hWaveOut;
     WAVEHDR  waveHeader[NB_SOUND_BUFFERS];
 
-    int sample_size;
     int periods; /* numbers of internal driver buffers */
     int num_frames;
 
@@ -379,7 +378,6 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t f
 
     /* Save copy of other variables */
     dev->write_ptr = write_ptr;
-    dev->sample_size = sample_size;
     /* number of frames in a buffer */
     dev->num_frames = period_size;
     /* number of buffers */

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -361,7 +361,9 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t f
         wfx.dwChannelMask = channel_mask_speakers[audio_channels - 1];
     }
 
-    /* length of a single buffer in bytes */
+    /* allocate the internal waveout buffers:
+      The length of a single buffer in bytes is dependant of period_size.
+    */
     lenBuffer = wfx.Format.nBlockAlign * period_size;
     /* create and clear the driver data */
     dev = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY,
@@ -389,6 +391,12 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t f
 
     if(func)
     {
+        /* allocate extra buffer used by fluid_waveout_write_processed_channels().
+           These buffers are buffer adaptation between the rendering
+           API fluid_synth_process() and the waveout internal buffers
+           Note: the size (in bytes) of these extra buffer (drybuf[]) must be the
+           same that the size of internal waveout buffers.
+        */
         dev->drybuf = FLUID_ARRAY(float*, audio_channels * 2);
         if(dev->drybuf == NULL)
         {
@@ -399,6 +407,7 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t f
         FLUID_MEMSET(dev->drybuf, 0, sizeof(float*) * audio_channels * 2);
         for(i = 0; i < audio_channels * 2; ++i)
         {
+            /* The length of a single buffer drybuf[i] is dependant of period_size */
             dev->drybuf[i] = FLUID_ARRAY(float, period_size);
             if(dev->drybuf[i] == NULL)
             {


### PR DESCRIPTION
This PR addresses issue https://github.com/FluidSynth/fluidsynth/issues/758.

It ensures that the `internal buffer size` used by waveout device driver and the `extra buffers size` required by fluid_synth_process() are both coherent (i.e they should be of same size). To ensure this, both kind of buffers are now dependent of`audio.period` and `audio.period-size settings`.