### PR TITLE
Rename generated table files from .c to .inc.h

### DIFF
--- a/src/gentables/make_tables.c
+++ b/src/gentables/make_tables.c
@@ -72,11 +72,11 @@ int main (int argc, char *argv[])
     if (argc < 2)
         return -1;
     
-    open_table(&fp, argv[1], "fluid_conv_tables.c");
+    open_table(&fp, argv[1], "fluid_conv_tables.inc.h");
     gen_conv_table(fp);
     fclose(fp);
 
-    open_table(&fp, argv[1], "fluid_rvoice_dsp_tables.c");
+    open_table(&fp, argv[1], "fluid_rvoice_dsp_tables.inc.h");
     gen_rvoice_table_dsp(fp);
     fclose(fp);
 

--- a/src/rvoice/fluid_rvoice_dsp.c
+++ b/src/rvoice/fluid_rvoice_dsp.c
@@ -21,7 +21,7 @@
 #include "fluid_sys.h"
 #include "fluid_phase.h"
 #include "fluid_rvoice.h"
-#include "fluid_rvoice_dsp_tables.c"
+#include "fluid_rvoice_dsp_tables.inc.h"
 
 /* Purpose:
  *

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -20,7 +20,7 @@
 
 #include "fluid_conv.h"
 #include "fluid_sys.h"
-#include "fluid_conv_tables.c"
+#include "fluid_conv_tables.inc.h"
 
 /*
  * Converts absolute cents to Hertz


### PR DESCRIPTION
These two files are not ordinary C files, and are being compiled
through #include's in other C source files, not through invoking
compiler on generated files. This might confuse both developers and
automated systems.

For longer explanation see discussion in #800.