### PR TITLE
Add optional per tick callback to player

### DIFF
--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -64,6 +64,32 @@ typedef int (*handle_midi_event_func_t)(void *data, fluid_midi_event_t *event);
  * @param data User defined data pointer
  * @param tick The current (zero-based) tick, which triggered the callback
  * @return Should return #FLUID_OK on success, #FLUID_FAILED otherwise
+ *
+ * This callback is fired at a constant rate depending on the current BPM and PPQ.
+ * e.g. for PPQ = 192 and BPM = 140 the callback is fired 192 * 140 times per minute (448/sec).
+ *
+ * It can be used to sync external elements with the beat,
+ * or stop / loop the song on a given tick.
+ * Ticks being BPM-dependent, you can manipulate values such as bars or beats,
+ * without having to care about BPM.
+ *
+ * For example, this callback loops the song whenever it reaches the 5th bar :
+ *
+ * int handle_tick_event(void *data, int tick)
+ * {
+ *      fluid_player_t *player = (fluid_player_t *)data;
+ *      int ppq = 192; // From MIDI header
+ *      int beatsPerBar = 4; // From the song's time signature
+ *      int loopBar = 5;
+ *      int loopTick = (loopBar - 1) * ppq * beatsPerBar;
+ *
+ *      if (tick == loopTick)
+ *      {
+ *	        return fluid_player_seek(player, 0);
+ *	}
+ *
+ *	return FLUID_OK;
+ * }
  */
 typedef int (*handle_midi_tick_func_t)(void *data, int tick);
 

--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -75,7 +75,7 @@ typedef int (*handle_midi_event_func_t)(void *data, fluid_midi_event_t *event);
  *
  * For example, this callback loops the song whenever it reaches the 5th bar :
  *
- * int handle_tick_event(void *data, int tick)
+ * int handle_tick(void *data, int tick)
  * {
  *      fluid_player_t *player = (fluid_player_t *)data;
  *      int ppq = 192; // From MIDI header
@@ -85,10 +85,10 @@ typedef int (*handle_midi_event_func_t)(void *data, fluid_midi_event_t *event);
  *
  *      if (tick == loopTick)
  *      {
- *	        return fluid_player_seek(player, 0);
- *	}
+ *              return fluid_player_seek(player, 0);
+ *      }
  *
- *	return FLUID_OK;
+ *      return FLUID_OK;
  * }
  */
 typedef int (*handle_midi_tick_func_t)(void *data, int tick);

--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -72,24 +72,6 @@ typedef int (*handle_midi_event_func_t)(void *data, fluid_midi_event_t *event);
  * or stop / loop the song on a given tick.
  * Ticks being BPM-dependent, you can manipulate values such as bars or beats,
  * without having to care about BPM.
- *
- * For example, this callback loops the song whenever it reaches the 5th bar :
- *
- * int handle_tick(void *data, int tick)
- * {
- *      fluid_player_t *player = (fluid_player_t *)data;
- *      int ppq = 192; // From MIDI header
- *      int beatsPerBar = 4; // From the song's time signature
- *      int loopBar = 5;
- *      int loopTick = (loopBar - 1) * ppq * beatsPerBar;
- *
- *      if (tick == loopTick)
- *      {
- *              return fluid_player_seek(player, 0);
- *      }
- *
- *      return FLUID_OK;
- * }
  */
 typedef int (*handle_midi_tick_func_t)(void *data, int tick);
 

