### PR TITLE
Make Windows CRT linkage user-selectable

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
         SET "PATH=d:\deps\bin;%PATH%"
         pkg-config --list-all
         mkdir build && cd build || exit -1
-        cmake -Werror=dev -A $(platform) -T $(toolset) -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -Denable-readline=0 -Denable-floats=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 .. || exit -1
+        cmake -Werror=dev -A $(platform) -T $(toolset) -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -Denable-readline=0 -Denable-floats=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 .. || exit -1
         cmake --build . --config Release || exit -1
       displayName: 'Compile fluidsynth'
     - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -13,14 +13,14 @@ jobs:
         gtk-bundle: $(gtk-bundle-x86)
         libsndfile-url: $(libsndfile-url-x86)
         artifact-prefix: "fluidsynth"
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
       XP_x64:
         platform: x64
         toolset: v141_xp
         gtk-bundle: $(gtk-bundle-x64)
         libsndfile-url: $(libsndfile-url-x64)
         artifact-prefix: "fluidsynth"
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
   pool:
     vmImage: $(imageName)
   steps:
@@ -157,7 +157,7 @@ jobs:
         mingw-url: $(mingw-url-x64)
         artifact-prefix: "fluidsynth-mingw"
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
     - task: DownloadBuildArtifacts@0
       inputs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@
 # CMake based build system. Pedro Lopez-Cabanillas <plcl@users.sf.net>
 
 cmake_minimum_required ( VERSION 3.1.0 ) # because of CMAKE_C_STANDARD
+
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 project ( FluidSynth C CXX )
 set ( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_admin )
 
@@ -288,30 +293,10 @@ if ( WIN32 )
 
   set ( LIBFLUID_CPPFLAGS "-DFLUIDSYNTH_DLL_EXPORTS" )
   set ( FLUID_CPPFLAGS "-DFLUIDSYNTH_NOT_A_DLL" )
-  if  ( MSVC )
-    # statically link in the CRT library to avoid a bunch of runtime DLL dependencies and allow 
-    # the CI windows builds to be run under WinXP
-    foreach ( flag_var
-        CMAKE_C_FLAGS
-        CMAKE_C_FLAGS_DEBUG
-        CMAKE_C_FLAGS_RELEASE
-        CMAKE_C_FLAGS_MINSIZEREL
-        CMAKE_C_FLAGS_RELWITHDEBINFO
-        CMAKE_CXX_FLAGS
-        CMAKE_CXX_FLAGS_DEBUG
-        CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_MINSIZEREL
-        CMAKE_CXX_FLAGS_RELWITHDEBINFO
-        )
-      if ( ${flag_var} MATCHES "/MD" )
-        string ( REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}" )
-      endif ( ${flag_var} MATCHES "/MD" )
-    endforeach ( flag_var )
-
-  else ( MSVC )
+  if  ( NOT MSVC )
     # only set debug postfix if not MSVS building
     set ( CMAKE_DEBUG_POSTFIX "_debug" )
-  endif ( MSVC )
+  endif ( NOT MSVC )
 
   # MinGW compiler (a Windows GCC port)
   if ( MINGW )

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -279,15 +279,15 @@ error_recovery:
 }
 
 /**
- * Convenience wrapper for free() that satisfies at least C90 requirements.
+ * Wrapper for free() that satisfies at least C90 requirements.
  *
  * @param ptr Pointer to memory region that should be freed
  *
- * Especially useful when using fluidsynth with programming languages that do not
- * provide malloc() and free().
- *
  * @note Only use this function when the API documentation explicitly says so. Otherwise use
  * adequate \c delete_fluid_* functions.
+ *
+ * @warning Calling ::free() on memory that is advised to be freed with fluid_free() results in undefined behaviour!
+ * (cf.: "Potential Errors Passing CRT Objects Across DLL Boundaries" found in MS Docs)
  *
  * @since 2.0.7
  */


### PR DESCRIPTION
This allows the user to select the CRT linkage via `CMAKE_MSVC_RUNTIME_LIBRARY`. If not specified, dynamic linkage becomes the default again.

Documentation of `fluid_free()` has been updated.

Resolves #840.
Supersedes and closes #842.