### PR TITLE
WASAPI driver reorganization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ install_manifest.txt
 
 # ProjectFiles
 *.pro.user*
+*.user

--- a/src/drivers/fluid_wasapi.c
+++ b/src/drivers/fluid_wasapi.c
@@ -102,13 +102,6 @@ static const IID   _IID_IAudioRenderClient =
 
 #define FLUID_WASAPI_MAX_OUTPUTS 1
 
-/* Please do not change the order of the HANDLE array */
-#define FLUID_WASAPI_START 0
-#define FLUID_WASAPI_THREAD 1
-#define FLUID_WASAPI_QUIT 2
-#define FLUID_WASAPI_LAST_HANDLE FLUID_WASAPI_QUIT
-#define FLUID_WASAPI_MAX_HANDLES FLUID_WASAPI_LAST_HANDLE + 1
-
 typedef void(*fluid_wasapi_devenum_callback_t)(IMMDevice *, void *);
 
 static DWORD WINAPI fluid_wasapi_audio_run(void *p);
@@ -142,8 +135,10 @@ typedef struct
     int channels_count;
     int float_samples;
 
+    HANDLE start_ev;
+    HANDLE thread;
     DWORD thread_id;
-    HANDLE handles[FLUID_WASAPI_MAX_HANDLES];
+    HANDLE quit_ev;
 
     IAudioClient *aucl;
     IAudioRenderClient *arcl;
