### PR TITLE
Fix player_seek command in user command file

### DIFF
--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -372,11 +372,11 @@ static const fluid_cmd_t fluid_commands[] =
     },
     {
         "player_stop", "player", fluid_handle_player_stop,
-        "player_stop                Stop playing"
+        "player_stop                Stop playing (cannot be executed in a user command file)"
     },
     {
         "player_cont", "player", fluid_handle_player_continue,
-        "player_cont                Continue playing"
+        "player_cont                Continue playing (cannot be executed in a user command file)"
     },
     {
         "player_step", "player", fluid_handle_player_step,
@@ -384,7 +384,7 @@ static const fluid_cmd_t fluid_commands[] =
     },
     {
         "player_next", "player", fluid_handle_player_next_song,
-        "player_next                Move to next song"
+        "player_next                Move to next song (cannot be executed in a user command file)"
     },
     {
         "player_loop", "player", fluid_handle_player_loop,

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -3525,7 +3525,7 @@ enum
 int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, int cmd)
 {
     FLUID_ENTRY_COMMAND(data);
-    int arg;
+    int arg, was_running;
     int seek = -1;  /* current seek position in tick */
 
     /* commands name table */
@@ -3556,7 +3556,11 @@ int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, 
         return FLUID_OK;
     }
 
-    fluid_player_stop(handler->player);  /* player_stop */
+    was_running = fluid_player_get_status(handler->player) == FLUID_PLAYER_PLAYING;
+    if(was_running)
+    {
+        fluid_player_stop(handler->player);  /* player_stop */
+    }
 
     if(cmd != PLAYER_STOP_CDE)
     {
@@ -3574,7 +3578,7 @@ int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, 
             {
                 seek = 0; /* minimum position */
             }
-            else if(arg < seek)
+            else if(!was_running || arg < seek)
             {
                 seek = arg; /* seek < maximum position */
             }
@@ -3586,7 +3590,10 @@ int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, 
         }
 
         fluid_player_seek(handler->player, seek);
-        fluid_player_play(handler->player);
+        if(was_running)
+        {
+            fluid_player_play(handler->player);
+        }
     }
     /* display position */
     player_print_position(handler->player, seek, out);

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -3521,7 +3521,9 @@ enum
     PLAYER_START_CDE      /* player_start   (Move to start of song) */
 };
 
