### PR TITLE
Auto select audio driver

### DIFF
--- a/doc/fluidsynth.1
+++ b/doc/fluidsynth.1
@@ -55,6 +55,8 @@ want to deactivate the use of the shell, start FluidSynth with the \-i
 option: 'fluidsynth \-ni soundfont.sf2 midifile1.mid midifile2.mid'.
 .PP
 Run fluidsynth with the \-\-help option to check for changes in the list of options.
+.PP
+Since version 2.2.1 fluidsynth automatically probes for an available audio and midi driver, if none was explicitly specified. During auto-probing, error messages from the drivers will not be printed, unless \-\-verbose was given. Error messages will be restored, when explicitly specifying a driver with the \-a or \-m options respectively.
 .SH OPTIONS
 \fBfluidsynth\fP accepts the following options:
 

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -256,7 +256,7 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
 {
     unsigned int i;
     char *valid_options;
-    char *selected_option;
+    char *selected_option = NULL;
     fluid_audio_driver_t *driver = NULL;
     const fluid_audriver_definition_t *def;
     int auto_select = fluid_settings_str_equal(settings, "audio.driver", "auto");
@@ -327,11 +327,18 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
     else
     {
         fluid_settings_dupstr(settings, "audio.driver", &selected_option);
-        FLUID_LOG(FLUID_ERR, "Couldn't find the requested audio driver '%s'.",
-                selected_option ? selected_option : "NULL");
+        if (fluid_settings_option_is_valid(settings, "audio.driver", selected_option))
+        {
+            FLUID_LOG(FLUID_ERR, "Couldn't start the requested audio driver '%s'.",
+                    selected_option ? selected_option : "NULL");
+        }
+        else
+        {
+            FLUID_LOG(FLUID_ERR, "Invalid audio driver '%s'.",
+                    selected_option ? selected_option : "NULL");
+            FLUID_LOG(FLUID_INFO, "Valid audio drivers are: %s", valid_options);
+        }
         FLUID_FREE(selected_option);
-
-        FLUID_LOG(FLUID_INFO, "Valid audio drivers are: %s", valid_options);
     }
 
     FLUID_FREE(valid_options);

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -42,7 +42,7 @@ static const fluid_audriver_definition_t fluid_audio_drivers[] =
 {
 #if JACK_SUPPORT
     {
-        "jack",
+        "jack_client",
         new_fluid_jack_audio_driver,
         new_fluid_jack_audio_driver2,
         delete_fluid_jack_audio_driver,
@@ -77,6 +77,16 @@ static const fluid_audriver_definition_t fluid_audio_drivers[] =
         new_fluid_oss_audio_driver2,
         delete_fluid_oss_audio_driver,
         fluid_oss_audio_driver_settings
+    },
+#endif
+
+#if JACK_SUPPORT
+    {
+        "jack",
+        new_fluid_jack_audio_driver_server,
+        new_fluid_jack_audio_driver_server2,
+        delete_fluid_jack_audio_driver,
+        fluid_jack_audio_driver_settings
     },
 #endif
 
@@ -286,7 +296,7 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
         {
             if (def->new2 == NULL)
             {
-                FLUID_LOG(FLUID_DBG, "'%s' does not support callback mode", def->name);
+                FLUID_LOG(FLUID_DBG, "'%s' audio driver does not support callback mode", def->name);
                 driver = NULL;
             }
             else
@@ -301,7 +311,7 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
             return driver;
         }
 
-        FLUID_LOG(FLUID_DBG, "'%s' failed to start", def->name);
+        FLUID_LOG(FLUID_DBG, "'%s' audio driver failed to start", def->name);
 
         if (auto_select)
         {
@@ -332,7 +342,7 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
                 selected_option ? selected_option : "NULL");
         FLUID_FREE(selected_option);
 
-        FLUID_LOG(FLUID_INFO, "Valid drivers are: %s", valid_options);
+        FLUID_LOG(FLUID_INFO, "Valid audio drivers are: %s", valid_options);
     }
 
     FLUID_FREE(valid_options);

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -214,7 +214,6 @@ static uint8_t fluid_adriver_disable_mask[(FLUID_N_ELEMENTS(fluid_audio_drivers)
 void fluid_audio_driver_settings(fluid_settings_t *settings)
 {
     unsigned int i;
-    const char *def_name = NULL;
 
     fluid_settings_register_str(settings, "audio.sample-format", "16bits", 0);
     fluid_settings_add_option(settings, "audio.sample-format", "16bits");
@@ -238,12 +237,6 @@ void fluid_audio_driver_settings(fluid_settings_t *settings)
 
     for(i = 0; i < FLUID_N_ELEMENTS(fluid_audio_drivers) - 1; i++)
     {
-        /* Select the default driver */
-        if (def_name == NULL)
-        {
-            def_name = fluid_audio_drivers[i].name;
-        }
-
         /* Add the driver to the list of options */
         fluid_settings_add_option(settings, "audio.driver", fluid_audio_drivers[i].name);
 
@@ -254,11 +247,7 @@ void fluid_audio_driver_settings(fluid_settings_t *settings)
         }
     }
 
-    /* Set the default driver, if any */
-    if(def_name != NULL)
-    {
-        fluid_settings_setstr(settings, "audio.driver", def_name);
-    }
+    fluid_settings_setstr(settings, "audio.driver", "auto");
 }
 
 static fluid_audio_driver_t *

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -277,8 +277,13 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
     char *selected_option = NULL;
     fluid_audio_driver_t *driver = NULL;
     const fluid_audriver_definition_t *def;
-    int auto_select = fluid_settings_str_equal(settings, "audio.driver", "auto");
+    int probe = fluid_settings_str_equal(settings, "audio.driver", "auto");
     int flags;
+
+    if (probe)
+    {
+        FLUID_LOG(FLUID_INFO, "Trying to auto-select an audio driver");
+    }
 
     for(i = 0; i < FLUID_N_ELEMENTS(fluid_audio_drivers) - 1; i++)
     {
@@ -289,7 +294,7 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
 
         def = &fluid_audio_drivers[i];
 
-        if (!auto_select && !fluid_settings_str_equal(settings, "audio.driver", def->name))
+        if (!probe && !fluid_settings_str_equal(settings, "audio.driver", def->name))
         {
             continue;
         }
@@ -297,7 +302,7 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
         FLUID_LOG(FLUID_DBG, "Trying '%s' audio driver", def->name);
 
         flags = def->flags;
-        if (auto_select)
+        if (probe)
         {
             flags |= FLUID_AUDRIVER_PROBE;
         }
@@ -321,13 +326,17 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
 
         if (driver)
         {
+            if (probe)
+            {
+                FLUID_LOG(FLUID_INFO, "Using '%s' audio driver", def->name);
+            }
             driver->define = def;
             return driver;
         }
 
         FLUID_LOG(FLUID_DBG, "'%s' audio driver failed to start", def->name);
 
-        if (auto_select)
+        if (probe)
         {
             continue;
         }
@@ -343,7 +352,7 @@ create_fluid_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth,
         return NULL;
     }
 
-    if (auto_select)
+    if (probe)
     {
         FLUID_LOG(FLUID_ERR,
                 "Couldn't auto-select an audio driver, tried %s",

--- a/src/drivers/fluid_adriver.h
+++ b/src/drivers/fluid_adriver.h
@@ -23,10 +23,15 @@
 
 #include "fluidsynth_priv.h"
 
+enum fluid_audriver_flags
+{
+    FLUID_AUDRIVER_PROBE = 1,
+    FLUID_AUDRIVER_START_SERVER = 2,
+};
+
 /*
  * fluid_audio_driver_t
  */
-
 typedef struct _fluid_audriver_definition_t fluid_audriver_definition_t;
 
 struct _fluid_audio_driver_t
@@ -41,27 +46,27 @@ void fluid_file_renderer_settings(fluid_settings_t *settings);
 
 #if PULSE_SUPPORT
 fluid_audio_driver_t *new_fluid_pulse_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_pulse_audio_driver2(fluid_settings_t *settings,
-        fluid_audio_func_t func, void *data);
+        fluid_audio_func_t func, void *data, int flags);
 void delete_fluid_pulse_audio_driver(fluid_audio_driver_t *p);
 void fluid_pulse_audio_driver_settings(fluid_settings_t *settings);
 #endif
 
 #if ALSA_SUPPORT
 fluid_audio_driver_t *new_fluid_alsa_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
-        fluid_audio_func_t func, void *data);
+        fluid_audio_func_t func, void *data, int flags);
 void delete_fluid_alsa_audio_driver(fluid_audio_driver_t *p);
 void fluid_alsa_audio_driver_settings(fluid_settings_t *settings);
 #endif
 
 #if OSS_SUPPORT
 fluid_audio_driver_t *new_fluid_oss_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_oss_audio_driver2(fluid_settings_t *settings,
-        fluid_audio_func_t func, void *data);
+        fluid_audio_func_t func, void *data, int flags);
 void delete_fluid_oss_audio_driver(fluid_audio_driver_t *p);
 void fluid_oss_audio_driver_settings(fluid_settings_t *settings);
 #endif
@@ -69,7 +74,7 @@ void fluid_oss_audio_driver_settings(fluid_settings_t *settings);
 #if OPENSLES_SUPPORT
 fluid_audio_driver_t*
 new_fluid_opensles_audio_driver(fluid_settings_t* settings,
-		fluid_synth_t* synth);
+		fluid_synth_t* synth, int flags);
 void delete_fluid_opensles_audio_driver(fluid_audio_driver_t* p);
 void fluid_opensles_audio_driver_settings(fluid_settings_t* settings);
 #endif
@@ -77,47 +82,51 @@ void fluid_opensles_audio_driver_settings(fluid_settings_t* settings);
 #if OBOE_SUPPORT
 fluid_audio_driver_t*
 new_fluid_oboe_audio_driver(fluid_settings_t* settings,
-		fluid_synth_t* synth);
+		fluid_synth_t* synth, int flags);
 void delete_fluid_oboe_audio_driver(fluid_audio_driver_t* p);
 void fluid_oboe_audio_driver_settings(fluid_settings_t* settings);
 #endif
 
 #if COREAUDIO_SUPPORT
 fluid_audio_driver_t *new_fluid_core_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_core_audio_driver2(fluid_settings_t *settings,
         fluid_audio_func_t func,
-        void *data);
+        void *data,
+        int flags);
 void delete_fluid_core_audio_driver(fluid_audio_driver_t *p);
 void fluid_core_audio_driver_settings(fluid_settings_t *settings);
 #endif
 
 #if DSOUND_SUPPORT
 fluid_audio_driver_t *new_fluid_dsound_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
         fluid_audio_func_t func,