@@ -168,7 +163,6 @@ fluid_audio_driver_t *new_fluid_wasapi_audio_driver(fluid_settings_t *settings, 
 
 fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
 {
-    DWORD ret = 0;
     fluid_wasapi_audio_driver_t *dev = NULL;
     OSVERSIONINFOEXW vi = {sizeof(vi), 6, 0, 0, 0, {0}, 0, 0, 0, 0, 0};
 
@@ -231,41 +225,32 @@ fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
     dev->buffer_duration_reftime = (fluid_long_long_t)(dev->buffer_duration * 1e7 + .5);
     dev->periods_reftime = (fluid_long_long_t)( dev->period_size / dev->sample_rate * 1e7 + .5);
 
-    dev->handles[FLUID_WASAPI_QUIT] = CreateEvent(NULL, FALSE, FALSE, NULL);
+    dev->quit_ev = CreateEvent(NULL, FALSE, FALSE, NULL);
 
-    if(dev->handles[FLUID_WASAPI_QUIT] == NULL)
+    if(dev->quit_ev == NULL)
     {
         FLUID_LOG(FLUID_ERR, "wasapi: failed to create quit event.");
         goto cleanup;
     }
 
-    dev->handles[FLUID_WASAPI_START] = CreateEvent(NULL, FALSE, FALSE, NULL);
+    dev->start_ev = CreateEvent(NULL, FALSE, FALSE, NULL);
 
-    if(dev->handles[FLUID_WASAPI_START] == NULL)
+    if(dev->start_ev == NULL)
     {
         FLUID_LOG(FLUID_ERR, "wasapi: failed to create start event.");
         goto cleanup;
     }
 
-    dev->handles[FLUID_WASAPI_THREAD] = CreateThread(NULL, 0, fluid_wasapi_audio_run, (void *)dev, 0, &dev->thread_id);
+    dev->thread = CreateThread(NULL, 0, fluid_wasapi_audio_run, (void *)dev, 0, &dev->thread_id);
 
-    if(dev->handles[FLUID_WASAPI_THREAD] == NULL)
+    if(dev->thread == NULL)
     {
         FLUID_LOG(FLUID_ERR, "wasapi: failed to create audio thread.");
         goto cleanup;
     }
 
-    ret = WaitForMultipleObjects(2, (HANDLE *)&dev->handles, FALSE, 1000);
-    switch (ret) {
-        case WAIT_OBJECT_0:
-            return &dev->driver;
-
-        case WAIT_TIMEOUT:
-            FLUID_LOG(FLUID_WARN, "wasapi: initialization timeout!");
-            break;
-
-        default:
-            break;
+    if (WaitForMultipleObjects(2, &dev->start_ev, FALSE, 200) == WAIT_OBJECT_0) {
+        return &dev->driver;
     }
 
 cleanup:
@@ -281,27 +266,27 @@ void delete_fluid_wasapi_audio_driver(fluid_audio_driver_t *p)
 
     fluid_return_if_fail(dev != NULL);
 
-    if(dev->handles[FLUID_WASAPI_THREAD] != NULL)
+    if(dev->thread != NULL)
     {
-        SetEvent(dev->handles[FLUID_WASAPI_QUIT]);
+        SetEvent(dev->quit_ev);
 
-        if(WaitForSingleObject(dev->handles[FLUID_WASAPI_THREAD], 2000) != WAIT_OBJECT_0)
+        if(WaitForSingleObject(dev->thread, 2000) != WAIT_OBJECT_0)
         {
             FLUID_LOG(FLUID_WARN, "wasapi: couldn't join the audio thread. killing it.");
-            TerminateThread(dev->handles[FLUID_WASAPI_THREAD], 0);
+            TerminateThread(dev->thread, 0);
         }
 
-        CloseHandle(dev->handles[FLUID_WASAPI_THREAD]);
+        CloseHandle(dev->thread);
     }
 
-    if(dev->handles[FLUID_WASAPI_QUIT] != NULL)
+    if(dev->quit_ev != NULL)
     {
-        CloseHandle(dev->handles[FLUID_WASAPI_QUIT]);
+        CloseHandle(dev->quit_ev);
     }
 
-    if(dev->handles[FLUID_WASAPI_START] != NULL)
+    if(dev->start_ev != NULL)
     {
-        CloseHandle(dev->handles[FLUID_WASAPI_START]);
+        CloseHandle(dev->start_ev);
     }
 
     if(dev->drybuf)
@@ -527,7 +512,7 @@ static DWORD WINAPI fluid_wasapi_audio_run(void *p)
     }
 
     /* Signal the success of the driver initialization */
-    SetEvent(dev->handles[FLUID_WASAPI_START]);
+    SetEvent(dev->start_ev);
 
     for(;;)
     {
@@ -568,7 +553,7 @@ static DWORD WINAPI fluid_wasapi_audio_run(void *p)
             goto cleanup;
         }
 
-        if(WaitForSingleObject(dev->handles[FLUID_WASAPI_QUIT], time_to_sleep) == WAIT_OBJECT_0)
+        if(WaitForSingleObject(dev->quit_ev, time_to_sleep) == WAIT_OBJECT_0)
         {
             break;
         }

--- a/src/drivers/fluid_wasapi.c
+++ b/src/drivers/fluid_wasapi.c
@@ -331,6 +331,7 @@ static DWORD WINAPI fluid_wasapi_audio_run(void *p)
     AUDCLNT_SHAREMODE share_mode;
     OSVERSIONINFOEXW vi = {sizeof(vi), 6, 0, 0, 0, {0}, 0, 0, 0, 0, 0};
     int needs_com_uninit = FALSE;
+    int i;
 
     if(time_to_sleep < 1)
     {
@@ -478,7 +479,7 @@ static DWORD WINAPI fluid_wasapi_audio_run(void *p)
 
     FLUID_MEMSET(dev->drybuf, 0, sizeof(float *) * dev->audio_channels * 2);
 
-    for(int i = 0; i < dev->audio_channels * 2; ++i)
+    for(i = 0; i < dev->audio_channels * 2; ++i)
     {
         dev->drybuf[i] = FLUID_ARRAY(float, dev->nframes);
 

--- a/src/drivers/fluid_wasapi.c
+++ b/src/drivers/fluid_wasapi.c
@@ -231,7 +231,7 @@ fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(dev->quit_ev == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: failed to create quit event.");
+        FLUID_LOG(FLUID_ERR, "wasapi: failed to create quit event: '%s'", fluid_get_windows_error());
         goto cleanup;
     }
 
@@ -239,7 +239,7 @@ fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(dev->start_ev == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: failed to create start event.");
+        FLUID_LOG(FLUID_ERR, "wasapi: failed to create start event: '%s'", fluid_get_windows_error());
         goto cleanup;
     }
 
@@ -247,7 +247,7 @@ fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(dev->thread == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: failed to create audio thread.");
+        FLUID_LOG(FLUID_ERR, "wasapi: failed to create audio thread: '%s'", fluid_get_windows_error());
         goto cleanup;
     }
 

--- a/src/drivers/fluid_wasapi.c
+++ b/src/drivers/fluid_wasapi.c
@@ -225,7 +225,7 @@ fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
     dev->channels_count = dev->audio_channels * 2;
     dev->float_samples = (dev->sample_format == WAVE_FORMAT_IEEE_FLOAT);
     dev->buffer_duration_reftime = (fluid_long_long_t)(dev->buffer_duration * 1e7 + .5);
-    dev->periods_reftime = (fluid_long_long_t)( dev->period_size / dev->sample_rate * 1e7 + .5);
+    dev->periods_reftime = (fluid_long_long_t)(dev->period_size / dev->sample_rate * 1e7 + .5);
 
     dev->quit_ev = CreateEvent(NULL, FALSE, FALSE, NULL);
 
@@ -255,17 +255,18 @@ fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
     wait_handles[0] = dev->start_ev;
     wait_handles[1] = dev->thread;
     ret = WaitForMultipleObjects(FLUID_N_ELEMENTS(wait_handles), wait_handles, FALSE, 1000);
-    switch (ret)
+
+    switch(ret)
     {
-        case WAIT_OBJECT_0:
-            return &dev->driver;
+    case WAIT_OBJECT_0:
+        return &dev->driver;
 
-        case WAIT_TIMEOUT:
-            FLUID_LOG(FLUID_WARN, "wasapi: initialization timeout!");
-            break;
+    case WAIT_TIMEOUT:
+        FLUID_LOG(FLUID_WARN, "wasapi: initialization timeout!");
+        break;
 
-        default:
-            break;
+    default:
+        break;
     }
 
 cleanup:
@@ -422,6 +423,7 @@ static DWORD WINAPI fluid_wasapi_audio_run(void *p)
     }
 
     ret = IAudioClient_IsFormatSupported(dev->aucl, share_mode, (const WAVEFORMATEX *)&wfx, (WAVEFORMATEX **)&rwfx);
+
     if(FAILED(ret))
     {
         FLUID_LOG(FLUID_ERR, "wasapi: device doesn't support the mode we want. 0x%x", (unsigned)ret);
@@ -598,7 +600,7 @@ cleanup:
         IMMDeviceEnumerator_Release(denum);
     }
 
-    if (needs_com_uninit)
+    if(needs_com_uninit)
     {
         CoUninitialize();
     }
@@ -658,7 +660,7 @@ static void fluid_wasapi_foreach_device(fluid_wasapi_devenum_callback_t callback
 
     if(FAILED(ret))
     {
-        if (ret == RPC_E_CHANGED_MODE)
+        if(ret == RPC_E_CHANGED_MODE)
         {
             com_was_initialized = TRUE;
             FLUID_LOG(FLUID_DBG, "wasapi: COM was already initialized");
@@ -728,7 +730,7 @@ cleanup:
         IMMDeviceEnumerator_Release(denum);
     }
 
-    if (!com_was_initialized)
+    if(!com_was_initialized)
     {
         CoUninitialize();
     }


### PR DESCRIPTION
Avoid initializing COM in the caller's thread context.

See also: #833