-/* Command handler for player commands: player_seek, player_loop, player_tempo_bpm */
+/* Command handler: see player commands enum (above)
+ * @cmd player commands enumeration value.
+*/
 int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, int cmd)
 {
     FLUID_ENTRY_COMMAND(data);

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -379,8 +379,8 @@ static const fluid_cmd_t fluid_commands[] =
         "player_cont                Continue playing (cannot be executed in a user command file)"
     },
     {
-        "player_step", "player", fluid_handle_player_step,
-        "player_step num            Move forward/backward in current song to +/-num ticks"
+        "player_seek", "player", fluid_handle_player_seek,
+        "player_seek num            Move forward/backward in current song to +/-num ticks"
     },
     {
         "player_next", "player", fluid_handle_player_next_song,
@@ -3514,14 +3514,14 @@ void player_print_position(fluid_player_t *player, int current_tick, fluid_ostre
 enum
 {
     PLAYER_LOOP_CDE, /* player_loop num,(Set loop number to num) */
-    PLAYER_STEP_CDE, /* player_step num (Move forward/backward to +/-num ticks) */
+    PLAYER_SEEK_CDE, /* player_seek num (Move forward/backward to +/-num ticks) */
     PLAYER_STOP_CDE,      /* player_stop    (Stop playing) */
     PLAYER_CONT_CDE,      /* player_cont    (Continue playing) */
     PLAYER_NEXT_CDE,      /* player_next    (Move to next song) */
     PLAYER_START_CDE      /* player_start   (Move to start of song) */
 };
 
-/* Command handler for player commands: player_step, player_loop, player_tempo_bpm */
+/* Command handler for player commands: player_seek, player_loop, player_tempo_bpm */
 int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, int cmd)
 {
     FLUID_ENTRY_COMMAND(data);
@@ -3530,10 +3530,10 @@ int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, 
 
     /* commands name table */
     static const char *name_cde[] =
-    {"player_loop", "player_step"};
+    {"player_loop", "player_seek"};
 
-    /* get argument for PLAYER_LOOP_CDE, PLAYER_STEP_CDE */
-    if(cmd <= PLAYER_STEP_CDE)
+    /* get argument for PLAYER_LOOP_CDE, PLAYER_SEEK_CDE */
+    if(cmd <= PLAYER_SEEK_CDE)
     {
         /* check argument */
         if(player_check_arg(name_cde[cmd], ac, av, out) == FLUID_FAILED)
@@ -3564,11 +3564,11 @@ int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, 
 
     if(cmd != PLAYER_STOP_CDE)
     {
-        /* seek for player_next, player_step, player_start */
+        /* seek for player_next, player_seek, player_start */
         /* set seek to maximum position */
         seek = fluid_player_get_total_ticks(handler->player);
 
-        if(cmd == PLAYER_STEP_CDE)
+        if(cmd == PLAYER_SEEK_CDE)
         {
             /* Move position forward/backward +/- num ticks*/
             arg  += fluid_player_get_current_tick(handler->player);
@@ -3618,10 +3618,10 @@ int fluid_handle_player_continue(void *data, int ac, char **av, fluid_ostream_t 
 {
     return fluid_handle_player_cde(data, ac, av, out, PLAYER_CONT_CDE);
 }
-/* Command handler for "player_step" command */
-int fluid_handle_player_step(void *data, int ac, char **av, fluid_ostream_t out)
+/* Command handler for "player_seek" command */
+int fluid_handle_player_seek(void *data, int ac, char **av, fluid_ostream_t out)
 {
-    return fluid_handle_player_cde(data, ac, av, out, PLAYER_STEP_CDE);
+    return fluid_handle_player_cde(data, ac, av, out, PLAYER_SEEK_CDE);
 }
 
 /* Command handler for "player_next" command */

--- a/src/bindings/fluid_cmd.h
+++ b/src/bindings/fluid_cmd.h
@@ -88,7 +88,7 @@ int fluid_handle_player_start(void *data, int ac, char **av, fluid_ostream_t out
 int fluid_handle_player_stop(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_player_continue(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_player_next_song(void *data, int ac, char **av, fluid_ostream_t out);
-int fluid_handle_player_step(void *data, int ac, char **av, fluid_ostream_t out);
+int fluid_handle_player_seek(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_player_loop(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_player_tempo_bpm(void *data, int ac, char **av, fluid_ostream_t out);
 int fluid_handle_player_tempo_int(void *data, int ac, char **av, fluid_ostream_t out);

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2199,7 +2199,7 @@ fluid_player_get_status(fluid_player_t *player)
  */
 int fluid_player_seek(fluid_player_t *player, int ticks)
 {
-    if(ticks < 0 || ticks > fluid_player_get_total_ticks(player))
+    if(ticks < 0 || (fluid_player_get_status(player) != FLUID_PLAYER_READY && ticks > fluid_player_get_total_ticks(player)))
     {
         return FLUID_FAILED;
     }

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2065,7 +2065,7 @@ fluid_player_callback(void *data, unsigned int msec)
 
     loadnextfile = player->currentfile == NULL ? 1 : 0;
 
-    if(fluid_player_get_status(player) == FLUID_PLAYER_DONE)
+    if(fluid_player_get_status(player) != FLUID_PLAYER_PLAYING)
     {
         fluid_synth_all_notes_off(synth, -1);
         return 1;


### PR DESCRIPTION
@jjceresa I was more thinking of a solution like that, to fix the `player_step`. I can't think of a use-case to support `player_next` in the command file. Because if the user wanted to skip the first `n` files, he could have just left them out on the commandline in the first place.

P.S.: I would vote to rename `player_step` to `player_seek` to be more consistent with the API.

Addresses #757.
Resolves #763.