-        void *data);
+        void *data,
+        int flags);
 void delete_fluid_dsound_audio_driver(fluid_audio_driver_t *p);
 void fluid_dsound_audio_driver_settings(fluid_settings_t *settings);
 #endif
 
 #if WASAPI_SUPPORT
 fluid_audio_driver_t *new_fluid_wasapi_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
         fluid_audio_func_t func,
-        void *data);
+        void *data,
+        int flags);
 void delete_fluid_wasapi_audio_driver(fluid_audio_driver_t *p);
 void fluid_wasapi_audio_driver_settings(fluid_settings_t *settings);
 #endif
 
 #if WAVEOUT_SUPPORT
 fluid_audio_driver_t *new_fluid_waveout_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
         fluid_audio_func_t func,
-        void *data);
+        void *data,
+        int flags);
 void delete_fluid_waveout_audio_driver(fluid_audio_driver_t *p);
 void fluid_waveout_audio_driver_settings(fluid_settings_t *settings);
 #endif
@@ -125,17 +134,15 @@ void fluid_waveout_audio_driver_settings(fluid_settings_t *settings);
 #if PORTAUDIO_SUPPORT
 void fluid_portaudio_driver_settings(fluid_settings_t *settings);
 fluid_audio_driver_t *new_fluid_portaudio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 void delete_fluid_portaudio_driver(fluid_audio_driver_t *p);
 #endif
 
 #if JACK_SUPPORT
-fluid_audio_driver_t *new_fluid_jack_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth);
-fluid_audio_driver_t *new_fluid_jack_audio_driver_server(fluid_settings_t *settings, fluid_synth_t *synth);
+fluid_audio_driver_t *new_fluid_jack_audio_driver(fluid_settings_t *settings,
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_jack_audio_driver2(fluid_settings_t *settings,
-        fluid_audio_func_t func, void *data);
-fluid_audio_driver_t *new_fluid_jack_audio_driver_server2(fluid_settings_t *settings,
-        fluid_audio_func_t func, void *data);
+        fluid_audio_func_t func, void *data, int flags);
 void delete_fluid_jack_audio_driver(fluid_audio_driver_t *p);
 void fluid_jack_audio_driver_settings(fluid_settings_t *settings);
 int fluid_jack_obtain_synth(fluid_settings_t *settings, fluid_synth_t **synth);
@@ -143,30 +150,31 @@ int fluid_jack_obtain_synth(fluid_settings_t *settings, fluid_synth_t **synth);
 
 #if SNDMAN_SUPPORT
 fluid_audio_driver_t *new_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 fluid_audio_driver_t *new_fluid_sndmgr_audio_driver2(fluid_settings_t *settings,
         fluid_audio_func_t func,
-        void *data);
+        void *data,
+        int flags);
 void delete_fluid_sndmgr_audio_driver(fluid_audio_driver_t *p);
 #endif
 
 #if DART_SUPPORT
 fluid_audio_driver_t *new_fluid_dart_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 void delete_fluid_dart_audio_driver(fluid_audio_driver_t *p);
 void fluid_dart_audio_driver_settings(fluid_settings_t *settings);
 #endif
 
 #if SDL2_SUPPORT
 fluid_audio_driver_t *new_fluid_sdl2_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 void delete_fluid_sdl2_audio_driver(fluid_audio_driver_t *p);
 void fluid_sdl2_audio_driver_settings(fluid_settings_t *settings);
 #endif
 
 #if AUFILE_SUPPORT
 fluid_audio_driver_t *new_fluid_file_audio_driver(fluid_settings_t *settings,
-        fluid_synth_t *synth);
+        fluid_synth_t *synth, int flags);
 void delete_fluid_file_audio_driver(fluid_audio_driver_t *p);
 #endif
 

--- a/src/drivers/fluid_adriver.h
+++ b/src/drivers/fluid_adriver.h
@@ -131,7 +131,10 @@ void delete_fluid_portaudio_driver(fluid_audio_driver_t *p);
 
 #if JACK_SUPPORT
 fluid_audio_driver_t *new_fluid_jack_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth);
+fluid_audio_driver_t *new_fluid_jack_audio_driver_server(fluid_settings_t *settings, fluid_synth_t *synth);
 fluid_audio_driver_t *new_fluid_jack_audio_driver2(fluid_settings_t *settings,
+        fluid_audio_func_t func, void *data);
+fluid_audio_driver_t *new_fluid_jack_audio_driver_server2(fluid_settings_t *settings,
         fluid_audio_func_t func, void *data);
 void delete_fluid_jack_audio_driver(fluid_audio_driver_t *p);
 void fluid_jack_audio_driver_settings(fluid_settings_t *settings);

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -144,14 +144,16 @@ void fluid_alsa_audio_driver_settings(fluid_settings_t *settings)
 
 fluid_audio_driver_t *
 new_fluid_alsa_audio_driver(fluid_settings_t *settings,
-                            fluid_synth_t *synth)
+                            fluid_synth_t *synth,
+                            int flags)
 {
-    return new_fluid_alsa_audio_driver2(settings, NULL, synth);
+    return new_fluid_alsa_audio_driver2(settings, NULL, synth, flags);
 }
 
 fluid_audio_driver_t *
 new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
-                             fluid_audio_func_t func, void *data)
+                             fluid_audio_func_t func, void *data,
+                             int flags)
 {
     fluid_alsa_audio_driver_t *dev;
     double sample_rate;
@@ -638,7 +640,8 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
 fluid_midi_driver_t *
 new_fluid_alsa_rawmidi_driver(fluid_settings_t *settings,
                               handle_midi_event_func_t handler,
-                              void *data)
+                              void *data,
+                              int flags)
 {
     int i, err;
     fluid_alsa_rawmidi_driver_t *dev;
@@ -978,7 +981,8 @@ static void fluid_alsa_seq_autoconnect(fluid_alsa_seq_driver_t *dev, const snd_s
  */
 fluid_midi_driver_t *
 new_fluid_alsa_seq_driver(fluid_settings_t *settings,
-                          handle_midi_event_func_t handler, void *data)
+                          handle_midi_event_func_t handler, void *data,
+                          int flags)
 {
     int i, err;
     fluid_alsa_seq_driver_t *dev;

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -165,6 +165,7 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
     snd_pcm_sw_params_t *swparams = NULL;
     snd_pcm_uframes_t uframes;
     unsigned int tmp;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     dev = FLUID_NEW(fluid_alsa_audio_driver_t);
 
@@ -193,13 +194,13 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
     {
         if(err == -EBUSY)
         {
-            FLUID_LOG(FLUID_ERR, "The \"%s\" audio device is used by another application",
+            FLUID_LOG(err_level, "The \"%s\" audio device is used by another application",
                       device ? device : "default");
             goto error_recovery;
         }
         else
         {
-            FLUID_LOG(FLUID_ERR, "Failed to open the \"%s\" audio device",
+            FLUID_LOG(err_level, "Failed to open the \"%s\" audio device",
                       device ? device : "default");
             goto error_recovery;
         }
@@ -232,7 +233,7 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
 
         if((err = snd_pcm_hw_params_set_channels(dev->pcm, hwparams, 2)) < 0)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to set the channels: %s",
+            FLUID_LOG(err_level, "Failed to set the channels: %s",
                       snd_strerror(err));
             goto error_recovery;
         }
@@ -241,7 +242,7 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
 
         if((err = snd_pcm_hw_params_set_rate_near(dev->pcm, hwparams, &tmp, NULL)) < 0)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to set the sample rate: %s",
+            FLUID_LOG(err_level, "Failed to set the sample rate: %s",
                       snd_strerror(err));
             goto error_recovery;
         }
@@ -258,7 +259,7 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
 
         if(snd_pcm_hw_params_set_period_size_near(dev->pcm, hwparams, &uframes, &dir) < 0)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to set the period size");
+            FLUID_LOG(err_level, "Failed to set the period size");
             goto error_recovery;
         }
 
@@ -274,7 +275,7 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
 
         if(snd_pcm_hw_params_set_periods_near(dev->pcm, hwparams, &tmp, &dir) < 0)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to set the number of periods");
+            FLUID_LOG(err_level, "Failed to set the number of periods");
             goto error_recovery;
         }
 
@@ -295,7 +296,7 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
 
     if(fluid_alsa_formats[i].name == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to find an audio format supported by alsa");
+        FLUID_LOG(err_level, "Failed to find an audio format supported by alsa");
         goto error_recovery;
     }
 
@@ -319,7 +320,7 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
 
     if(snd_pcm_nonblock(dev->pcm, 0) != 0)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to set the audio device to blocking mode");
+        FLUID_LOG(err_level, "Failed to set the audio device to blocking mode");
         goto error_recovery;
     }
 
@@ -328,7 +329,7 @@ new_fluid_alsa_audio_driver2(fluid_settings_t *settings,
 
     if(!dev->thread)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to start the alsa-audio thread.");
+        FLUID_LOG(err_level, "Failed to start the alsa-audio thread.");
         goto error_recovery;
     }
 

