### PR TITLE
[MinGW-x64] Fix some warnings for MinGW.

### DIFF
--- a/src/drivers/fluid_dsound.c
+++ b/src/drivers/fluid_dsound.c
@@ -53,7 +53,7 @@ static char *fluid_win32_error(HRESULT hr);
 /* Maximum number of stereo outputs */
 #define DSOUND_MAX_STEREO_CHANNELS 4
 /* Speakers mapping */
-const static DWORD channel_mask_speakers[DSOUND_MAX_STEREO_CHANNELS] =
+static const DWORD channel_mask_speakers[DSOUND_MAX_STEREO_CHANNELS] =
 {
     /* 1 stereo output */
     SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT,

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -52,7 +52,7 @@ static int fluid_waveout_write_processed_channels(fluid_synth_t *data, int len,
                                int channels_incr[]);
 
 /* Speakers mapping */
-const static DWORD channel_mask_speakers[WAVEOUT_MAX_STEREO_CHANNELS] =
+static const DWORD channel_mask_speakers[WAVEOUT_MAX_STEREO_CHANNELS] =
 {
     /* 1 stereo output */
     SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT,


### PR DESCRIPTION
These corrections fix this warnings on MinGW for x86_64:
`warning: ‘static’ is not at beginning of declaration [-Wold-style-declaration]`