### PR TITLE
Add Chris' soundcard enumeration tool

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -379,7 +379,6 @@ if ( WASAPI_SUPPORT )
   set ( fluidsynth_SOURCES ${fluidsynth_SOURCES} fluid_wasapi_device_enumerate.c )
 endif ( WASAPI_SUPPORT )
 
-
 add_executable ( fluidsynth
     ${fluidsynth_SOURCES}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -375,6 +375,11 @@ target_link_libraries ( libfluidsynth
 
 set ( fluidsynth_SOURCES fluidsynth.c )
 
+if ( WASAPI_SUPPORT )
+  set ( fluidsynth_SOURCES ${fluidsynth_SOURCES} fluid_wasapi_device_enumerate.c )
+endif ( WASAPI_SUPPORT )
+
+
 add_executable ( fluidsynth
     ${fluidsynth_SOURCES}
 )

--- a/src/fluid_wasapi_device_enumerate.c
+++ b/src/fluid_wasapi_device_enumerate.c
@@ -1,3 +1,22 @@
+/* FluidSynth - A Software Synthesizer
+ *
+ * Copyright (C) 2021  Chris Xiong and others.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ */
 
 #include "fluid_sys.h"
 #include <assert.h>

--- a/src/fluid_wasapi_device_enumerate.c
+++ b/src/fluid_wasapi_device_enumerate.c
@@ -3,10 +3,7 @@
 #include <assert.h>
 
 static char **devs;
-static int devcnt;
 static int flag;
-static const int sample_rates[] = {8000, 11025, 16000, 22050, 24000, 32000, 44100, 48000, 88200, 96000, 0};
-static const char *sample_formats[3] = {"16bits", "float", "\0"};
 
 static void devenumcb(void *p, const char *s, const char *opt)
 {
@@ -24,6 +21,10 @@ static void eatlog(int lvl,const char *m, void* d)
 
 void fluid_wasapi_device_enumerate(void)
 {
+    static const int sample_rates[] = {8000, 11025, 16000, 22050, 24000, 32000, 44100, 48000, 88200, 96000, 0};
+    static const char *sample_formats[3] = {"16bits", "float", "\0"};
+
+    int e, d, s, f, i, devcnt;
     fluid_synth_t *synth;
     fluid_audio_driver_t *adriver;
     fluid_settings_t *settings = new_fluid_settings();
@@ -41,20 +42,20 @@ void fluid_wasapi_device_enumerate(void)
 
 	assert(devcnt == fluid_settings_option_count(settings, "audio.wasapi.device"));
 	puts("");
-	for (int e = 0; e < 2; ++e)
+	for (e = 0; e < 2; ++e)
 	{
 		puts(e ? "Exclusive mode:" : "Shared mode:");
 		fluid_settings_setint(settings, "audio.wasapi.exclusive-mode", e);
-		for (int d = 0; d < devcnt; ++d)
+		for (d = 0; d < devcnt; ++d)
 		{
 			printf("\t%s\n", devs[d]);
 			fluid_settings_setstr(settings, "audio.wasapi.device", devs[d]);
-			for (int s = 0; sample_rates[s]; ++s)
+			for (s = 0; sample_rates[s]; ++s)
 			{
 				fluid_settings_setnum(settings, "synth.sample-rate", sample_rates[s]);
-				for (int f = 0; sample_formats[f][0]; ++f)
+				for (f = 0; sample_formats[f][0]; ++f)
 				{
-					int n, supported;
+					int n, supported, c;
 					fluid_settings_setstr(settings, "audio.sample-format", sample_formats[f]);
 					flag = 0;
 					synth = new_fluid_synth(settings);
@@ -63,7 +64,7 @@ void fluid_wasapi_device_enumerate(void)
                     delete_fluid_audio_driver(adriver);
 					delete_fluid_synth(synth);
 					n = printf("\t  %dHz, %s ", sample_rates[s], sample_formats[f]);
-					for (int c = 50 - n; c; --c)
+					for (c = 50 - n; c; --c)
 					{
 						putchar('.');
 					}
@@ -79,7 +80,7 @@ void fluid_wasapi_device_enumerate(void)
     puts("FAILED: Mode is not supported.");
 
 	delete_fluid_settings(settings);
-	for (int i = 0; i < devcnt; ++i)
+	for (i = 0; i < devcnt; ++i)
 	{
 		free(devs[i]);
 	}

--- a/src/fluid_wasapi_device_enumerate.c
+++ b/src/fluid_wasapi_device_enumerate.c
@@ -1,0 +1,87 @@
+
+#include "fluid_sys.h"
+#include <assert.h>
+
+static char **devs;
+static int devcnt;
+static int flag;
+static const int sample_rates[] = {8000, 11025, 16000, 22050, 24000, 32000, 44100, 48000, 88200, 96000, 0};
+static const char *sample_formats[3] = {"16bits", "float", "\0"};
+
+static void devenumcb(void *p, const char *s, const char *opt)
+{
+	int *c = (int*) p;
+	printf(" %s\n", opt);
+	devs[*c] = malloc(strlen(opt) + 1);
+	strcpy(devs[*c], opt);
+	++ *c;
+}
+
+static void eatlog(int lvl,const char *m, void* d)
+{
+	flag = lvl;
+}
+
+void fluid_wasapi_device_enumerate(void)
+{
+    fluid_synth_t *synth;
+    fluid_audio_driver_t *adriver;
+    fluid_settings_t *settings = new_fluid_settings();
+	fluid_settings_setstr(settings, "audio.driver", "wasapi");
+	devcnt = fluid_settings_option_count(settings, "audio.wasapi.device");
+	devs = calloc(devcnt, sizeof(char*));
+
+	puts("Available audio devices:");
+	devcnt = 0;
+	fluid_settings_foreach_option(settings, "audio.wasapi.device", &devcnt, devenumcb);
+
+	fluid_set_log_function(FLUID_INFO, eatlog, NULL);
+	fluid_set_log_function(FLUID_WARN, eatlog, NULL);
+	fluid_set_log_function(FLUID_ERR, eatlog, NULL);
+
+	assert(devcnt == fluid_settings_option_count(settings, "audio.wasapi.device"));
+	puts("");
+	for (int e = 0; e < 2; ++e)
+	{
+		puts(e ? "Exclusive mode:" : "Shared mode:");
+		fluid_settings_setint(settings, "audio.wasapi.exclusive-mode", e);
+		for (int d = 0; d < devcnt; ++d)
+		{
+			printf("\t%s\n", devs[d]);
+			fluid_settings_setstr(settings, "audio.wasapi.device", devs[d]);
+			for (int s = 0; sample_rates[s]; ++s)
+			{
+				fluid_settings_setnum(settings, "synth.sample-rate", sample_rates[s]);
+				for (int f = 0; sample_formats[f][0]; ++f)
+				{
+					int n, supported;
+					fluid_settings_setstr(settings, "audio.sample-format", sample_formats[f]);
+					flag = 0;
+					synth = new_fluid_synth(settings);
+					adriver = new_fluid_audio_driver(settings,synth);
+                    supported = adriver != NULL;
+                    delete_fluid_audio_driver(adriver);
+					delete_fluid_synth(synth);
+					n = printf("\t  %dHz, %s ", sample_rates[s], sample_formats[f]);
+					for (int c = 50 - n; c; --c)
+					{
+						putchar('.');
+					}
+					printf(" %s%s\n", supported ? "OK" : "FAILED", flag == FLUID_WARN ? "(W)" : flag == FLUID_INFO ? "(I)" : "\0");
+				}
+			}
+			puts("");
+		}
+	}
+    
+    puts("OK    : Mode is natively supported by the audio device.");
+    puts("OK(I) : Mode is supported, but resampling may occur deep within WASAPI to satisfy device's needs.");
+    puts("FAILED: Mode is not supported.");
+
+	delete_fluid_settings(settings);
+	for (int i = 0; i < devcnt; ++i)
+	{
+		free(devs[i]);
+	}
+	free(devs);
+}

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -46,6 +46,7 @@ void print_usage(void);
 void print_help(fluid_settings_t *settings);
 void print_welcome(void);
 void print_configure(void);
+void fluid_wasapi_device_enumerate(void);
 
 /*
  * the globals
@@ -407,6 +408,7 @@ int main(int argc, char **argv)
             {"no-shell", 0, 0, 'i'},
             {"option", 1, 0, 'o'},
             {"portname", 1, 0, 'p'},
+            {"query-audio-devices", 0, 0, 'D'},
             {"quiet", 0, 0, 'q'},
             {"reverb", 1, 0, 'R'},
             {"sample-rate", 1, 0, 'r'},
@@ -518,6 +520,17 @@ int main(int argc, char **argv)
                 goto cleanup;
             }
             break;
+
+        case 'D':
+            print_welcome();
+#ifdef WASAPI_SUPPORT
+            fluid_wasapi_device_enumerate();
+            result = 0;
+#else
+            fprintf(stderr, "Error: This version of fluidsynth was compiled without WASAPI support. Audio device enumeration is not available.");
+            result = 1;
+#endif
+            goto cleanup;
 
         case 'd':
             dump = 1;
@@ -1184,6 +1197,10 @@ print_help(fluid_settings_t *settings)
            "    Number of audio buffers\n");
     printf(" -C, --chorus\n"
            "    Turn the chorus on or off [0|1|yes|no, default = on]\n");
+#ifdef WASAPI_SUPPORT
+    printf(" -D, --query-audio-devices\n"
+           "    Probe all available soundcards for supported modes, sample-rates and sample-formats.\n");
+#endif
     printf(" -d, --dump\n"
            "    Dump incoming and outgoing MIDI events to stdout\n");
     printf(" -E, --audio-file-endian\n"


### PR DESCRIPTION
The fluidsynth executable now supports querying for supported sample-rates and sample-formats via the ` -D, --query-audio-devices` commandline options.

The tool itself relies on eating the log levels the WASAPI driver gave out. This is a bit suboptimal, but for now I think it's good enough. Alternatively one would have to place all the code in `fluid_wasapi.c` itself, which is also questionable and much more effort.

I'm open to a better naming of the option.

Resolves #761.