--- a/src/drivers/fluid_aufile.c
+++ b/src/drivers/fluid_aufile.c
@@ -59,7 +59,8 @@ static int fluid_file_audio_run_s16(void *d, unsigned int msec);
 
 fluid_audio_driver_t *
 new_fluid_file_audio_driver(fluid_settings_t *settings,
-                            fluid_synth_t *synth)
+                            fluid_synth_t *synth,
+                            int flags)
 {
     fluid_file_audio_driver_t *dev;
     int msec;

--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -152,18 +152,20 @@ fluid_core_audio_driver_settings(fluid_settings_t *settings)
  * new_fluid_core_audio_driver
  */
 fluid_audio_driver_t *
-new_fluid_core_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_core_audio_driver(fluid_settings_t *settings,
+                            fluid_synth_t *synth,
+                            int flags)
 {
-    return new_fluid_core_audio_driver2(settings,
-                                        NULL,
-                                        synth);
+    return new_fluid_core_audio_driver2(settings, NULL, synth, flags);
 }
 
 /*
  * new_fluid_core_audio_driver2
  */
 fluid_audio_driver_t *
-new_fluid_core_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
+new_fluid_core_audio_driver2(fluid_settings_t *settings,
+                             fluid_audio_func_t func, void *data,
+                             int flags)
 {
     char *devname = NULL;
     fluid_core_audio_driver_t *dev = NULL;

--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -174,6 +174,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
     OSStatus status;
     UInt32 size;
     int i;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     dev = FLUID_NEW(fluid_core_audio_driver_t);
 
@@ -200,7 +201,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
 
     if(comp == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to get the default audio device");
+        FLUID_LOG(err_level, "Failed to get the default audio device");
         goto error_recovery;
     }
 
@@ -208,7 +209,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
 
     if(status != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to open the default audio device. Status=%ld\n", (long int)status);
+        FLUID_LOG(err_level, "Failed to open the default audio device. Status=%ld\n", (long int)status);
         goto error_recovery;
     }
 
@@ -225,7 +226,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
 
     if(status != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Error setting the audio callback. Status=%ld\n", (long int)status);
+        FLUID_LOG(err_level, "Error setting the audio callback. Status=%ld\n", (long int)status);
         goto error_recovery;
     }
 
@@ -269,7 +270,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
 
                             if(status != noErr)
                             {
-                                FLUID_LOG(FLUID_ERR, "Error setting the selected output device. Status=%ld\n", (long int)status);
+                                FLUID_LOG(err_level, "Error setting the selected output device. Status=%ld\n", (long int)status);
                                 goto error_recovery;
                             }
                         }
@@ -311,7 +312,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
 
     if(status != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Error setting the audio format. Status=%ld\n", (long int)status);
+        FLUID_LOG(err_level, "Error setting the audio format. Status=%ld\n", (long int)status);
         goto error_recovery;
     }
 
@@ -324,7 +325,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
 
     if(status != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to set the MaximumFramesPerSlice. Status=%ld\n", (long int)status);
+        FLUID_LOG(err_level, "Failed to set the MaximumFramesPerSlice. Status=%ld\n", (long int)status);
         goto error_recovery;
     }
 
@@ -344,7 +345,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
 
     if(status != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Error calling AudioUnitInitialize(). Status=%ld\n", (long int)status);
+        FLUID_LOG(err_level, "Error calling AudioUnitInitialize(). Status=%ld\n", (long int)status);
         goto error_recovery;
     }
 
@@ -353,7 +354,7 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings,
 
     if(status != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Error calling AudioOutputUnitStart(). Status=%ld\n", (long int)status);
+        FLUID_LOG(err_level, "Error calling AudioOutputUnitStart(). Status=%ld\n", (long int)status);
         goto error_recovery;
     }
 

--- a/src/drivers/fluid_coremidi.c
+++ b/src/drivers/fluid_coremidi.c
@@ -98,7 +98,9 @@ static void fluid_coremidi_autoconnect(fluid_coremidi_driver_t *dev, MIDIPortRef
  * new_fluid_coremidi_driver
  */
 fluid_midi_driver_t *
-new_fluid_coremidi_driver(fluid_settings_t *settings, handle_midi_event_func_t handler, void *data)
+new_fluid_coremidi_driver(fluid_settings_t *settings,
+                          handle_midi_event_func_t handler, void *data,
+                          int flags)
 {
     fluid_coremidi_driver_t *dev;
     MIDIClientRef client;

--- a/src/drivers/fluid_coremidi.c
+++ b/src/drivers/fluid_coremidi.c
@@ -110,6 +110,7 @@ new_fluid_coremidi_driver(fluid_settings_t *settings,
     char *id;
     CFStringRef str_portname;
     CFStringRef str_clientname;
+    int err_level = (flags & FLUID_MDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     /* not much use doing anything */
     if(handler == NULL)
@@ -180,7 +181,7 @@ new_fluid_coremidi_driver(fluid_settings_t *settings,
 
     if(result != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create the MIDI input client");
+        FLUID_LOG(err_level, "Failed to create the MIDI input client");
         goto error_recovery;
     }
 
@@ -192,7 +193,7 @@ new_fluid_coremidi_driver(fluid_settings_t *settings,
 
     if(result != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create the MIDI input port. MIDI input not available.");
+        FLUID_LOG(err_level, "Failed to create the MIDI input port. MIDI input not available.");
         goto error_recovery;
     }
 
@@ -204,7 +205,7 @@ new_fluid_coremidi_driver(fluid_settings_t *settings,
 
     if(result != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create input port.");
+        FLUID_LOG(err_level, "Failed to create input port.");
         goto error_recovery;
     }
 

--- a/src/drivers/fluid_dart.c
+++ b/src/drivers/fluid_dart.c
@@ -71,7 +71,9 @@ void fluid_dart_audio_driver_settings(fluid_settings_t *settings)
 
 
 fluid_audio_driver_t *
-new_fluid_dart_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_dart_audio_driver(fluid_settings_t *settings,
+                            fluid_synth_t *synth,
+                            int flags)
 {
     fluid_dart_audio_driver_t *dev;
     double sample_rate;

--- a/src/drivers/fluid_dart.c
+++ b/src/drivers/fluid_dart.c
@@ -82,6 +82,7 @@ new_fluid_dart_audio_driver(fluid_settings_t *settings,
     MCI_AMP_OPEN_PARMS AmpOpenParms;
     int i;
     ULONG rc;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     dev = FLUID_NEW(fluid_dart_audio_driver_t);
 
@@ -100,7 +101,7 @@ new_fluid_dart_audio_driver(fluid_settings_t *settings,
     /* check the format */
     if(!fluid_settings_str_equal(settings, "audio.sample-format", "16bits"))
     {
-        FLUID_LOG(FLUID_ERR, "Unhandled sample format");
+        FLUID_LOG(err_level, "Unhandled sample format");
         goto error_recovery;
     }
 
@@ -115,7 +116,7 @@ new_fluid_dart_audio_driver(fluid_settings_t *settings,
 
         if(rc != 0)
         {
-            FLUID_LOG(FLUID_ERR, "Cannot load MDM.DLL for DART due to %s", szFailedName);
+            FLUID_LOG(err_level, "Cannot load MDM.DLL for DART due to %s", szFailedName);
             goto error_recovery;
         }
 
@@ -123,7 +124,7 @@ new_fluid_dart_audio_driver(fluid_settings_t *settings,
 
         if(rc != 0)
         {
-            FLUID_LOG(FLUID_ERR, "Cannot find mciSendCommand() in MDM.DLL");
+            FLUID_LOG(err_level, "Cannot find mciSendCommand() in MDM.DLL");
             DosFreeModule(m_hmodMDM);
             m_hmodMDM = NULLHANDLE;
             goto error_recovery;
@@ -142,7 +143,7 @@ new_fluid_dart_audio_driver(fluid_settings_t *settings,
 
     if(rc != MCIERR_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Cannot open DART, rc = %lu", rc);
+        FLUID_LOG(err_level, "Cannot open DART, rc = %lu", rc);
         goto error_recovery;
     }
 
@@ -168,7 +169,7 @@ new_fluid_dart_audio_driver(fluid_settings_t *settings,
 
     if(rc != MCIERR_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Cannot setup DART, rc = %lu", rc);
+        FLUID_LOG(err_level, "Cannot setup DART, rc = %lu", rc);
         goto error_recovery;
     }
 
@@ -185,7 +186,7 @@ new_fluid_dart_audio_driver(fluid_settings_t *settings,
 
     if((USHORT)rc != MCIERR_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Cannot allocate memory for DART, rc = %lu", rc);
+        FLUID_LOG(err_level, "Cannot allocate memory for DART, rc = %lu", rc);
         goto error_recovery;
     }
 

--- a/src/drivers/fluid_dsound.c
+++ b/src/drivers/fluid_dsound.c
@@ -206,6 +206,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
     int i;
     fluid_dsound_devsel_t devsel;
     WAVEFORMATEXTENSIBLE format;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     /* create and clear the driver data */
     dev = FLUID_NEW(fluid_dsound_audio_driver_t);
@@ -256,7 +257,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
         }
         else
         {
-            FLUID_LOG(FLUID_ERR, "Unhandled sample format");
+            FLUID_LOG(err_level, "Unhandled sample format");
             goto error_recovery;
         }
     }
@@ -293,7 +294,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if(audio_channels > DSOUND_MAX_STEREO_CHANNELS)
     {
-        FLUID_LOG(FLUID_ERR, "Channels number %d exceed internal limit %d",
+        FLUID_LOG(err_level, "Channels number %d exceed internal limit %d",
                   format.Format.nChannels, DSOUND_MAX_STEREO_CHANNELS * 2);
         goto error_recovery;
     }
@@ -347,7 +348,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if(hr != DS_OK)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create the DirectSound object: '%s'", fluid_win32_error(hr));
+        FLUID_LOG(err_level, "Failed to create the DirectSound object: '%s'", fluid_win32_error(hr));
         goto error_recovery;
     }
 
@@ -355,7 +356,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if(hr != DS_OK)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to set the cooperative level: '%s'", fluid_win32_error(hr));
+        FLUID_LOG(err_level, "Failed to set the cooperative level: '%s'", fluid_win32_error(hr));
         goto error_recovery;
     }
 
@@ -364,7 +365,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if(hr != DS_OK)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to query the device capacities: '%s'", fluid_win32_error(hr));
+        FLUID_LOG(err_level, "Failed to query the device capacities: '%s'", fluid_win32_error(hr));
         goto error_recovery;
     }
 
@@ -383,7 +384,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if(hr != DS_OK)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to allocate the primary buffer: '%s'", fluid_win32_error(hr));
+        FLUID_LOG(err_level, "Failed to allocate the primary buffer: '%s'", fluid_win32_error(hr));
         goto error_recovery;
     }
 
@@ -419,7 +420,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if(hr != DS_OK)
     {
-        FLUID_LOG(FLUID_ERR, "dsound: Can't create sound buffer: '%s'", fluid_win32_error(hr));
+        FLUID_LOG(err_level, "dsound: Can't create sound buffer: '%s'", fluid_win32_error(hr));
         goto error_recovery;
     }
 
@@ -429,7 +430,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if((hr != DS_OK) || (buf1 == NULL))
     {
-        FLUID_LOG(FLUID_PANIC, "Failed to lock the audio buffer: '%s'", fluid_win32_error(hr));
+        FLUID_LOG(err_level, "Failed to lock the audio buffer: '%s'", fluid_win32_error(hr));
         goto error_recovery;
     }
 
@@ -444,7 +445,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if(dev->quit_ev == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create quit Event: '%s'", fluid_get_windows_error());
+        FLUID_LOG(err_level, "Failed to create quit Event: '%s'", fluid_get_windows_error());
         goto error_recovery;
     }
 
@@ -453,7 +454,7 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
 
     if(dev->thread == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create DSound audio thread: '%s'", fluid_get_windows_error());
+        FLUID_LOG(err_level, "Failed to create DSound audio thread: '%s'", fluid_get_windows_error());
         goto error_recovery;
     }
 

--- a/src/drivers/fluid_dsound.c
+++ b/src/drivers/fluid_dsound.c
@@ -182,13 +182,17 @@ void fluid_dsound_audio_driver_settings(fluid_settings_t *settings)
  * the driver fails and return NULL.
 */
 fluid_audio_driver_t *
-new_fluid_dsound_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_dsound_audio_driver(fluid_settings_t *settings,
+                              fluid_synth_t *synth,
+                              int flags)
 {
-    return new_fluid_dsound_audio_driver2(settings, NULL, synth);
+    return new_fluid_dsound_audio_driver2(settings, NULL, synth, flags);
 }
 
 fluid_audio_driver_t *
-new_fluid_dsound_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
+new_fluid_dsound_audio_driver2(fluid_settings_t *settings,
+                               fluid_audio_func_t func, void *data,
+                               int flags)
 {
     HRESULT hr;
     DSBUFFERDESC desc;

--- a/src/drivers/fluid_jack.c
+++ b/src/drivers/fluid_jack.c
@@ -94,6 +94,10 @@ static fluid_audio_driver_t *
 new_fluid_jack_audio_driver_LOCAL(fluid_settings_t *settings, fluid_audio_func_t func, void *data,
         int start_server);
 
+static fluid_midi_driver_t *
+new_fluid_jack_midi_driver_LOCAL(fluid_settings_t *settings,
+                           handle_midi_event_func_t handler, void *data, int start_server);
+
 void fluid_jack_driver_shutdown(void *arg);
 int fluid_jack_driver_srate(jack_nframes_t nframes, void *arg);
 int fluid_jack_driver_bufsize(jack_nframes_t nframes, void *arg);
@@ -856,12 +860,26 @@ void fluid_jack_midi_driver_settings(fluid_settings_t *settings)
     fluid_settings_register_str(settings, "midi.jack.server", "", 0);
 }
 
-/*
- * new_fluid_jack_midi_driver
- */
 fluid_midi_driver_t *
 new_fluid_jack_midi_driver(fluid_settings_t *settings,
                            handle_midi_event_func_t handler, void *data)
+{
+    return new_fluid_jack_midi_driver_LOCAL(settings, handler, data, FALSE);
+}
+
+fluid_midi_driver_t *
+new_fluid_jack_midi_driver_server(fluid_settings_t *settings,
+                           handle_midi_event_func_t handler, void *data)
+{
+    return new_fluid_jack_midi_driver_LOCAL(settings, handler, data, TRUE);
+}
+
+/*
+ * new_fluid_jack_midi_driver
+ */
+static fluid_midi_driver_t *
+new_fluid_jack_midi_driver_LOCAL(fluid_settings_t *settings,
+                           handle_midi_event_func_t handler, void *data, int start_server)
 {
     fluid_jack_midi_driver_t *dev;
 
@@ -893,7 +911,7 @@ new_fluid_jack_midi_driver(fluid_settings_t *settings,
     fluid_settings_getint(settings, "midi.autoconnect", &dev->autoconnect_inputs);
     fluid_atomic_int_set(&dev->autoconnect_is_outdated, dev->autoconnect_inputs);
 
-    dev->client_ref = new_fluid_jack_client(settings, FALSE, dev, FALSE);
+    dev->client_ref = new_fluid_jack_client(settings, FALSE, dev, start_server);
 
     if(!dev->client_ref)
     {

--- a/src/drivers/fluid_mdriver.c
+++ b/src/drivers/fluid_mdriver.c
@@ -108,7 +108,6 @@ static const fluid_mdriver_definition_t fluid_midi_drivers[] =
 void fluid_midi_driver_settings(fluid_settings_t *settings)
 {
     unsigned int i;
-    const char *def_name = NULL;
 
     fluid_settings_register_int(settings, "midi.autoconnect", 0, 0, 1, FLUID_HINT_TOGGLED);
 
@@ -119,12 +118,6 @@ void fluid_midi_driver_settings(fluid_settings_t *settings)
 
     for(i = 0; i < FLUID_N_ELEMENTS(fluid_midi_drivers) - 1; i++)
     {
-        /* Select the default driver */
-        if (def_name == NULL)
-        {
-            def_name = fluid_midi_drivers[i].name;
-        }
-    
         /* Add the driver to the list of options */
         fluid_settings_add_option(settings, "midi.driver", fluid_midi_drivers[i].name);
 
@@ -134,11 +127,7 @@ void fluid_midi_driver_settings(fluid_settings_t *settings)
         }
     }
 
-    /* Set the default driver, if any */
-    if(def_name != NULL)
-    {
-        fluid_settings_setstr(settings, "midi.driver", def_name);
-    }
+    fluid_settings_setstr(settings, "midi.driver", "auto");
 }
 
 /**

--- a/src/drivers/fluid_mdriver.c
+++ b/src/drivers/fluid_mdriver.c
@@ -160,6 +160,11 @@ fluid_midi_driver_t *new_fluid_midi_driver(fluid_settings_t *settings, handle_mi
     int probe = fluid_settings_str_equal(settings, "midi.driver", "auto");
     int flags;
 
+    if (probe)
+    {
+        FLUID_LOG(FLUID_INFO, "Trying to auto-select a MIDI driver");
+    }
+
     for(def = fluid_midi_drivers; def->name != NULL; def++)
     {
         if(!probe && !fluid_settings_str_equal(settings, "midi.driver", def->name))
@@ -179,6 +184,10 @@ fluid_midi_driver_t *new_fluid_midi_driver(fluid_settings_t *settings, handle_mi
 
         if(driver)
         {
+            if (probe)
+            {
+                FLUID_LOG(FLUID_INFO, "Using '%s' MIDI driver", def->name);
+            }
             driver->define = def;
             return driver;
         }

--- a/src/drivers/fluid_mdriver.c
+++ b/src/drivers/fluid_mdriver.c
@@ -193,11 +193,18 @@ fluid_midi_driver_t *new_fluid_midi_driver(fluid_settings_t *settings, handle_mi
     else
     {
         fluid_settings_dupstr(settings, "midi.driver", &selected_option);
-        FLUID_LOG(FLUID_ERR, "Couldn't find the requested MIDI driver '%s'.",
-                selected_option ? selected_option : "NULL");
+        if (fluid_settings_option_is_valid(settings, "midi.driver", selected_option))
+        {
+            FLUID_LOG(FLUID_ERR, "Couldn't start the requested MIDI driver '%s'.",
+                    selected_option ? selected_option : "NULL");
+        }
+        else
+        {
+            FLUID_LOG(FLUID_ERR, "Invalid MIDI driver '%s'.",
+                    selected_option ? selected_option : "NULL");
+            FLUID_LOG(FLUID_INFO, "Valid MIDI drivers are: %s", valid_options);
+        }
         FLUID_FREE(selected_option);
-
-        FLUID_LOG(FLUID_INFO, "Valid MIDI drivers are: %s", valid_options);
     }
 
     FLUID_FREE(valid_options);

--- a/src/drivers/fluid_mdriver.h
+++ b/src/drivers/fluid_mdriver.h
@@ -23,10 +23,15 @@
 
 #include "fluid_sys.h"
 
+enum fluid_mdriver_flags
+{
+    FLUID_MDRIVER_PROBE = 1,
+    FLUID_MDRIVER_RETRY = 2,
+};
+
 /*
  * fluid_midi_driver_t
  */
-
 typedef struct _fluid_mdriver_definition_t fluid_mdriver_definition_t;
 
 struct _fluid_midi_driver_t
@@ -42,13 +47,15 @@ void fluid_midi_driver_settings(fluid_settings_t *settings);
 #if ALSA_SUPPORT
 fluid_midi_driver_t *new_fluid_alsa_rawmidi_driver(fluid_settings_t *settings,
         handle_midi_event_func_t handler,
-        void *event_handler_data);
+        void *event_handler_data,
+        int flags);
 void delete_fluid_alsa_rawmidi_driver(fluid_midi_driver_t *p);
 void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings);
 
 fluid_midi_driver_t *new_fluid_alsa_seq_driver(fluid_settings_t *settings,
         handle_midi_event_func_t handler,
-        void *event_handler_data);
+        void *event_handler_data,
+        int flags);
 void delete_fluid_alsa_seq_driver(fluid_midi_driver_t *p);
 void fluid_alsa_seq_driver_settings(fluid_settings_t *settings);
 #endif
@@ -58,10 +65,8 @@ void fluid_alsa_seq_driver_settings(fluid_settings_t *settings);
 void fluid_jack_midi_driver_settings(fluid_settings_t *settings);
 fluid_midi_driver_t *new_fluid_jack_midi_driver(fluid_settings_t *settings,
         handle_midi_event_func_t handler,
-        void *data);
-fluid_midi_driver_t *new_fluid_jack_midi_driver_server(fluid_settings_t *settings,
-        handle_midi_event_func_t handler,
-        void *data);
+        void *data,
+        int flags);
 void delete_fluid_jack_midi_driver(fluid_midi_driver_t *p);
 #endif
 
@@ -69,7 +74,8 @@ void delete_fluid_jack_midi_driver(fluid_midi_driver_t *p);
 #if OSS_SUPPORT
 fluid_midi_driver_t *new_fluid_oss_midi_driver(fluid_settings_t *settings,
         handle_midi_event_func_t handler,
-        void *event_handler_data);
+        void *event_handler_data,
+        int flags);
 void delete_fluid_oss_midi_driver(fluid_midi_driver_t *p);
 void fluid_oss_midi_driver_settings(fluid_settings_t *settings);
 #endif
@@ -78,7 +84,8 @@ void fluid_oss_midi_driver_settings(fluid_settings_t *settings);
 #if WINMIDI_SUPPORT
 fluid_midi_driver_t *new_fluid_winmidi_driver(fluid_settings_t *settings,
         handle_midi_event_func_t handler,
-        void *event_handler_data);
+        void *event_handler_data,
+        int flags);
 void delete_fluid_winmidi_driver(fluid_midi_driver_t *p);
 void fluid_winmidi_midi_driver_settings(fluid_settings_t *settings);
 #endif
@@ -87,7 +94,8 @@ void fluid_winmidi_midi_driver_settings(fluid_settings_t *settings);
 #if MIDISHARE_SUPPORT
 fluid_midi_driver_t *new_fluid_midishare_midi_driver(fluid_settings_t *settings,
         handle_midi_event_func_t handler,
-        void *event_handler_data);
+        void *event_handler_data,
+        int flags);
 void delete_fluid_midishare_midi_driver(fluid_midi_driver_t *p);
 #endif
 
@@ -95,7 +103,8 @@ void delete_fluid_midishare_midi_driver(fluid_midi_driver_t *p);
 #if COREMIDI_SUPPORT
 fluid_midi_driver_t *new_fluid_coremidi_driver(fluid_settings_t *settings,
         handle_midi_event_func_t handler,
-        void *event_handler_data);
+        void *event_handler_data,
+        int flags);
 void delete_fluid_coremidi_driver(fluid_midi_driver_t *p);
 void fluid_coremidi_driver_settings(fluid_settings_t *settings);
 #endif

--- a/src/drivers/fluid_mdriver.h
+++ b/src/drivers/fluid_mdriver.h
@@ -59,6 +59,9 @@ void fluid_jack_midi_driver_settings(fluid_settings_t *settings);
 fluid_midi_driver_t *new_fluid_jack_midi_driver(fluid_settings_t *settings,
         handle_midi_event_func_t handler,
         void *data);
+fluid_midi_driver_t *new_fluid_jack_midi_driver_server(fluid_settings_t *settings,
+        handle_midi_event_func_t handler,
+        void *data);
 void delete_fluid_jack_midi_driver(fluid_midi_driver_t *p);
 #endif
 

--- a/src/drivers/fluid_midishare.c
+++ b/src/drivers/fluid_midishare.c
@@ -86,6 +86,7 @@ new_fluid_midishare_midi_driver(fluid_settings_t *settings,
 {
     fluid_midishare_midi_driver_t *dev;
     int i;
+    int err_level = (flags & FLUID_MDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     /* not much use doing anything */
     if(handler == NULL)
@@ -112,6 +113,7 @@ new_fluid_midishare_midi_driver(fluid_settings_t *settings,
 
     if(!fluid_midishare_open_driver(dev))
     {
+        FLUID_LOG(err_level, "Can not open MidiShare Application client");
         goto error_recovery;
     }
 
@@ -119,6 +121,7 @@ new_fluid_midishare_midi_driver(fluid_settings_t *settings,
 
     if(!fluid_midishare_open_appl(dev))
     {
+        FLUID_LOG(err_level, "Can not open MidiShare Driver client");
         goto error_recovery;
     }
 
@@ -130,7 +133,7 @@ new_fluid_midishare_midi_driver(fluid_settings_t *settings,
 
     if(dev->filter == 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can not allocate MidiShare filter");
+        FLUID_LOG(err_level, "Can not allocate MidiShare filter");
         goto error_recovery;
     }
 
@@ -360,7 +363,6 @@ static int fluid_midishare_open_driver(fluid_midishare_midi_driver_t *dev)
 
     if(dev->refnum < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can not open MidiShare Application client");
         return 0;
     }
 
@@ -373,7 +375,6 @@ static int fluid_midishare_open_driver(fluid_midishare_midi_driver_t *dev)
 
     if(dev->refnum < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can not open MidiShare Application client");
         return 0;
     }
 
@@ -407,7 +408,6 @@ static int fluid_midishare_open_appl(fluid_midishare_midi_driver_t *dev)
 
     if(dev->refnum < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can not open MidiShare Driver client");
         return 0;
     }
 
@@ -419,7 +419,6 @@ static int fluid_midishare_open_appl(fluid_midishare_midi_driver_t *dev)
 
     if(dev->refnum < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can not open MidiShare Driver client");
         return 0;
     }
 

--- a/src/drivers/fluid_midishare.c
+++ b/src/drivers/fluid_midishare.c
@@ -81,8 +81,8 @@ static void fluid_midishare_close_appl(fluid_midishare_midi_driver_t *dev);
  */
 fluid_midi_driver_t *
 new_fluid_midishare_midi_driver(fluid_settings_t *settings,
-                                handle_midi_event_func_t handler,
-                                void *data)
+                                handle_midi_event_func_t handler, void *data,
+                                int flags)
 {
     fluid_midishare_midi_driver_t *dev;
     int i;

--- a/src/drivers/fluid_oboe.cpp
+++ b/src/drivers/fluid_oboe.cpp
@@ -166,6 +166,7 @@ new_fluid_oboe_audio_driver(fluid_settings_t *settings,
                             int flags)
 {
     fluid_oboe_audio_driver_t *dev = nullptr;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     try
     {
@@ -211,7 +212,7 @@ new_fluid_oboe_audio_driver(fluid_settings_t *settings,
 
         if(result != Result::OK)
         {
-            FLUID_LOG(FLUID_ERR, "Unable to open Oboe audio stream");
+            FLUID_LOG(err_level, "Unable to open Oboe audio stream");
             goto error_recovery;
         }
 
@@ -223,7 +224,7 @@ new_fluid_oboe_audio_driver(fluid_settings_t *settings,
 
         if(result != Result::OK)
         {
-            FLUID_LOG(FLUID_ERR, "Unable to start Oboe audio stream");
+            FLUID_LOG(err_level, "Unable to start Oboe audio stream");
             goto error_recovery;
         }
 
@@ -235,11 +236,11 @@ new_fluid_oboe_audio_driver(fluid_settings_t *settings,
     }
     catch(const std::exception &e)
     {
-        FLUID_LOG(FLUID_ERR, "oboe: std::exception caught: %s", e.what());
+        FLUID_LOG(err_level, "oboe: std::exception caught: %s", e.what());
     }
     catch(...)
     {
-        FLUID_LOG(FLUID_ERR, "Unexpected Oboe driver initialization error");
+        FLUID_LOG(err_level, "Unexpected Oboe driver initialization error");
     }
 
 error_recovery:

--- a/src/drivers/fluid_oboe.cpp
+++ b/src/drivers/fluid_oboe.cpp
@@ -161,7 +161,9 @@ static oboe::SampleRateConversionQuality get_srate_conversion_quality(fluid_sett
  * new_fluid_oboe_audio_driver
  */
 fluid_audio_driver_t *
-new_fluid_oboe_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_oboe_audio_driver(fluid_settings_t *settings,
+                            fluid_synth_t *synth,
+                            int flags)
 {
     fluid_oboe_audio_driver_t *dev = nullptr;
 

--- a/src/drivers/fluid_opensles.c
+++ b/src/drivers/fluid_opensles.c
@@ -74,7 +74,9 @@ void fluid_opensles_audio_driver_settings(fluid_settings_t *settings)
  * new_fluid_opensles_audio_driver
  */
 fluid_audio_driver_t *
-new_fluid_opensles_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_opensles_audio_driver(fluid_settings_t *settings,
+                                fluid_synth_t *synth,
+                                int flags)
 {
     SLresult result;
     fluid_opensles_audio_driver_t *dev;

--- a/src/drivers/fluid_opensles.c
+++ b/src/drivers/fluid_opensles.c
@@ -85,6 +85,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
     int realtime_prio = 0;
     int is_sample_format_float;
     SLEngineItf engine_interface;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     dev = FLUID_NEW(fluid_opensles_audio_driver_t);
 
@@ -111,7 +112,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(!dev->engine)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create the OpenSL ES engine, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to create the OpenSL ES engine, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -119,7 +120,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to realize the OpenSL ES engine, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to realize the OpenSL ES engine, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -127,7 +128,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to retrieve the OpenSL ES engine interface, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to retrieve the OpenSL ES engine interface, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -135,7 +136,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create the OpenSL ES output mix object, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to create the OpenSL ES output mix object, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -143,7 +144,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to realize the OpenSL ES output mix object, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to realize the OpenSL ES output mix object, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -185,7 +186,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create the OpenSL ES audio player object, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to create the OpenSL ES audio player object, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -193,7 +194,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to realize the OpenSL ES audio player object, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to realize the OpenSL ES audio player object, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -202,7 +203,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to retrieve the OpenSL ES audio player interface, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to retrieve the OpenSL ES audio player interface, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -211,7 +212,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to retrieve the OpenSL ES buffer queue interface, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to retrieve the OpenSL ES buffer queue interface, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -234,7 +235,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to register the opensles_callback, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to register the opensles_callback, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -249,7 +250,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to add a buffer to the queue, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to add a buffer to the queue, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -257,7 +258,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to set OpenSL ES audio player callback events, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to set OpenSL ES audio player callback events, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 
@@ -265,7 +266,7 @@ new_fluid_opensles_audio_driver(fluid_settings_t *settings,
 
     if(result != SL_RESULT_SUCCESS)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to set OpenSL ES audio player play state to playing, error code 0x%lx", (unsigned long)result);
+        FLUID_LOG(err_level, "Failed to set OpenSL ES audio player play state to playing, error code 0x%lx", (unsigned long)result);
         goto error_recovery;
     }
 

--- a/src/drivers/fluid_oss.c
+++ b/src/drivers/fluid_oss.c
@@ -111,7 +111,9 @@ fluid_oss_audio_driver_settings(fluid_settings_t *settings)
  * new_fluid_oss_audio_driver
  */
 fluid_audio_driver_t *
-new_fluid_oss_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_oss_audio_driver(fluid_settings_t *settings,
+                           fluid_synth_t *synth,
+                           int flags)
 {
     fluid_oss_audio_driver_t *dev = NULL;
     int channels, sr, sample_size = 0, oss_format;
@@ -284,7 +286,9 @@ error_recovery:
 }
 
 fluid_audio_driver_t *
-new_fluid_oss_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
+new_fluid_oss_audio_driver2(fluid_settings_t *settings,
+                            fluid_audio_func_t func, void *data,
+                            int flags)
 {
     fluid_oss_audio_driver_t *dev = NULL;
     int channels, sr;
@@ -601,7 +605,8 @@ void fluid_oss_midi_driver_settings(fluid_settings_t *settings)
  */
 fluid_midi_driver_t *
 new_fluid_oss_midi_driver(fluid_settings_t *settings,
-                          handle_midi_event_func_t handler, void *data)
+                          handle_midi_event_func_t handler, void *data,
+                          int flags)
 {
     fluid_oss_midi_driver_t *dev;
     int realtime_prio = 0;

--- a/src/drivers/fluid_oss.c
+++ b/src/drivers/fluid_oss.c
@@ -124,6 +124,7 @@ new_fluid_oss_audio_driver(fluid_settings_t *settings,
     int realtime_prio = 0;
     char *devname = NULL;
     int format;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     dev = FLUID_NEW(fluid_oss_audio_driver_t);
 
@@ -191,13 +192,13 @@ new_fluid_oss_audio_driver(fluid_settings_t *settings,
 
     if(stat(devname, &devstat) == -1)
     {
-        FLUID_LOG(FLUID_ERR, "Device <%s> does not exists", devname);
+        FLUID_LOG(err_level, "Device <%s> does not exists", devname);
         goto error_recovery;
     }
 
     if((devstat.st_mode & S_IFCHR) != S_IFCHR)
     {
-        FLUID_LOG(FLUID_ERR, "Device <%s> is not a device file", devname);
+        FLUID_LOG(err_level, "Device <%s> is not a device file", devname);
         goto error_recovery;
     }
 
@@ -205,14 +206,14 @@ new_fluid_oss_audio_driver(fluid_settings_t *settings,
 
     if(dev->dspfd == -1)
     {
-        FLUID_LOG(FLUID_ERR, "Device <%s> could not be opened for writing: %s",
+        FLUID_LOG(err_level, "Device <%s> could not be opened for writing: %s",
                   devname, strerror(errno));
         goto error_recovery;
     }
 
     if(fluid_oss_set_queue_size(dev, sample_size, 2, queuesize, period_size) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set device buffer size");
+        FLUID_LOG(err_level, "Can't set device buffer size");
         goto error_recovery;
     }
 
@@ -220,13 +221,13 @@ new_fluid_oss_audio_driver(fluid_settings_t *settings,
 
     if(ioctl(dev->dspfd, SNDCTL_DSP_SETFMT, &oss_format) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the sample format");
+        FLUID_LOG(err_level, "Can't set the sample format");
         goto error_recovery;
     }
 
     if(oss_format != format)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the sample format");
+        FLUID_LOG(err_level, "Can't set the sample format");
         goto error_recovery;
     }
 
@@ -234,13 +235,13 @@ new_fluid_oss_audio_driver(fluid_settings_t *settings,
 
     if(ioctl(dev->dspfd, SOUND_PCM_WRITE_CHANNELS, &channels) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the number of channels");
+        FLUID_LOG(err_level, "Can't set the number of channels");
         goto error_recovery;
     }
 
     if(channels != 2)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the number of channels");
+        FLUID_LOG(err_level, "Can't set the number of channels");
         goto error_recovery;
     }
 
@@ -248,14 +249,14 @@ new_fluid_oss_audio_driver(fluid_settings_t *settings,
 
     if(ioctl(dev->dspfd, SNDCTL_DSP_SPEED, &sr) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the sample rate");
+        FLUID_LOG(err_level, "Can't set the sample rate");
         goto error_recovery;
     }
 
     if((sr < 0.95 * sample_rate) ||
             (sr > 1.05 * sample_rate))
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the sample rate");
+        FLUID_LOG(err_level, "Can't set the sample rate");
         goto error_recovery;
     }
 
@@ -299,6 +300,7 @@ new_fluid_oss_audio_driver2(fluid_settings_t *settings,
     char *devname = NULL;
     int realtime_prio = 0;
     int format;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     dev = FLUID_NEW(fluid_oss_audio_driver_t);
 
@@ -339,13 +341,13 @@ new_fluid_oss_audio_driver2(fluid_settings_t *settings,
 
     if(stat(devname, &devstat) == -1)
     {
-        FLUID_LOG(FLUID_ERR, "Device <%s> does not exists", devname);
+        FLUID_LOG(err_level, "Device <%s> does not exists", devname);
         goto error_recovery;
     }
 
     if((devstat.st_mode & S_IFCHR) != S_IFCHR)
     {
-        FLUID_LOG(FLUID_ERR, "Device <%s> is not a device file", devname);
+        FLUID_LOG(err_level, "Device <%s> is not a device file", devname);
         goto error_recovery;
     }
 
@@ -353,7 +355,7 @@ new_fluid_oss_audio_driver2(fluid_settings_t *settings,
 
     if(dev->dspfd == -1)
     {
-        FLUID_LOG(FLUID_ERR, "Device <%s> could not be opened for writing: %s",
+        FLUID_LOG(err_level, "Device <%s> could not be opened for writing: %s",
                   devname, strerror(errno));
         goto error_recovery;
     }
@@ -361,7 +363,7 @@ new_fluid_oss_audio_driver2(fluid_settings_t *settings,
 
     if(fluid_oss_set_queue_size(dev, 16, 2, queuesize, period_size) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set device buffer size");
+        FLUID_LOG(err_level, "Can't set device buffer size");
         goto error_recovery;
     }
 
@@ -369,13 +371,13 @@ new_fluid_oss_audio_driver2(fluid_settings_t *settings,
 
     if(ioctl(dev->dspfd, SNDCTL_DSP_SETFMT, &format) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the sample format");
+        FLUID_LOG(err_level, "Can't set the sample format");
         goto error_recovery;
     }
 
     if(format != AFMT_S16_LE)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the sample format");
+        FLUID_LOG(err_level, "Can't set the sample format");
         goto error_recovery;
     }
 
@@ -383,13 +385,13 @@ new_fluid_oss_audio_driver2(fluid_settings_t *settings,
 
     if(ioctl(dev->dspfd, SOUND_PCM_WRITE_CHANNELS, &channels) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the number of channels");
+        FLUID_LOG(err_level, "Can't set the number of channels");
         goto error_recovery;
     }
 
     if(channels != 2)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the number of channels");
+        FLUID_LOG(err_level, "Can't set the number of channels");
         goto error_recovery;
     }
 
@@ -397,14 +399,14 @@ new_fluid_oss_audio_driver2(fluid_settings_t *settings,
 
     if(ioctl(dev->dspfd, SNDCTL_DSP_SPEED, &sr) < 0)
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the sample rate");
+        FLUID_LOG(err_level, "Can't set the sample rate");
         goto error_recovery;
     }
 
     if((sr < 0.95 * sample_rate) ||
             (sr > 1.05 * sample_rate))
     {
-        FLUID_LOG(FLUID_ERR, "Can't set the sample rate");
+        FLUID_LOG(err_level, "Can't set the sample rate");
         goto error_recovery;
     }
 
@@ -611,6 +613,7 @@ new_fluid_oss_midi_driver(fluid_settings_t *settings,
     fluid_oss_midi_driver_t *dev;
     int realtime_prio = 0;
     char *device = NULL;
+    int err_level = (flags & FLUID_MDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     /* not much use doing anything */
     if(handler == NULL)
@@ -670,7 +673,7 @@ new_fluid_oss_midi_driver(fluid_settings_t *settings,
 
     if(fcntl(dev->fd, F_SETFL, O_NONBLOCK) == -1)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to set OSS MIDI device to non-blocking: %s",
+        FLUID_LOG(err_level, "Failed to set OSS MIDI device to non-blocking: %s",
                   strerror(errno));
         goto error_recovery;
     }

--- a/src/drivers/fluid_portaudio.c
+++ b/src/drivers/fluid_portaudio.c
@@ -203,6 +203,7 @@ new_fluid_portaudio_driver(fluid_settings_t *settings,
     double sample_rate;  /* intended sample rate */
     int period_size;     /* intended buffer size */
     PaError err;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     dev = FLUID_NEW(fluid_portaudio_driver_t);
 
@@ -216,7 +217,7 @@ new_fluid_portaudio_driver(fluid_settings_t *settings,
 
     if(err != paNoError)
     {
-        FLUID_LOG(FLUID_ERR, "Error initializing PortAudio driver: %s",
+        FLUID_LOG(err_level, "Error initializing PortAudio driver: %s",
                   Pa_GetErrorText(err));
         FLUID_FREE(dev);
         return NULL;
@@ -247,7 +248,7 @@ new_fluid_portaudio_driver(fluid_settings_t *settings,
 
         if(numDevices < 0)
         {
-            FLUID_LOG(FLUID_ERR, "PortAudio returned unexpected device count %d", numDevices);
+            FLUID_LOG(err_level, "PortAudio returned unexpected device count %d", numDevices);
             goto error_recovery;
         }
 
@@ -282,7 +283,7 @@ new_fluid_portaudio_driver(fluid_settings_t *settings,
 
         if(i == numDevices)
         {
-            FLUID_LOG(FLUID_ERR, "PortAudio device '%s' was not found", device);
+            FLUID_LOG(err_level, "PortAudio device '%s' was not found", device);
             goto error_recovery;
         }
     }
@@ -307,7 +308,7 @@ new_fluid_portaudio_driver(fluid_settings_t *settings,
     }
     else
     {
-        FLUID_LOG(FLUID_ERR, "Unknown sample format");
+        FLUID_LOG(err_level, "Unknown sample format");
         goto error_recovery;
     }
 
@@ -325,7 +326,7 @@ new_fluid_portaudio_driver(fluid_settings_t *settings,
 
     if(err != paNoError)
     {
-        FLUID_LOG(FLUID_ERR, "Error opening PortAudio stream: %s",
+        FLUID_LOG(err_level, "Error opening PortAudio stream: %s",
                   Pa_GetErrorText(err));
         goto error_recovery;
     }
@@ -334,7 +335,7 @@ new_fluid_portaudio_driver(fluid_settings_t *settings,
 
     if(err != paNoError)
     {
-        FLUID_LOG(FLUID_ERR, "Error starting PortAudio stream: %s",
+        FLUID_LOG(err_level, "Error starting PortAudio stream: %s",
                   Pa_GetErrorText(err));
         goto error_recovery;
     }

--- a/src/drivers/fluid_portaudio.c
+++ b/src/drivers/fluid_portaudio.c
@@ -193,7 +193,9 @@ fluid_portaudio_driver_settings(fluid_settings_t *settings)
  * @return pointer to the driver on success, NULL otherwise.
  */
 fluid_audio_driver_t *
-new_fluid_portaudio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_portaudio_driver(fluid_settings_t *settings,
+                           fluid_synth_t *synth,
+                           int flags)
 {
     fluid_portaudio_driver_t *dev = NULL;
     PaStreamParameters outputParams;

--- a/src/drivers/fluid_pulse.c
+++ b/src/drivers/fluid_pulse.c
@@ -94,6 +94,7 @@ new_fluid_pulse_audio_driver2(fluid_settings_t *settings,
     float *left = NULL,
            *right = NULL,
             *buf = NULL;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     dev = FLUID_NEW(fluid_pulse_audio_driver_t);
 
@@ -159,11 +160,9 @@ new_fluid_pulse_audio_driver2(fluid_settings_t *settings,
 
     if(!dev->pa_handle)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create PulseAudio connection");
+        FLUID_LOG(err_level, "Failed to create PulseAudio connection");
         goto error_recovery;
     }
-
-    FLUID_LOG(FLUID_INFO, "Using PulseAudio driver");
 
     if(func != NULL)
     {

--- a/src/drivers/fluid_pulse.c
+++ b/src/drivers/fluid_pulse.c
@@ -70,14 +70,16 @@ void fluid_pulse_audio_driver_settings(fluid_settings_t *settings)
 
 fluid_audio_driver_t *
 new_fluid_pulse_audio_driver(fluid_settings_t *settings,
-                             fluid_synth_t *synth)
+                             fluid_synth_t *synth,
+                             int flags)
 {
-    return new_fluid_pulse_audio_driver2(settings, NULL, synth);
+    return new_fluid_pulse_audio_driver2(settings, NULL, synth, flags);
 }
 
 fluid_audio_driver_t *
 new_fluid_pulse_audio_driver2(fluid_settings_t *settings,
-                              fluid_audio_func_t func, void *data)
+                              fluid_audio_func_t func, void *data,
+                              int flags)
 {
     fluid_pulse_audio_driver_t *dev;
     pa_sample_spec samplespec;

--- a/src/drivers/fluid_sdl2.c
+++ b/src/drivers/fluid_sdl2.c
@@ -96,11 +96,12 @@ new_fluid_sdl2_audio_driver(fluid_settings_t *settings,
     SDL_AudioSpec aspec, rspec;
     char *device;
     const char *dev_name;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     /* Check if SDL library has been started */
     if(!SDL_WasInit(SDL_INIT_AUDIO))
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create SDL2 audio driver, because the audio subsystem of SDL2 is not initialized.");
+        FLUID_LOG(err_level, "Failed to create SDL2 audio driver, because the audio subsystem of SDL2 is not initialized.");
         return NULL;
     }
 
@@ -118,7 +119,7 @@ new_fluid_sdl2_audio_driver(fluid_settings_t *settings,
         /* According to documentation, it MUST be a power of two */
         if((period_size & (period_size - 1)) != 0)
         {
-            FLUID_LOG(FLUID_ERR, "\"audio.period-size\" must be a power of 2 for SDL2");
+            FLUID_LOG(err_level, "\"audio.period-size\" must be a power of 2 for SDL2");
             return NULL;
         }
     }
@@ -149,7 +150,7 @@ new_fluid_sdl2_audio_driver(fluid_settings_t *settings,
     }
     else
     {
-        FLUID_LOG(FLUID_ERR, "Unhandled sample format");
+        FLUID_LOG(err_level, "Unhandled sample format");
         return NULL;
     }
 
@@ -219,7 +220,7 @@ new_fluid_sdl2_audio_driver(fluid_settings_t *settings,
 
         if(!dev->devid)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to open audio device");
+            FLUID_LOG(err_level, "Failed to open audio device");
             break;
         }
 

--- a/src/drivers/fluid_sdl2.c
+++ b/src/drivers/fluid_sdl2.c
@@ -85,7 +85,9 @@ void fluid_sdl2_audio_driver_settings(fluid_settings_t *settings)
  * new_fluid_sdl2_audio_driver
  */
 fluid_audio_driver_t *
-new_fluid_sdl2_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_sdl2_audio_driver(fluid_settings_t *settings,
+                            fluid_synth_t *synth,
+                            int flags)
 {
     fluid_sdl2_audio_driver_t *dev = NULL;
     fluid_audio_callback_t write_ptr;

--- a/src/drivers/fluid_sndmgr.c
+++ b/src/drivers/fluid_sndmgr.c
@@ -146,7 +146,9 @@ start_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
  * This implementation used the 16bit format.
  */
 fluid_audio_driver_t *
-new_fluid_sndmgr_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
+                              fluid_synth_t *synth,
+                              int flags)
 {
     fluid_sndmgr_audio_driver_t *dev = NULL;
     int period_size, periods, buffer_size;
@@ -194,7 +196,9 @@ new_fluid_sndmgr_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
  * conversion from float to 16bits in the driver.
  */
 fluid_audio_driver_t *
-new_fluid_sndmgr_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
+new_fluid_sndmgr_audio_driver2(fluid_settings_t *settings,
+                               fluid_audio_func_t func, void *data,
+                               int flags)
 {
     fluid_sndmgr_audio_driver_t *dev = NULL;
     int period_size, periods, buffer_size;

--- a/src/drivers/fluid_sndmgr.c
+++ b/src/drivers/fluid_sndmgr.c
@@ -55,7 +55,7 @@ Fixed fluid_sndmgr_double_to_fix(long double theLD);
 int
 start_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
                                 fluid_sndmgr_audio_driver_t *dev,
-                                int buffer_size)
+                                int buffer_size, int flags)
 {
     int i;
     SndDoubleBufferHeader2 *doubleHeader = NULL;
@@ -63,6 +63,7 @@ start_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
     OSErr err;
     SndChannelPtr channel = NULL;
     double sample_rate;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
 
@@ -74,7 +75,7 @@ start_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
 
     if((err != noErr) || (channel == NULL))
     {
-        FLUID_LOG(FLUID_ERR, "Failed to allocate a sound channel (error %i)", err);
+        FLUID_LOG(err_level, "Failed to allocate a sound channel (error %i)", err);
         return err;
     }
 
@@ -133,7 +134,7 @@ start_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
 
     if(err != noErr)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to start the sound driver (error %i)", err);
+        FLUID_LOG(err_level, "Failed to start the sound driver (error %i)", err);
         return err;
     }
 
@@ -152,11 +153,12 @@ new_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
 {
     fluid_sndmgr_audio_driver_t *dev = NULL;
     int period_size, periods, buffer_size;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     /* check the format */
     if(!fluid_settings_str_equal(settings, "audio.sample-format", "16bits"))
     {
-        FLUID_LOG(FLUID_ERR, "Unhandled sample format");
+        FLUID_LOG(err_level, "Unhandled sample format");
         return NULL;
     }
 
@@ -180,7 +182,7 @@ new_fluid_sndmgr_audio_driver(fluid_settings_t *settings,
     dev->data = (void *)synth;
     dev->callback = NULL;
 
-    if(start_fluid_sndmgr_audio_driver(settings, dev, buffer_size) != 0)
+    if(start_fluid_sndmgr_audio_driver(settings, dev, buffer_size, flags) != 0)
     {
         delete_fluid_sndmgr_audio_driver((fluid_audio_driver_t *)dev);
         return NULL;
@@ -233,7 +235,7 @@ new_fluid_sndmgr_audio_driver2(fluid_settings_t *settings,
     dev->data = data;
     dev->callback = func;
 
-    if(start_fluid_sndmgr_audio_driver(settings, dev, buffer_size) != 0)
+    if(start_fluid_sndmgr_audio_driver(settings, dev, buffer_size, flags) != 0)
     {
         goto error_recovery;
     }

--- a/src/drivers/fluid_wasapi.c
+++ b/src/drivers/fluid_wasapi.c
@@ -180,6 +180,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
     IMMDevice *mmdev = NULL;
     HRESULT ret;
     OSVERSIONINFOEXW vi = {sizeof(vi), 6, 0, 0, 0, {0}, 0, 0, 0, 0, 0};
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     if(!VerifyVersionInfoW(&vi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR,
                            VerSetConditionMask(VerSetConditionMask(VerSetConditionMask(0,
@@ -187,7 +188,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
                                    VER_MINORVERSION, VER_GREATER_EQUAL),
                                    VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL)))
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: this driver requires Windows Vista or newer.");
+        FLUID_LOG(err_level, "wasapi: this driver requires Windows Vista or newer.");
         return NULL;
     }
 
@@ -199,7 +200,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(audio_channels > FLUID_WASAPI_MAX_OUTPUTS)
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: channel configuration with more than one stereo pair is not supported.");
+        FLUID_LOG(err_level, "wasapi: channel configuration with more than one stereo pair is not supported.");
         return NULL;
     }
 
@@ -250,7 +251,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(FAILED(ret))
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: cannot initialize COM. 0x%x", (unsigned)ret);
+        FLUID_LOG(err_level, "wasapi: cannot initialize COM. 0x%x", (unsigned)ret);
         goto cleanup;
     }
 
@@ -261,7 +262,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(FAILED(ret))
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: cannot create device enumerator. 0x%x", (unsigned)ret);
+        FLUID_LOG(err_level, "wasapi: cannot create device enumerator. 0x%x", (unsigned)ret);
         goto cleanup;
     }
 
@@ -290,7 +291,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(FAILED(ret))
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: cannot activate audio client. 0x%x", (unsigned)ret);
+        FLUID_LOG(err_level, "wasapi: cannot activate audio client. 0x%x", (unsigned)ret);
         goto cleanup;
     }
 
@@ -318,7 +319,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(FAILED(ret))
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: device doesn't support the mode we want. 0x%x", (unsigned)ret);
+        FLUID_LOG(err_level, "wasapi: device doesn't support the mode we want. 0x%x", (unsigned)ret);
         goto cleanup;
     }
     else if(ret == S_FALSE)
@@ -350,18 +351,18 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(FAILED(ret))
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: failed to initialize audio client. 0x%x", (unsigned)ret);
+        FLUID_LOG(err_level, "wasapi: failed to initialize audio client. 0x%x", (unsigned)ret);
 
         if(ret == AUDCLNT_E_INVALID_DEVICE_PERIOD)
         {
             fluid_long_long_t defp, minp;
-            FLUID_LOG(FLUID_ERR, "wasapi: the device period size is invalid.");
+            FLUID_LOG(err_level, "wasapi: the device period size is invalid.");
 
             if(SUCCEEDED(IAudioClient_GetDevicePeriod(dev->aucl, &defp, &minp)))
             {
                 int defpf = (int)(defp / 1e7 * sample_rate);
                 int minpf = (int)(minp / 1e7 * sample_rate);
-                FLUID_LOG(FLUID_ERR, "wasapi: minimum period is %d, default period is %d. selected %d.", minpf, defpf, period_size);
+                FLUID_LOG(err_level, "wasapi: minimum period is %d, default period is %d. selected %d.", minpf, defpf, period_size);
             }
         }
 
@@ -372,7 +373,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(FAILED(ret))
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: cannot get audio buffer size. 0x%x", (unsigned)ret);
+        FLUID_LOG(err_level, "wasapi: cannot get audio buffer size. 0x%x", (unsigned)ret);
         goto cleanup;
     }
 
@@ -404,7 +405,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(FAILED(ret))
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: cannot get audio render device. 0x%x", (unsigned)ret);
+        FLUID_LOG(err_level, "wasapi: cannot get audio render device. 0x%x", (unsigned)ret);
         goto cleanup;
     }
 
@@ -417,7 +418,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(dev->quit_ev == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: failed to create quit event.");
+        FLUID_LOG(err_level, "wasapi: failed to create quit event.");
         goto cleanup;
     }
 
@@ -425,7 +426,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
     if(dev->thread == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "wasapi: failed to create audio thread.");
+        FLUID_LOG(err_level, "wasapi: failed to create audio thread.");
         goto cleanup;
     }
 

--- a/src/drivers/fluid_wasapi.c
+++ b/src/drivers/fluid_wasapi.c
@@ -144,12 +144,22 @@ typedef struct
 
 } fluid_wasapi_audio_driver_t;
 
-fluid_audio_driver_t *new_fluid_wasapi_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+fluid_audio_driver_t *
+new_fluid_wasapi_audio_driver(fluid_settings_t *settings,
+                              fluid_synth_t *synth,
+                              int flags)
 {
-    return new_fluid_wasapi_audio_driver2(settings, (fluid_audio_func_t)fluid_synth_process, synth);
+    // FIXME: remove explicit cast to fluid_audio_func_t
+    return new_fluid_wasapi_audio_driver2(
+            settings,
+            (fluid_audio_func_t)fluid_synth_process, synth,
+            flags);
 }
 
-fluid_audio_driver_t *new_fluid_wasapi_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
+fluid_audio_driver_t *
+new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
+                               fluid_audio_func_t func, void *data,
+                               int flags)
 {
     fluid_wasapi_audio_driver_t *dev = NULL;
     double sample_rate;

--- a/src/drivers/fluid_wasapi.c
+++ b/src/drivers/fluid_wasapi.c
@@ -171,7 +171,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
     int sample_size;
     int i;
     char *dname = NULL;
-    DWORD flags = 0;
+    DWORD stream_flags = 0;
     //GUID guid_float = {DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_IEEE_FLOAT)};
     WAVEFORMATEXTENSIBLE wfx;
     WAVEFORMATEXTENSIBLE *rwfx = NULL;
@@ -329,7 +329,7 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
 
         if(rwfx->Format.nSamplesPerSec != wfx.Format.nSamplesPerSec) // needs resampling
         {
-            flags = AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM;
+            stream_flags = AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM;
             vi.dwMinorVersion = 1;
 
             if(VerifyVersionInfoW(&vi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR,
@@ -339,14 +339,14 @@ new_fluid_wasapi_audio_driver2(fluid_settings_t *settings,
                                           VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL)))
                 //IAudioClient::Initialize in Vista fails with E_INVALIDARG if this flag is set
             {
-                flags |= AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+                stream_flags |= AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
             }
         }
 
         CoTaskMemFree(rwfx);
     }
 
-    ret = IAudioClient_Initialize(dev->aucl, share_mode, flags,
+    ret = IAudioClient_Initialize(dev->aucl, share_mode, stream_flags,
                                   buffer_duration_reftime, periods_reftime, (WAVEFORMATEX *)&wfx, &GUID_NULL);
 
     if(FAILED(ret))

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -289,6 +289,7 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
     WAVEFORMATEXTENSIBLE wfx;
     char dev_name[MAXPNAMELEN];
     MMRESULT errCode;
+    int err_level = (flags & FLUID_AUDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     /* Retrieve the settings */
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
@@ -329,7 +330,7 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
     }
     else
     {
-        FLUID_LOG(FLUID_ERR, "Unhandled sample format");
+        FLUID_LOG(err_level, "Unhandled sample format");
         return NULL;
     }
 
@@ -341,7 +342,7 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
 
     if(audio_channels > WAVEOUT_MAX_STEREO_CHANNELS)
     {
-        FLUID_LOG(FLUID_ERR, "Channels number %d exceed internal limit %d",
+        FLUID_LOG(err_level, "Channels number %d exceed internal limit %d",
                   wfx.Format.nChannels, WAVEOUT_MAX_STEREO_CHANNELS * 2);
         return NULL;
     }
@@ -465,7 +466,7 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
 
         if(dev->hQuit == NULL)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to create quit event: '%s'", fluid_get_windows_error());
+            FLUID_LOG(err_level, "Failed to create quit event: '%s'", fluid_get_windows_error());
             break;
         }
 
@@ -481,7 +482,7 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
 
         if(dev->hThread == NULL)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to create waveOut thread: '%s'", fluid_get_windows_error());
+            FLUID_LOG(err_level, "Failed to create waveOut thread: '%s'", fluid_get_windows_error());
             break;
         }
 
@@ -494,7 +495,7 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
 
         if(errCode != MMSYSERR_NOERROR)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to open waveOut device: '%s'", fluid_waveout_error(errCode));
+            FLUID_LOG(err_level, "Failed to open waveOut device: '%s'", fluid_waveout_error(errCode));
             break;
         }
 

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -264,13 +264,17 @@ void fluid_waveout_audio_driver_settings(fluid_settings_t *settings)
  * the driver fails and return NULL.
  */
 fluid_audio_driver_t *
-new_fluid_waveout_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+new_fluid_waveout_audio_driver(fluid_settings_t *settings,
+                               fluid_synth_t *synth,
+                               int flags)
 {
-    return new_fluid_waveout_audio_driver2(settings, NULL, synth);
+    return new_fluid_waveout_audio_driver2(settings, NULL, synth, flags);
 }
 
 fluid_audio_driver_t *
-new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func, void *data)
+new_fluid_waveout_audio_driver2(fluid_settings_t *settings,
+                                fluid_audio_func_t func, void *data,
+                                int flags)
 {
     fluid_waveout_audio_driver_t *dev = NULL;
     fluid_audio_channels_callback_t write_ptr;

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -463,7 +463,8 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char *dev_name)
  */
 fluid_midi_driver_t *
 new_fluid_winmidi_driver(fluid_settings_t *settings,
-                         handle_midi_event_func_t handler, void *data)
+                         handle_midi_event_func_t handler, void *data,
+                         int flags)
 {
     fluid_winmidi_driver_t *dev;
     MMRESULT res;

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -472,6 +472,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     int max_devices;  /* maximum number of devices to handle */
     char strError[MAXERRORLENGTH];
     char dev_name[MAXPNAMELEN];
+    int err_level = (flags & FLUID_MDRIVER_PROBE) ? FLUID_DBG : FLUID_ERR;
 
     /* not much use doing anything */
     if(handler == NULL)
@@ -493,7 +494,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     /* check if any device has be found	*/
     if(!max_devices)
     {
-        FLUID_LOG(FLUID_ERR, "Device \"%s\" does not exists", dev_name);
+        FLUID_LOG(err_level, "Device \"%s\" does not exists", dev_name);
         return NULL;
     }
 
@@ -528,7 +529,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
 
         if(res != MMSYSERR_NOERROR)
         {
-            FLUID_LOG(FLUID_ERR, "Couldn't open MIDI input: %s (error %d)",
+            FLUID_LOG(err_level, "Couldn't open MIDI input: %s (error %d)",
                       fluid_winmidi_input_error(strError, res), res);
             goto error_recovery;
         }
@@ -574,7 +575,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
 
     if(dev->hThread == NULL)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create SYSEX buffer processing thread");
+        FLUID_LOG(err_level, "Failed to create SYSEX buffer processing thread");
         goto error_recovery;
     }
 
@@ -583,7 +584,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     {
         if(midiInStart(dev->dev_infos[i].hmidiin) != MMSYSERR_NOERROR)
         {
-            FLUID_LOG(FLUID_ERR, "Failed to start the MIDI input. MIDI input not available.");
+            FLUID_LOG(err_level, "Failed to start the MIDI input. MIDI input not available.");
             goto error_recovery;
         }
     }

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -546,6 +546,7 @@ fluid_settings_register_str(fluid_settings_t *settings, const char *name, const 
         if(node->type == FLUID_STR_TYPE)
         {
             fluid_str_setting_t *setting = &node->str;
+            FLUID_FREE(setting->def);
             setting->def = def ? FLUID_STRDUP(def) : NULL;
             setting->hints = hints;
             retval = FLUID_OK;

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -1336,6 +1336,46 @@ fluid_settings_remove_option(fluid_settings_t *settings, const char *name, const
     return retval;
 }
 
+int
+fluid_settings_option_is_valid(fluid_settings_t *settings, const char *name, const char *s)
+{
+    fluid_setting_node_t *node;
+    fluid_str_setting_t *setting;
+    int retval = FALSE;
+    fluid_list_t *list;
+
+
+    fluid_return_val_if_fail(settings != NULL, retval);
+    fluid_return_val_if_fail(name != NULL, retval);
+    fluid_return_val_if_fail(name[0] != '\0', retval);
+    fluid_return_val_if_fail(s != NULL, retval);
+
+    fluid_rec_mutex_lock(settings->mutex);
+
+    if(fluid_settings_get(settings, name, &node) != FLUID_OK
+            || (node->type != FLUID_STR_TYPE))
+    {
+        goto EXIT;
+    }
+
+    setting = &node->str;
+
+    for(list = setting->options; list; list = fluid_list_next(list))
+    {
+        const char *option = fluid_list_get(list);
+
+        if (FLUID_STRCMP(s, option) == 0)
+        {
+            retval = TRUE;
+            goto EXIT;
+        }
+    }
+
+EXIT:
+    fluid_rec_mutex_unlock(settings->mutex);
+    return retval;
+}
+
 /**
  * Set a numeric value for a named setting.
  *

--- a/src/utils/fluid_settings.h
+++ b/src/utils/fluid_settings.h
@@ -24,6 +24,7 @@
 
 int fluid_settings_add_option(fluid_settings_t *settings, const char *name, const char *s);
 int fluid_settings_remove_option(fluid_settings_t *settings, const char *name, const char *s);
+int fluid_settings_option_is_valid(fluid_settings_t *settings, const char *name, const char *s);
 
 
 typedef void (*fluid_str_update_t)(void *data, const char *name, const char *value);


### PR DESCRIPTION
As mentioned in #838, this PR adds auto-selection of audio and MIDI drivers.

A new default value of "auto" is used for `midi.driver` and `audio.driver`. If a driver is set to "auto", then all available drivers are tried in the order that they appear in the `fluid_audio_drivers` and `fluid_midi_drivers` lists.

In order prevent flooding the user with lots of error messages during the probing, a new `int flags` parameter was added to the MIDI and audio driver creation functions. The flag field is set to `FLUID_(MDRIVER|AUDRIVER)_PROBE` during probing. Drivers can then change the log level or error messages accordingly (I've modified all drivers to honor this, but can't test all drivers locally).

The flag is also used to add additional info from the driver definitions list. The jack driver is currently the only driver using this to switch between simply connecting and trying to start a new server.

Still needs some more documentation and lots of testing on other platforms. And obviously feedback about the approach in general.