### PR TITLE
Rename variables in fluid_sffile.c for easier readability

### DIFF
--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1366,7 +1366,8 @@ static int load_pmod(SFData *sf, int size)
  * ------------------------------------------------------------------- */
 static int load_pgen(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2, *p3, *dup, **hz = NULL;
+    fluid_list_t *p, *p2, *dup, **hz = NULL;
+    fluid_list_t *gen_list;
     SFZone *z;
     SFGen *g;
     SFGenAmount genval;
@@ -1392,9 +1393,9 @@ static int load_pgen(SFData *sf, int size)
             /* traverse preset's zones */
             level = 0;
             z = (SFZone *)(p2->data);
-            p3 = z->gen;
+            gen_list = z->gen;
 
-            while(p3)
+            while(gen_list)
             {
                 /* load zone's generators */
                 dup = NULL;
@@ -1472,7 +1473,7 @@ static int load_pgen(SFData *sf, int size)
                             return FALSE;
                         }
 
-                        p3->data = g;
+                        gen_list->data = g;
                         g->id = genid;
                     }
                     else
@@ -1493,18 +1494,18 @@ static int load_pgen(SFData *sf, int size)
 
                 if(!drop)
                 {
-                    p3 = fluid_list_next(p3);    /* next gen */
+                    gen_list = fluid_list_next(gen_list);    /* next gen */
                 }
                 else
                 {
-                    SLADVREM(z->gen, p3);    /* drop place holder */
+                    SLADVREM(z->gen, gen_list);    /* drop place holder */
                 }
 
             } /* generator loop */
 
             if(level == 3)
             {
-                SLADVREM(z->gen, p3);    /* zone has inst? */
+                SLADVREM(z->gen, gen_list);    /* zone has inst? */
             }
             else
             {
@@ -1535,7 +1536,7 @@ static int load_pgen(SFData *sf, int size)
                 }
             }
 
-            while(p3)
+            while(gen_list)
             {
                 /* Kill any zones following an instrument */
                 discarded = TRUE;
@@ -1547,7 +1548,7 @@ static int load_pgen(SFData *sf, int size)
                 }
 
                 FSKIP(sf, SF_GEN_SIZE);
