### PR TITLE
Fix two gcc warnings

### DIFF
--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -1241,7 +1241,10 @@ fluid_handle_reverb_command(void *data, int ac, char **av, fluid_ostream_t out,
     /* name and min/max values table */
     static struct value values[FLUID_REVERB_PARAM_LAST] =
     {
-        {"room size"}, {"damp"}, {"width"}, {"level"}
+        {"room size", 0, 0},
+        {"damp", 0, 0},
+        {"width", 0, 0},
+        {"level", 0, 0}
     };
 
     FLUID_ENTRY_COMMAND(data);

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -3556,7 +3556,7 @@ enum
 int fluid_handle_player_cde(void *data, int ac, char **av, fluid_ostream_t out, int cmd)
 {
     FLUID_ENTRY_COMMAND(data);
-    int arg, was_running;
+    int arg = 0, was_running;
     int seek = -1;  /* current seek position in tick */
 
     /* commands name table */


### PR DESCRIPTION
This PR fixes two warnings from gcc 9.3.0 on current master:

```
fluidsynth/src/bindings/fluid_cmd.c: In function ‘fluid_handle_reverb_command’:
fluidsynth/src/bindings/fluid_cmd.c:1244:9: warning: missing initializer for field ‘min’ of ‘struct value’ [-Wmissing-field-initializers]
 1244 |         {"room size"}, {"damp"}, {"width"}, {"level"}
      |         ^
fluidsynth/src/bindings/fluid_cmd.c:1185:12: note: ‘min’ declared here
 1185 |     double min;
      |            ^~~
fluidsynth/src/bindings/fluid_cmd.c:1244:9: warning: missing initializer for field ‘min’ of ‘struct value’ [-Wmissing-field-initializers]
 1244 |         {"room size"}, {"damp"}, {"width"}, {"level"}
      |         ^
fluidsynth/src/bindings/fluid_cmd.c:1185:12: note: ‘min’ declared here
 1185 |     double min;
      |            ^~~
fluidsynth/src/bindings/fluid_cmd.c:1244:9: warning: missing initializer for field ‘min’ of ‘struct value’ [-Wmissing-field-initializers]
 1244 |         {"room size"}, {"damp"}, {"width"}, {"level"}
      |         ^
fluidsynth/src/bindings/fluid_cmd.c:1185:12: note: ‘min’ declared here
 1185 |     double min;
      |            ^~~
fluidsynth/src/bindings/fluid_cmd.c:1244:9: warning: missing initializer for field ‘min’ of ‘struct value’ [-Wmissing-field-initializers]
 1244 |         {"room size"}, {"damp"}, {"width"}, {"level"}
      |         ^
fluidsynth/src/bindings/fluid_cmd.c:1185:12: note: ‘min’ declared here
 1185 |     double min;
      |
```

and 

```
fluidsynth/src/bindings/fluid_cmd.c: In function ‘fluid_handle_player_cde’:
fluidsynth/src/bindings/fluid_cmd.c:3605:18: warning: ‘arg’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3605 |             arg  += fluid_player_get_current_tick(handler->player);
      |                  ^~
```