--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -56,7 +56,6 @@ extern "C" {
  * a \ref sequencer via fluid_sequencer_add_midi_event_to_buffer().
  */
 typedef int (*handle_midi_event_func_t)(void *data, fluid_midi_event_t *event);
-/* @} */
 
 /**
  * Generic callback function fired once by MIDI tick change.
@@ -94,6 +93,7 @@ int handle_tick(void *data, int tick)
  * @endcode
  */
 typedef int (*handle_midi_tick_func_t)(void *data, int tick);
+/* @} */
 
 /**
  * @defgroup midi_events MIDI Events

--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -59,6 +59,15 @@ typedef int (*handle_midi_event_func_t)(void *data, fluid_midi_event_t *event);
 /* @} */
 
 /**
+ * Generic callback function fired once by MIDI tick change.
+ *
+ * @param data User defined data pointer
+ * @param tick The current (zero-based) tick, which triggered the callback
+ * @return Should return #FLUID_OK on success, #FLUID_FAILED otherwise
+ */
+typedef int (*handle_midi_tick_func_t)(void *data, int tick);
+
+/**
  * @defgroup midi_events MIDI Events
  * @ingroup midi_input
  *
@@ -239,6 +248,7 @@ FLUIDSYNTH_API int fluid_player_set_tempo(fluid_player_t *player, int tempo_type
 FLUID_DEPRECATED FLUIDSYNTH_API int fluid_player_set_midi_tempo(fluid_player_t *player, int tempo);
 FLUID_DEPRECATED FLUIDSYNTH_API int fluid_player_set_bpm(fluid_player_t *player, int bpm);
 FLUIDSYNTH_API int fluid_player_set_playback_callback(fluid_player_t *player, handle_midi_event_func_t handler, void *handler_data);
+FLUIDSYNTH_API int fluid_player_set_tick_callback(fluid_player_t *player, handle_midi_tick_func_t handler, void *handler_data);
 
 FLUIDSYNTH_API int fluid_player_get_status(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_get_current_tick(fluid_player_t *player);

--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -72,6 +72,26 @@ typedef int (*handle_midi_event_func_t)(void *data, fluid_midi_event_t *event);
  * or stop / loop the song on a given tick.
  * Ticks being BPM-dependent, you can manipulate values such as bars or beats,
  * without having to care about BPM.
+ *
+ * For example, this callback loops the song whenever it reaches the 5th bar :
+ *
+ * @code{.cpp}
+int handle_tick(void *data, int tick)
+{
+    fluid_player_t *player = (fluid_player_t *)data;
+    int ppq = 192; // From MIDI header
+    int beatsPerBar = 4; // From the song's time signature
+    int loopBar = 5;
+    int loopTick = (loopBar - 1) * ppq * beatsPerBar;
+
+    if (tick == loopTick)
+    {
+        return fluid_player_seek(player, 0);
+    }
+
+    return FLUID_OK;
+}
+ * @endcode
  */
 typedef int (*handle_midi_tick_func_t)(void *data, int tick);
 

--- a/src/midi/fluid_midi.h
+++ b/src/midi/fluid_midi.h
@@ -297,6 +297,7 @@ struct _fluid_player_t
     fluid_atomic_int_t seek_ticks; /* new position in tempo ticks (midi ticks) for seeking */
     int start_ticks;          /* the number of tempo ticks passed at the last tempo change */
     int cur_ticks;            /* the number of tempo ticks passed */
+    int last_callback_ticks;  /* the last tick number that was passed to player->tick_callback */
     int begin_msec;           /* the time (msec) of the beginning of the file */
     int start_msec;           /* the start time of the last tempo change */
     int cur_msec;             /* the current time */
@@ -318,6 +319,8 @@ struct _fluid_player_t
 
     handle_midi_event_func_t playback_callback; /* function fired on each midi event as it is played */
     void *playback_userdata; /* pointer to user-defined data passed to playback_callback function */
+    handle_midi_tick_func_t tick_callback; /* function fired on each tick change */
+    void *tick_userdata; /* pointer to user-defined data passed to tick_callback function */
 };
 
 void fluid_player_settings(fluid_settings_t *settings);


### PR DESCRIPTION
This pull request introduces an optional per-tick callback for the midi player. It solves the problem described in #777.

From a user point of view, it adds the `fluid_player_set_tick_callback()` function, that works in a very similar way than `fluid_player_set_playback_callback()`. 

The callback is then invoked from `fluid_player_callback()` every time `player->cur_ticks` changes.