### PR TITLE
Reset synth after end, not before start of song

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -760,7 +760,7 @@ and commit the results. Refresh with the following command:
             <type>bool</type>
             <def>1 (TRUE)</def>
             <realtime/>
-            <desc>If true, reset the synth before starting a new MIDI song, so the state of a previous song can't affect the new song. Turn it off for seamless looping of a song.</desc>
+            <desc>If true, reset the synth after the end of a MIDI song, so that the state of a previous song can't affect the next song. Turn it off for seamless looping of a song.</desc>
         </setting>
         <setting>
             <name>timing-source</name>

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2059,11 +2059,6 @@ fluid_player_playlist_load(fluid_player_t *player, unsigned int msec)
     player->start_ticks = 0;
     player->cur_ticks = 0;
 
-    if(player->reset_synth_between_songs)
-    {
-        fluid_synth_system_reset(player->synth);
-    }
-
     for(i = 0; i < player->ntracks; i++)
     {
         if(player->track[i] != NULL)
@@ -2145,6 +2140,12 @@ fluid_player_callback(void *data, unsigned int msec)
         {
             FLUID_LOG(FLUID_DBG, "%s: %d: Duration=%.3f sec", __FILE__,
                       __LINE__, (msec - player->begin_msec) / 1000.0);
+
+            if(player->reset_synth_between_songs)
+            {
+                fluid_synth_system_reset(player->synth);
+            }
+
             loadnextfile = 1;
         }
 


### PR DESCRIPTION
As discussed in #816, this PR moves the synth reset from the beginning of a MIDI song to the end of a song.