### PR TITLE
wait for seek position if a seek is in progress

### DIFF
--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2419,10 +2419,24 @@ fluid_player_join(fluid_player_t *player)
  * Get the number of tempo ticks passed.
  * @param player MIDI player instance
  * @return The number of tempo ticks passed
+ * Note: if a seek is in progress, the function waits for the seek position
+ *       before returning.
  * @since 1.1.7
  */
 int fluid_player_get_current_tick(fluid_player_t *player)
 {
+    int time_out = 0;
+
+    /* wait a limited time (500 ms max) if a seek is in progress */
+    while(fluid_atomic_int_get(&player->seek_ticks) != -1)
+    {
+        fluid_msleep(10);
+        if(++time_out == 50) /* stop waiting if timeout (500 ms) is reached */
+        {
+            break;
+        }
+    }
+
     return player->cur_ticks;
 }
 

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2426,9 +2426,9 @@ fluid_player_join(fluid_player_t *player)
 int fluid_player_get_current_tick(fluid_player_t *player)
 {
     int time_out = 0;
-
     /* wait a limited time (500 ms max) if a seek is in progress */
-    while(fluid_atomic_int_get(&player->seek_ticks) != -1)
+    while((fluid_atomic_int_get(&player->seek_ticks) != -1)
+           && (fluid_player_get_status(player) == FLUID_PLAYER_PLAYING))
     {
         fluid_msleep(10);
         if(++time_out == 50) /* stop waiting if timeout (500 ms) is reached */
@@ -2436,7 +2436,6 @@ int fluid_player_get_current_tick(fluid_player_t *player)
             break;
         }
     }
-
     return player->cur_ticks;
 }
 


### PR DESCRIPTION
When `fluid_player_get_current_tick()` is called immediately after fluid_player_seek(), the position returned by fluid_player_get_current_tick() is the `position` before calling fluid_player_seek().
This PR makes fluid_player_get_current_tick() the opportunity to return the new `seek position`.