### PR TITLE
fluid_compare_func_t const correctness

### DIFF
--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -243,7 +243,7 @@ static int load_shdr(SFData *sf, unsigned int size);
 static int chunkid(uint32_t id);
 static int read_listchunk(SFData *sf, SFChunk *chunk);
 static int pdtahelper(SFData *sf, unsigned int expid, unsigned int reclen, SFChunk *chunk, int *size);
-static int preset_compare_func(void *a, void *b);
+static int preset_compare_func(const void *a, const void *b);
 static fluid_list_t *find_gen_by_id(int gen, fluid_list_t *genlist);
 static int valid_inst_genid(unsigned short genid);
 static int valid_preset_genid(unsigned short genid);
@@ -623,7 +623,7 @@ static int load_body(SFData *sf)
     }
 
     /* sort preset list by bank, preset # */
-    sf->preset = fluid_list_sort(sf->preset, (fluid_compare_func_t)preset_compare_func);
+    sf->preset = fluid_list_sort(sf->preset, preset_compare_func);
 
     return TRUE;
 }
@@ -2120,12 +2120,12 @@ void delete_zone(SFZone *zone)
 }
 
 /* preset sort function, first by bank, then by preset # */
-static int preset_compare_func(void *a, void *b)
+static int preset_compare_func(const void *a, const void *b)
 {
     int aval, bval;
 
-    aval = (int)(((SFPreset *)a)->bank) << 16 | ((SFPreset *)a)->prenum;
-    bval = (int)(((SFPreset *)b)->bank) << 16 | ((SFPreset *)b)->prenum;
+    aval = (int)(((const SFPreset *)a)->bank) << 16 | ((const SFPreset *)a)->prenum;
+    bval = (int)(((const SFPreset *)b)->bank) << 16 | ((const SFPreset *)b)->prenum;
 
     return (aval - bval);
 }

--- a/src/utils/fluid_list.c
+++ b/src/utils/fluid_list.c
@@ -300,11 +300,11 @@ fluid_list_t *fluid_list_insert_at(fluid_list_t *list, int n, void *data)
 /* Compare function to sort strings alphabetically,
  * for use with fluid_list_sort(). */
 int
-fluid_list_str_compare_func(void *a, void *b)
+fluid_list_str_compare_func(const void *a, const void *b)
 {
     if(a && b)
     {
-        return FLUID_STRCMP((char *)a, (char *)b);
+        return FLUID_STRCMP(a, b);
     }
 
     if(!a && !b)

--- a/src/utils/fluid_list.h
+++ b/src/utils/fluid_list.h
@@ -33,7 +33,7 @@
 
 typedef struct _fluid_list_t fluid_list_t;
 
-typedef int (*fluid_compare_func_t)(void *a, void *b);
+typedef int (*fluid_compare_func_t)(const void *a, const void *b);
 
 struct _fluid_list_t
 {
@@ -58,6 +58,6 @@ int fluid_list_size(fluid_list_t *list);
 #define fluid_list_next(slist)	((slist) ? (((fluid_list_t *)(slist))->next) : NULL)
 #define fluid_list_get(slist)	((slist) ? ((slist)->data) : NULL)
 
-int fluid_list_str_compare_func(void *a, void *b);
+int fluid_list_str_compare_func(const void *a, const void *b);
 
 #endif  /* _FLUID_LIST_H */

--- a/test/dump_sfont.c
+++ b/test/dump_sfont.c
@@ -12,7 +12,7 @@ static void dump_preset(fluid_preset_t *preset);
 static void dump_inst_zone(fluid_inst_zone_t *zone);
 static void dump_inst(fluid_inst_t *inst);
 static void dump_defsfont(fluid_defsfont_t *defsfont);
-static int inst_compare_func(void *a, void *b);
+static int inst_compare_func(const void *a, const void *b);
 static fluid_list_t *collect_preset_insts(fluid_preset_t *preset, fluid_list_t *inst_list);
 
 #define FMT_BUFSIZE (4096)
@@ -288,7 +288,7 @@ static void dump_inst(fluid_inst_t *inst)
     }
 }
 
-static int inst_compare_func(void *a, void *b)
+static int inst_compare_func(const void *a, const void *b)
 {
     const fluid_inst_t *inst_a = a;
     const fluid_inst_t *inst_b = b;
@@ -355,7 +355,7 @@ static void dump_defsfont(fluid_defsfont_t *defsfont)
         inst_list = collect_preset_insts(preset, inst_list);
     }
 
-    inst_list = fluid_list_sort(inst_list, (fluid_compare_func_t)inst_compare_func);
+    inst_list = fluid_list_sort(inst_list, inst_compare_func);
 
     fmt("instruments:");
     for (list = inst_list; list; list = fluid_list_next(list))


### PR DESCRIPTION
fluid_compare_func_t should receive const args.

Resolves #835.