-                SLADVREM(z->gen, p3);
+                SLADVREM(z->gen, gen_list);
             }
 
             p2 = fluid_list_next(p2); /* next zone */

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1807,7 +1807,8 @@ static int load_ibag(SFData *sf, int size)
 /* instrument modulator loader */
 static int load_imod(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2, *p3;
+    fluid_list_t *p, *p2;
+    fluid_list_t *mod_list;
     SFMod *m;
 
     p = sf->inst;
@@ -1820,9 +1821,9 @@ static int load_imod(SFData *sf, int size)
         while(p2)
         {
             /* traverse this inst's zones */
-            p3 = ((SFZone *)(p2->data))->mod;
+            mod_list = ((SFZone *)(p2->data))->mod;
 
-            while(p3)
+            while(mod_list)
             {
                 /* load zone's modulators */
                 if((size -= SF_MOD_SIZE) < 0)
@@ -1837,13 +1838,13 @@ static int load_imod(SFData *sf, int size)
                     return FALSE;
                 }
 
-                p3->data = m;
+                mod_list->data = m;
                 READW(sf, m->src);
                 READW(sf, m->dest);
                 READW(sf, m->amount);
                 READW(sf, m->amtsrc);
                 READW(sf, m->trans);
-                p3 = fluid_list_next(p3);
+                mod_list = fluid_list_next(mod_list);
             }
 
             p2 = fluid_list_next(p2);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1285,7 +1285,8 @@ static int load_pbag(SFData *sf, int size)
 /* preset modulator loader */
 static int load_pmod(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2;
+    fluid_list_t *p;
+    fluid_list_t *zone_list;
     fluid_list_t *mod_list;
     SFMod *m;
 
@@ -1294,12 +1295,12 @@ static int load_pmod(SFData *sf, int size)
     while(p)
     {
         /* traverse through all presets */
-        p2 = ((SFPreset *)(p->data))->zone;
+        zone_list = ((SFPreset *)(p->data))->zone;
 
-        while(p2)
+        while(zone_list)
         {
             /* traverse this preset's zones */
-            mod_list = ((SFZone *)(p2->data))->mod;
+            mod_list = ((SFZone *)(zone_list->data))->mod;
 
             while(mod_list)
             {
@@ -1325,7 +1326,7 @@ static int load_pmod(SFData *sf, int size)
                 mod_list = fluid_list_next(mod_list);
             }
 
-            p2 = fluid_list_next(p2);
+            zone_list = fluid_list_next(zone_list);
         }
 
         p = fluid_list_next(p);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1672,7 +1672,8 @@ static int load_ihdr(SFData *sf, unsigned int size)
 /* instrument bag loader */
 static int load_ibag(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2;
+    fluid_list_t *p;
+    fluid_list_t *zone_list;
     SFZone *z, *pz = NULL;
     unsigned short genndx, modndx, pgenndx = 0, pmodndx = 0;
     int i;
@@ -1688,9 +1689,9 @@ static int load_ibag(SFData *sf, int size)
     while(p)
     {
         /* traverse through inst */
-        p2 = ((SFInst *)(p->data))->zone;
+        zone_list = ((SFInst *)(p->data))->zone;
 
-        while(p2)
+        while(zone_list)
         {
             /* load this inst's zones */
             if((size -= SF_BAG_SIZE) < 0)
@@ -1705,7 +1706,7 @@ static int load_ibag(SFData *sf, int size)
                 return FALSE;
             }
 
-            p2->data = z;
+            zone_list->data = z;
             z->gen = NULL; /* In case of failure, */
             z->mod = NULL; /* fluid_sffile_close can clean up */
             READW(sf, genndx); /* READW = possible read failure */
@@ -1745,7 +1746,7 @@ static int load_ibag(SFData *sf, int size)
             pz = z; /* update previous zone ptr */
             pgenndx = genndx;
             pmodndx = modndx;
-            p2 = fluid_list_next(p2);
+            zone_list = fluid_list_next(zone_list);
         }
 
         p = fluid_list_next(p);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1592,7 +1592,7 @@ static int load_ihdr(SFData *sf, unsigned int size)
 {
     unsigned int i;
     int i2;
-    SFInst *p, *pr = NULL; /* ptr to current & previous instrument */
+    SFInst *inst, *pr = NULL; /* ptr to current & previous instrument */
     unsigned short zndx, pzndx = 0;
 
     if(size % SF_IHDR_SIZE || size == 0)  /* chunk size is valid? */
@@ -1614,16 +1614,16 @@ static int load_ihdr(SFData *sf, unsigned int size)
     for(i = 0; i < size; i++)
     {
         /* load all instrument headers */
-        if((p = FLUID_NEW(SFInst)) == NULL)
+        if((inst = FLUID_NEW(SFInst)) == NULL)
         {
             FLUID_LOG(FLUID_ERR, "Out of memory");
             return FALSE;
         }
 
-        sf->inst = fluid_list_append(sf->inst, p);
-        p->zone = NULL; /* For proper cleanup if fail (fluid_sffile_close) */
-        p->idx = i;
-        READSTR(sf, &p->name); /* Possible read failure ^ */
+        sf->inst = fluid_list_append(sf->inst, inst);
+        inst->zone = NULL; /* For proper cleanup if fail (fluid_sffile_close) */
+        inst->idx = i;
+        READSTR(sf, &inst->name); /* Possible read failure ^ */
         READW(sf, zndx);
 
         if(pr)
@@ -1648,7 +1648,7 @@ static int load_ihdr(SFData *sf, unsigned int size)
         }
 
         pzndx = zndx;
-        pr = p; /* update instrument ptr */
+        pr = inst; /* update instrument ptr */
     }
 
     FSKIP(sf, 20);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1285,17 +1285,17 @@ static int load_pbag(SFData *sf, int size)
 /* preset modulator loader */
 static int load_pmod(SFData *sf, int size)
 {
-    fluid_list_t *p;
+    fluid_list_t *preset_list;
     fluid_list_t *zone_list;
     fluid_list_t *mod_list;
     SFMod *m;
 
-    p = sf->preset;
+    preset_list = sf->preset;
 
-    while(p)
+    while(preset_list)
     {
         /* traverse through all presets */
-        zone_list = ((SFPreset *)(p->data))->zone;
+        zone_list = ((SFPreset *)(preset_list->data))->zone;
 
         while(zone_list)
         {
@@ -1329,7 +1329,7 @@ static int load_pmod(SFData *sf, int size)
             zone_list = fluid_list_next(zone_list);
         }
 
-        p = fluid_list_next(p);
+        preset_list = fluid_list_next(preset_list);
     }
 
     /*

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1592,7 +1592,7 @@ static int load_ihdr(SFData *sf, unsigned int size)
 {
     unsigned int i;
     int i2;
-    SFInst *inst, *pr = NULL; /* ptr to current & previous instrument */
+    SFInst *inst, *prev_inst = NULL; /* ptr to current & previous instrument */
     unsigned short zndx, pzndx = 0;
 
     if(size % SF_IHDR_SIZE || size == 0)  /* chunk size is valid? */
@@ -1626,7 +1626,7 @@ static int load_ihdr(SFData *sf, unsigned int size)
         READSTR(sf, &inst->name); /* Possible read failure ^ */
         READW(sf, zndx);
 
-        if(pr)
+        if(prev_inst)
         {
             /* not first instrument? */
             if(zndx < pzndx)
@@ -1639,7 +1639,7 @@ static int load_ihdr(SFData *sf, unsigned int size)
 
             while(i2--)
             {
-                pr->zone = fluid_list_prepend(pr->zone, NULL);
+                prev_inst->zone = fluid_list_prepend(prev_inst->zone, NULL);
             }
         }
         else if(zndx > 0)  /* 1st inst, warn if ofs >0 */
@@ -1648,7 +1648,7 @@ static int load_ihdr(SFData *sf, unsigned int size)
         }
 
         pzndx = zndx;
-        pr = inst; /* update instrument ptr */
+        prev_inst = inst; /* update instrument ptr */
     }
 
     FSKIP(sf, 20);
@@ -1664,7 +1664,7 @@ static int load_ihdr(SFData *sf, unsigned int size)
 
     while(i2--)
     {
-        pr->zone = fluid_list_prepend(pr->zone, NULL);
+        prev_inst->zone = fluid_list_prepend(prev_inst->zone, NULL);
     }
 
     return TRUE;

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1811,7 +1811,8 @@ static int load_ibag(SFData *sf, int size)
 /* instrument modulator loader */
 static int load_imod(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2;
+    fluid_list_t *p;
+    fluid_list_t *zone_list;
     fluid_list_t *mod_list;
     SFMod *m;
 
@@ -1820,12 +1821,12 @@ static int load_imod(SFData *sf, int size)
     while(p)
     {
         /* traverse through all inst */
-        p2 = ((SFInst *)(p->data))->zone;
+        zone_list = ((SFInst *)(p->data))->zone;
 
-        while(p2)
+        while(zone_list)
         {
             /* traverse this inst's zones */
-            mod_list = ((SFZone *)(p2->data))->mod;
+            mod_list = ((SFZone *)(zone_list->data))->mod;
 
             while(mod_list)
             {
@@ -1851,7 +1852,7 @@ static int load_imod(SFData *sf, int size)
                 mod_list = fluid_list_next(mod_list);
             }
 
-            p2 = fluid_list_next(p2);
+            zone_list = fluid_list_next(zone_list);
         }
 
         p = fluid_list_next(p);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1368,7 +1368,8 @@ static int load_pmod(SFData *sf, int size)
  * ------------------------------------------------------------------- */
 static int load_pgen(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2, *dup, **hz = NULL;
+    fluid_list_t *p, *dup, **hz = NULL;
+    fluid_list_t *zone_list;
     fluid_list_t *gen_list;
     SFZone *z;
     SFGen *g;
@@ -1383,18 +1384,18 @@ static int load_pgen(SFData *sf, int size)
         /* traverse through all presets */
         gzone = FALSE;
         discarded = FALSE;
-        p2 = ((SFPreset *)(p->data))->zone;
+        zone_list = ((SFPreset *)(p->data))->zone;
 
-        if(p2)
+        if(zone_list)
         {
-            hz = &p2;
+            hz = &zone_list;
         }
 
-        while(p2)
+        while(zone_list)
         {
             /* traverse preset's zones */
             level = 0;
-            z = (SFZone *)(p2->data);
+            z = (SFZone *)(zone_list->data);
             gen_list = z->gen;
 
             while(gen_list)
@@ -1445,7 +1446,7 @@ static int load_pgen(SFData *sf, int size)
                     /* inst is last gen */
                     level = 3;
                     READW(sf, genval.uword);
-                    ((SFZone *)(p2->data))->instsamp = FLUID_INT_TO_POINTER(genval.uword + 1);
+                    ((SFZone *)(zone_list->data))->instsamp = FLUID_INT_TO_POINTER(genval.uword + 1);
                     break; /* break out of generator loop */
                 }
                 else
@@ -1518,12 +1519,12 @@ static int load_pgen(SFData *sf, int size)
                     gzone = TRUE;
 
                     /* if global zone is not 1st zone, relocate */
-                    if(*hz != p2)
+                    if(*hz != zone_list)
                     {
-                        void *save = p2->data;
+                        void *save = zone_list->data;
                         FLUID_LOG(FLUID_WARN, "Preset '%s': Global zone is not first zone",
                                   ((SFPreset *)(p->data))->name);
-                        SLADVREM(*hz, p2);
+                        SLADVREM(*hz, zone_list);
                         *hz = fluid_list_prepend(*hz, save);
                         continue;
                     }
@@ -1533,8 +1534,8 @@ static int load_pgen(SFData *sf, int size)
                     /* previous global zone exists, discard */
                     FLUID_LOG(FLUID_WARN, "Preset '%s': Discarding invalid global zone",
                               ((SFPreset *)(p->data))->name);
-                    *hz = fluid_list_remove(*hz, p2->data);
-                    delete_zone((SFZone *)fluid_list_get(p2));
+                    *hz = fluid_list_remove(*hz, zone_list->data);
+                    delete_zone((SFZone *)fluid_list_get(zone_list));
                 }
             }
 
@@ -1553,7 +1554,7 @@ static int load_pgen(SFData *sf, int size)
                 SLADVREM(z->gen, gen_list);
             }
 
-            p2 = fluid_list_next(p2); /* next zone */
+            zone_list = fluid_list_next(zone_list); /* next zone */
         }
 
         if(discarded)

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1812,17 +1812,17 @@ static int load_ibag(SFData *sf, int size)
 /* instrument modulator loader */
 static int load_imod(SFData *sf, int size)
 {
-    fluid_list_t *p;
+    fluid_list_t *inst_list;
     fluid_list_t *zone_list;
     fluid_list_t *mod_list;
     SFMod *m;
 
-    p = sf->inst;
+    inst_list = sf->inst;
 
-    while(p)
+    while(inst_list)
     {
         /* traverse through all inst */
-        zone_list = ((SFInst *)(p->data))->zone;
+        zone_list = ((SFInst *)(inst_list->data))->zone;
 
         while(zone_list)
         {
@@ -1856,7 +1856,7 @@ static int load_imod(SFData *sf, int size)
             zone_list = fluid_list_next(zone_list);
         }
 
-        p = fluid_list_next(p);
+        inst_list = fluid_list_next(inst_list);
     }
 
     /*

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -2193,7 +2193,8 @@ static int fixup_pgen(SFData *sf)
 /* "fixup" (sample # -> sample ptr) sample references in instrument list */
 static int fixup_igen(SFData *sf)
 {
-    fluid_list_t *p, *p2, *p3;
+    fluid_list_t *p, *p2;
+    fluid_list_t *inst_list;
     SFZone *z;
     int i;
 
@@ -2211,16 +2212,16 @@ static int fixup_igen(SFData *sf)
             if((i = FLUID_POINTER_TO_INT(z->instsamp)))
             {
                 /* load sample # */
-                p3 = fluid_list_nth(sf->sample, i - 1);
+                inst_list = fluid_list_nth(sf->sample, i - 1);
 
-                if(!p3)
+                if(!inst_list)
                 {
                     FLUID_LOG(FLUID_ERR, "Instrument '%s': Invalid sample reference",
                               ((SFInst *)(p->data))->name);
                     return FALSE;
                 }
 
-                z->instsamp = p3;
+                z->instsamp = inst_list;
             }
 
             p2 = fluid_list_next(p2);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1284,7 +1284,8 @@ static int load_pbag(SFData *sf, int size)
 /* preset modulator loader */
 static int load_pmod(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2, *p3;
+    fluid_list_t *p, *p2;
+    fluid_list_t *mod_list;
     SFMod *m;
 
     p = sf->preset;
@@ -1297,9 +1298,9 @@ static int load_pmod(SFData *sf, int size)
         while(p2)
         {
             /* traverse this preset's zones */
-            p3 = ((SFZone *)(p2->data))->mod;
+            mod_list = ((SFZone *)(p2->data))->mod;
 
-            while(p3)
+            while(mod_list)
             {
                 /* load zone's modulators */
                 if((size -= SF_MOD_SIZE) < 0)
@@ -1314,13 +1315,13 @@ static int load_pmod(SFData *sf, int size)
                     return FALSE;
                 }
 
-                p3->data = m;
+                mod_list->data = m;
                 READW(sf, m->src);
                 READW(sf, m->dest);
                 READW(sf, m->amount);
                 READW(sf, m->amtsrc);
                 READW(sf, m->trans);
-                p3 = fluid_list_next(p3);
+                mod_list = fluid_list_next(mod_list);
             }
 
             p2 = fluid_list_next(p2);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -2146,7 +2146,8 @@ static int load_shdr(SFData *sf, unsigned int size)
 /* "fixup" (inst # -> inst ptr) instrument references in preset list */
 static int fixup_pgen(SFData *sf)
 {
-    fluid_list_t *p, *p2, *p3;
+    fluid_list_t *p, *p2;
+    fluid_list_t *inst_list;
     SFZone *z;
     int i;
 
@@ -2164,16 +2165,16 @@ static int fixup_pgen(SFData *sf)
             if((i = FLUID_POINTER_TO_INT(z->instsamp)))
             {
                 /* load instrument # */
-                p3 = fluid_list_nth(sf->inst, i - 1);
+                inst_list = fluid_list_nth(sf->inst, i - 1);
 
-                if(!p3)
+                if(!inst_list)
                 {
                     FLUID_LOG(FLUID_ERR, "Preset %03d %03d: Invalid instrument reference",
                               ((SFPreset *)(p->data))->bank, ((SFPreset *)(p->data))->prenum);
                     return FALSE;
                 }
 
-                z->instsamp = p3;
+                z->instsamp = inst_list;
             }
             else
             {

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1673,7 +1673,7 @@ static int load_ihdr(SFData *sf, unsigned int size)
 /* instrument bag loader */
 static int load_ibag(SFData *sf, int size)
 {
-    fluid_list_t *p;
+    fluid_list_t *inst_list;
     fluid_list_t *zone_list;
     SFZone *z, *pz = NULL;
     unsigned short genndx, modndx, pgenndx = 0, pmodndx = 0;
@@ -1685,12 +1685,12 @@ static int load_ibag(SFData *sf, int size)
         return FALSE;
     }
 
-    p = sf->inst;
+    inst_list = sf->inst;
 
-    while(p)
+    while(inst_list)
     {
         /* traverse through inst */
-        zone_list = ((SFInst *)(p->data))->zone;
+        zone_list = ((SFInst *)(inst_list->data))->zone;
 
         while(zone_list)
         {
@@ -1750,7 +1750,7 @@ static int load_ibag(SFData *sf, int size)
             zone_list = fluid_list_next(zone_list);
         }
 
-        p = fluid_list_next(p);
+        inst_list = fluid_list_next(inst_list);
     }
 
     size -= SF_BAG_SIZE;

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1368,7 +1368,8 @@ static int load_pmod(SFData *sf, int size)
  * ------------------------------------------------------------------- */
 static int load_pgen(SFData *sf, int size)
 {
-    fluid_list_t *p, *dup, **hz = NULL;
+    fluid_list_t *dup, **hz = NULL;
+    fluid_list_t *preset_list;
     fluid_list_t *zone_list;
     fluid_list_t *gen_list;
     SFZone *z;
@@ -1377,14 +1378,14 @@ static int load_pgen(SFData *sf, int size)
     unsigned short genid;
     int level, skip, drop, gzone, discarded;
 
-    p = sf->preset;
+    preset_list = sf->preset;
 
-    while(p)
+    while(preset_list)
     {
         /* traverse through all presets */
         gzone = FALSE;
         discarded = FALSE;
-        zone_list = ((SFPreset *)(p->data))->zone;
+        zone_list = ((SFPreset *)(preset_list->data))->zone;
 
         if(zone_list)
         {
@@ -1523,7 +1524,7 @@ static int load_pgen(SFData *sf, int size)
                     {
                         void *save = zone_list->data;
                         FLUID_LOG(FLUID_WARN, "Preset '%s': Global zone is not first zone",
-                                  ((SFPreset *)(p->data))->name);
+                                  ((SFPreset *)(preset_list->data))->name);
                         SLADVREM(*hz, zone_list);
                         *hz = fluid_list_prepend(*hz, save);
                         continue;
@@ -1533,7 +1534,7 @@ static int load_pgen(SFData *sf, int size)
                 {
                     /* previous global zone exists, discard */
                     FLUID_LOG(FLUID_WARN, "Preset '%s': Discarding invalid global zone",
-                              ((SFPreset *)(p->data))->name);
+                              ((SFPreset *)(preset_list->data))->name);
                     *hz = fluid_list_remove(*hz, zone_list->data);
                     delete_zone((SFZone *)fluid_list_get(zone_list));
                 }
@@ -1561,10 +1562,10 @@ static int load_pgen(SFData *sf, int size)
         {
             FLUID_LOG(FLUID_WARN,
                       "Preset '%s': Some invalid generators were discarded",
-                      ((SFPreset *)(p->data))->name);
+                      ((SFPreset *)(preset_list->data))->name);
         }
 
-        p = fluid_list_next(p);
+        preset_list = fluid_list_next(preset_list);
     }
 
     /* in case there isn't a terminal record */

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1146,7 +1146,8 @@ static int load_phdr(SFData *sf, unsigned int size)
 /* preset bag loader */
 static int load_pbag(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2;
+    fluid_list_t *p;
+    fluid_list_t *zone_list;
     SFZone *z, *pz = NULL;
     unsigned short genndx, modndx;
     unsigned short pgenndx = 0, pmodndx = 0;
@@ -1163,9 +1164,9 @@ static int load_pbag(SFData *sf, int size)
     while(p)
     {
         /* traverse through presets */
-        p2 = ((SFPreset *)(p->data))->zone;
+        zone_list = ((SFPreset *)(p->data))->zone;
 
-        while(p2)
+        while(zone_list)
         {
             /* traverse preset's zones */
             if((size -= SF_BAG_SIZE) < 0)
@@ -1180,7 +1181,7 @@ static int load_pbag(SFData *sf, int size)
                 return FALSE;
             }
 
-            p2->data = z;
+            zone_list->data = z;
             z->gen = NULL; /* Init gen and mod before possible failure, */
             z->mod = NULL; /* to ensure proper cleanup (fluid_sffile_close) */
             READW(sf, genndx); /* possible read failure ^ */
@@ -1220,7 +1221,7 @@ static int load_pbag(SFData *sf, int size)
             pz = z; /* update previous zone ptr */
             pgenndx = genndx; /* update previous zone gen index */
             pmodndx = modndx; /* update previous zone mod index */
-            p2 = fluid_list_next(p2);
+            zone_list = fluid_list_next(zone_list);
         }
 
         p = fluid_list_next(p);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -2152,7 +2152,8 @@ static int load_shdr(SFData *sf, unsigned int size)
 /* "fixup" (inst # -> inst ptr) instrument references in preset list */
 static int fixup_pgen(SFData *sf)
 {
-    fluid_list_t *p, *p2;
+    fluid_list_t *p;
+    fluid_list_t *zone_list;
     fluid_list_t *inst_list;
     SFZone *z;
     int i;
@@ -2161,12 +2162,12 @@ static int fixup_pgen(SFData *sf)
 
     while(p)
     {
-        p2 = ((SFPreset *)(p->data))->zone;
+        zone_list = ((SFPreset *)(p->data))->zone;
 
-        while(p2)
+        while(zone_list)
         {
             /* traverse this preset's zones */
-            z = (SFZone *)(p2->data);
+            z = (SFZone *)(zone_list->data);
 
             if((i = FLUID_POINTER_TO_INT(z->instsamp)))
             {
@@ -2187,7 +2188,7 @@ static int fixup_pgen(SFData *sf)
                 z->instsamp = NULL;
             }
 
-            p2 = fluid_list_next(p2);
+            zone_list = fluid_list_next(zone_list);
         }
 
         p = fluid_list_next(p);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1878,7 +1878,8 @@ static int load_imod(SFData *sf, int size)
 /* load instrument generators (see load_pgen for loading rules) */
 static int load_igen(SFData *sf, int size)
 {
-    fluid_list_t *p, *p2, *p3, *dup, **hz = NULL;
+    fluid_list_t *p, *p2, *dup, **hz = NULL;
+    fluid_list_t *gen_list;
     SFZone *z;
     SFGen *g;
     SFGenAmount genval;
@@ -1904,9 +1905,9 @@ static int load_igen(SFData *sf, int size)
             /* traverse this instrument's zones */
             level = 0;
             z = (SFZone *)(p2->data);
-            p3 = z->gen;
+            gen_list = z->gen;
 
-            while(p3)
+            while(gen_list)
             {
                 /* load zone's generators */
                 dup = NULL;
@@ -1984,7 +1985,7 @@ static int load_igen(SFData *sf, int size)
                             return FALSE;
                         }
 
-                        p3->data = g;
+                        gen_list->data = g;
                         g->id = genid;
                     }
                     else
@@ -2005,18 +2006,18 @@ static int load_igen(SFData *sf, int size)
 
                 if(!drop)
                 {
-                    p3 = fluid_list_next(p3);    /* next gen */
+                    gen_list = fluid_list_next(gen_list);    /* next gen */
                 }
                 else
                 {
-                    SLADVREM(z->gen, p3);
+                    SLADVREM(z->gen, gen_list);
                 }
 
             } /* generator loop */
 
             if(level == 3)
             {
-                SLADVREM(z->gen, p3);    /* zone has sample? */
+                SLADVREM(z->gen, gen_list);    /* zone has sample? */
             }
             else
             {
@@ -2046,7 +2047,7 @@ static int load_igen(SFData *sf, int size)
                 }
             }
 
-            while(p3)
+            while(gen_list)
             {
                 /* Kill any zones following a sample */
                 discarded = TRUE;
@@ -2058,7 +2059,7 @@ static int load_igen(SFData *sf, int size)
                 }
 
                 FSKIP(sf, SF_GEN_SIZE);
-                SLADVREM(z->gen, p3);
+                SLADVREM(z->gen, gen_list);
             }
 
             p2 = fluid_list_next(p2); /* next zone */

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1146,7 +1146,7 @@ static int load_phdr(SFData *sf, unsigned int size)
 /* preset bag loader */
 static int load_pbag(SFData *sf, int size)
 {
-    fluid_list_t *p;
+    fluid_list_t *preset_list;
     fluid_list_t *zone_list;
     SFZone *z, *pz = NULL;
     unsigned short genndx, modndx;
@@ -1159,12 +1159,12 @@ static int load_pbag(SFData *sf, int size)
         return FALSE;
     }
 
-    p = sf->preset;
+    preset_list = sf->preset;
 
-    while(p)
+    while(preset_list)
     {
         /* traverse through presets */
-        zone_list = ((SFPreset *)(p->data))->zone;
+        zone_list = ((SFPreset *)(preset_list->data))->zone;
 
         while(zone_list)
         {
@@ -1224,7 +1224,7 @@ static int load_pbag(SFData *sf, int size)
             zone_list = fluid_list_next(zone_list);
         }
 
-        p = fluid_list_next(p);
+        preset_list = fluid_list_next(preset_list);
     }
 
     size -= SF_BAG_SIZE;

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -2200,7 +2200,8 @@ static int fixup_pgen(SFData *sf)
 /* "fixup" (sample # -> sample ptr) sample references in instrument list */
 static int fixup_igen(SFData *sf)
 {
-    fluid_list_t *p, *p2;
+    fluid_list_t *p;
+    fluid_list_t *zone_list;
     fluid_list_t *inst_list;
     SFZone *z;
     int i;
@@ -2209,12 +2210,12 @@ static int fixup_igen(SFData *sf)
 
     while(p)
     {
-        p2 = ((SFInst *)(p->data))->zone;
+        zone_list = ((SFInst *)(p->data))->zone;
 
-        while(p2)
+        while(zone_list)
         {
             /* traverse instrument's zones */
-            z = (SFZone *)(p2->data);
+            z = (SFZone *)(zone_list->data);
 
             if((i = FLUID_POINTER_TO_INT(z->instsamp)))
             {
@@ -2231,7 +2232,7 @@ static int fixup_igen(SFData *sf)
                 z->instsamp = inst_list;
             }
 
-            p2 = fluid_list_next(p2);
+            zone_list = fluid_list_next(zone_list);
         }
 
         p = fluid_list_next(p);

--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -1884,7 +1884,8 @@ static int load_imod(SFData *sf, int size)
 /* load instrument generators (see load_pgen for loading rules) */
 static int load_igen(SFData *sf, int size)
 {
-    fluid_list_t *p, *dup, **hz = NULL;
+    fluid_list_t *dup, **hz = NULL;
+    fluid_list_t *inst_list;
     fluid_list_t *zone_list;
     fluid_list_t *gen_list;
     SFZone *z;
@@ -1893,14 +1894,14 @@ static int load_igen(SFData *sf, int size)
     unsigned short genid;
     int level, skip, drop, gzone, discarded;
 
-    p = sf->inst;
+    inst_list = sf->inst;
 
-    while(p)
+    while(inst_list)
     {
         /* traverse through all instruments */
         gzone = FALSE;
         discarded = FALSE;
-        zone_list = ((SFInst *)(p->data))->zone;
+        zone_list = ((SFInst *)(inst_list->data))->zone;
 
         if(zone_list)
         {
@@ -2038,7 +2039,7 @@ static int load_igen(SFData *sf, int size)
                     {
                         void *save = zone_list->data;
                         FLUID_LOG(FLUID_WARN, "Instrument '%s': Global zone is not first zone",
-                                  ((SFPreset *)(p->data))->name);
+                                  ((SFPreset *)(inst_list->data))->name);
                         SLADVREM(*hz, zone_list);
                         *hz = fluid_list_prepend(*hz, save);
                         continue;
@@ -2048,7 +2049,7 @@ static int load_igen(SFData *sf, int size)
                 {
                     /* previous global zone exists, discard */
                     FLUID_LOG(FLUID_WARN, "Instrument '%s': Discarding invalid global zone",
-                              ((SFInst *)(p->data))->name);
+                              ((SFInst *)(inst_list->data))->name);
                     *hz = fluid_list_remove(*hz, zone_list->data);
                     delete_zone((SFZone *)fluid_list_get(zone_list));
                 }
@@ -2076,10 +2077,10 @@ static int load_igen(SFData *sf, int size)
         {
             FLUID_LOG(FLUID_WARN,
                       "Instrument '%s': Some invalid generators were discarded",
-                      ((SFInst *)(p->data))->name);
+                      ((SFInst *)(inst_list->data))->name);
         }
 
-        p = fluid_list_next(p);
+        inst_list = fluid_list_next(inst_list);
     }
 
     /* for those non-terminal record cases, grr! */


### PR DESCRIPTION
In preparation for #813, this PR renames some of the very short and sometimes confusing variables in fluid_sffile to more descriptive names. No functional changes were made, only the names of the variables were updated.

Each rename in it's own commit, for easier review. But when/if we accept this PR, we could probably squash them all into a single commit.