### PR TITLE
Improvements to LADSPA subsystem

### DIFF
--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -244,6 +244,7 @@ void delete_fluid_ladspa_fx(fluid_ladspa_fx_t *fx)
         node = (fluid_ladspa_node_t *) fluid_list_get(list);
         delete_fluid_ladspa_node(node);
     }
+    delete_fluid_list(fx->host_nodes);
 
     if(fx->run_finished_cond != NULL)
     {


### PR DESCRIPTION
This PR fixes #793 by removing the static limit on the number of nodes and effects by using dynamic allocation / linked lists instead. It also contains some cleanup work to make the LADSPA code (hopefully) easier to understand.

I've tested it locally and it seems to work as intended.