### PR TITLE
Parallelize SF2 loading

### DIFF
--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -422,11 +422,14 @@ int fluid_defsfont_load_all_sampledata(fluid_defsfont_t *defsfont, SFData *sfdat
         }
         else
         {
-            /* Data pointers of SF2 samples point to large sample data block loaded above */
-            sample->data = defsfont->sampledata;
-            sample->data24 = defsfont->sample24data;
-            fluid_sample_sanitize_loop(sample, defsfont->samplesize);
-            fluid_voice_optimize_sample(sample);
+            #pragma omp task firstprivate(sample, defsfont) default(none)
+            {
+                /* Data pointers of SF2 samples point to large sample data block loaded above */
+                sample->data = defsfont->sampledata;
+                sample->data24 = defsfont->sample24data;
+                fluid_sample_sanitize_loop(sample, defsfont->samplesize);
+                fluid_voice_optimize_sample(sample);
+            }
         }
     }
 

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -147,7 +147,7 @@ struct _fluid_sample_t
 {
     char name[21];                /**< Sample name */
 
-    /* The following for sample pointers store the original pointers from the Soundfont
+    /* The following four sample pointers store the original pointers from the Soundfont
      * file. They are never changed after loading and are used to re-create the
      * actual sample pointers after a sample has been unloaded and loaded again. The
      * actual sample pointers get modified during loading for SF3 (compressed) samples


### PR DESCRIPTION
The loading of SF2 samples can be parallelized as well, at least for bigger soundfonts like the Stgiga 4GB monster.

The following test is performed with hot-caches:

`time src/fluidsynth -i -a alsa Stgiga\'s\ HiDef\ Soundfont\ \(2019-05-25\).sf2`

Serial version:
```
real    0m15,460s
user    0m14,163s
sys     0m1,192s
```

Parallelized version proposed by this PR:
```
real    0m5,851s
user    0m14,089s
sys     0m1,194s
```