### PR TITLE
Invalid generators were not removed from zone list

### DIFF
--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1355,7 +1355,7 @@ static int load_pmod(SFData *sf, int size)
  * ------------------------------------------------------------------- */
 static int load_pgen(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2, *p3, *dup, **hz = NULL;
+    fluid_list_t *p, *p2, *p3, *dup, **hz = NULL, *start_of_zone_list;
     SFZone *z;
     SFGen *g;
     SFGenAmount genval;
@@ -1369,7 +1369,7 @@ static int load_pgen(SFData *sf, int size)
         /* traverse through all presets */
         gzone = FALSE;
         discarded = FALSE;
-        p2 = ((SFPreset *)(p->data))->zone;
+        start_of_zone_list = p2 = ((SFPreset *)(p->data))->zone;
 
         if(p2)
         {
@@ -1516,11 +1516,12 @@ static int load_pgen(SFData *sf, int size)
                 }
                 else
                 {
+                    SFZone * pzone = fluid_list_get(p2);
                     /* previous global zone exists, discard */
                     FLUID_LOG(FLUID_WARN, "Preset '%s': Discarding invalid global zone",
                               ((SFPreset *)(p->data))->name);
-                    *hz = fluid_list_remove(*hz, p2->data);
-                    delete_zone((SFZone *)fluid_list_get(p2));
+                    *hz = fluid_list_remove(start_of_zone_list, pzone);
+                    delete_zone(pzone);
                 }
             }
 
@@ -1864,7 +1865,7 @@ static int load_imod(SFData *sf, int size)
 /* load instrument generators (see load_pgen for loading rules) */
 static int load_igen(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2, *p3, *dup, **hz = NULL;
+    fluid_list_t *p, *p2, *p3, *dup, **hz = NULL, *start_of_zone_list;
     SFZone *z;
     SFGen *g;
     SFGenAmount genval;
@@ -1878,7 +1879,7 @@ static int load_igen(SFData *sf, int size)
         /* traverse through all instruments */
         gzone = FALSE;
         discarded = FALSE;
-        p2 = ((SFInst *)(p->data))->zone;
+        start_of_zone_list = p2 = ((SFInst *)(p->data))->zone;
 
         if(p2)
         {
@@ -2024,11 +2025,12 @@ static int load_igen(SFData *sf, int size)
                 }
                 else
                 {
+                    SFZone * izone = fluid_list_get(p2);
                     /* previous global zone exists, discard */
                     FLUID_LOG(FLUID_WARN, "Instrument '%s': Discarding invalid global zone",
                               ((SFInst *)(p->data))->name);
-                    *hz = fluid_list_remove(*hz, p2->data);
-                    delete_zone((SFZone *)fluid_list_get(p2));
+                    *hz = fluid_list_remove(start_of_zone_list, izone);
+                    delete_zone(izone);
                 }
             }
 

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1516,12 +1516,13 @@ static int load_pgen(SFData *sf, int size)
                 }
                 else
                 {
-                    SFZone * pzone = fluid_list_get(p2);
+                    p2 = fluid_list_next(p2); /* advance to next zone before deleting the current list element */
                     /* previous global zone exists, discard */
                     FLUID_LOG(FLUID_WARN, "Preset '%s': Discarding invalid global zone",
                               ((SFPreset *)(p->data))->name);
-                    *hz = fluid_list_remove(start_of_zone_list, pzone);
-                    delete_zone(pzone);
+                    fluid_list_remove(start_of_zone_list, z);
+                    delete_zone(z);
+                    continue;
                 }
             }
 
@@ -2025,12 +2026,13 @@ static int load_igen(SFData *sf, int size)
                 }
                 else
                 {
-                    SFZone * izone = fluid_list_get(p2);
+                    p2 = fluid_list_next(p2); /* advance to next zone before deleting the current list element */
                     /* previous global zone exists, discard */
                     FLUID_LOG(FLUID_WARN, "Instrument '%s': Discarding invalid global zone",
                               ((SFInst *)(p->data))->name);
-                    *hz = fluid_list_remove(start_of_zone_list, izone);
-                    delete_zone(izone);
+                    fluid_list_remove(start_of_zone_list, z);
+                    delete_zone(z);
+                    continue;
                 }
             }
 


### PR DESCRIPTION
`fluid_list_remove()` should receive the beginning of a list, so it can adjust the predecessor of the element to be removed. Otherwise, the element would remain in the list, which in this case led to a use-after-free afterwards.

Resolves #808