### PR TITLE
[WINDOWS] Fix declaration of GUIDs for formats.

### DIFF
--- a/src/drivers/fluid_dsound.c
+++ b/src/drivers/fluid_dsound.c
@@ -28,6 +28,7 @@
 #if DSOUND_SUPPORT
 
 
+#include <initguid.h>
 #include <mmsystem.h>
 #include <dsound.h>
 #include <mmreg.h>
@@ -43,6 +44,12 @@ static int fluid_dsound_write_processed_channels(fluid_synth_t *data, int len,
                                int channels_incr[]);
 
 static char *fluid_win32_error(HRESULT hr);
+
+/* Helper macro for declaring GUIDs for formats */
+#define FLUID_GUID(_name, _v) DEFINE_GUID(_name, _v)
+
+FLUID_GUID(guid_format_float, DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_IEEE_FLOAT));
+FLUID_GUID(guid_format_pcm,   DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_PCM));
 
 /**
 * The driver handle multiple channels.
@@ -227,22 +234,20 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t fu
     {
         if(fluid_settings_str_equal(settings, "audio.sample-format", "float"))
         {
-            GUID guid_float = {DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_IEEE_FLOAT)};
             FLUID_LOG(FLUID_DBG, "Selected 32 bit sample format");
             dev->write = fluid_synth_write_float_channels;
             /* sample container size in bits: 32 bits */
             format.Format.wBitsPerSample = 8 * sizeof(float);
-            format.SubFormat = guid_float;
+            format.SubFormat = guid_format_float;
             format.Format.wFormatTag = WAVE_FORMAT_IEEE_FLOAT;
         }
         else if(fluid_settings_str_equal(settings, "audio.sample-format", "16bits"))
         {
-            GUID guid_pcm = {DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_PCM)};
             FLUID_LOG(FLUID_DBG, "Selected 16 bit sample format");
             dev->write = fluid_synth_write_s16_channels;
             /* sample container size in bits: 16bits */
             format.Format.wBitsPerSample = 8 * sizeof(short);
-            format.SubFormat = guid_pcm;
+            format.SubFormat = guid_format_pcm;
             format.Format.wFormatTag = WAVE_FORMAT_PCM;
         }
         else
@@ -253,12 +258,11 @@ new_fluid_dsound_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t fu
     }
     else
     {
-        GUID guid_float = {DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_IEEE_FLOAT)};
         FLUID_LOG(FLUID_DBG, "Selected 32 bit sample format");
         dev->write = fluid_dsound_write_processed_channels;
         /* sample container size in bits: 32 bits */
         format.Format.wBitsPerSample = 8 * sizeof(float);
-        format.SubFormat = guid_float;
+        format.SubFormat = guid_format_float;
         format.Format.wFormatTag = WAVE_FORMAT_IEEE_FLOAT;
         dev->drybuf = FLUID_ARRAY(float*, audio_channels * 2);
         if(dev->drybuf == NULL)

--- a/src/drivers/fluid_waveout.c
+++ b/src/drivers/fluid_waveout.c
@@ -25,8 +25,8 @@
 
 #if WAVEOUT_SUPPORT
 
+#include <initguid.h>
 #include <mmsystem.h>
-
 #include <mmreg.h>
 
 /* Those two includes are required on Windows 9x/ME */
@@ -50,6 +50,12 @@ static int fluid_waveout_write_processed_channels(fluid_synth_t *data, int len,
                                int channels_count,
                                void *channels_out[], int channels_off[],
                                int channels_incr[]);
+
+/* Helper macro for declaring GUIDs for formats */
+#define FLUID_GUID(_name, _v) DEFINE_GUID(_name, _v)
+
+FLUID_GUID(guid_format_float, DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_IEEE_FLOAT));
+FLUID_GUID(guid_format_pcm,   DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_PCM));
 
 /* Speakers mapping */
 static const DWORD channel_mask_speakers[WAVEOUT_MAX_STEREO_CHANNELS] =
@@ -300,22 +306,20 @@ new_fluid_waveout_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t f
     /* check the format */
     if(fluid_settings_str_equal(settings, "audio.sample-format", "float") || func)
     {
-        GUID guid_float = {DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_IEEE_FLOAT)};
         FLUID_LOG(FLUID_DBG, "Selected 32 bit sample format");
 
         sample_size = sizeof(float);
         write_ptr = func ? fluid_waveout_write_processed_channels : fluid_synth_write_float_channels;
-        wfx.SubFormat = guid_float;
+        wfx.SubFormat = guid_format_float;
         wfx.Format.wFormatTag = WAVE_FORMAT_IEEE_FLOAT;
     }
     else if(fluid_settings_str_equal(settings, "audio.sample-format", "16bits"))
     {
-        GUID guid_pcm = {DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_PCM)};
         FLUID_LOG(FLUID_DBG, "Selected 16 bit sample format");
 
         sample_size = sizeof(short);
         write_ptr = fluid_synth_write_s16_channels;
-        wfx.SubFormat = guid_pcm;
+        wfx.SubFormat = guid_format_pcm;
         wfx.Format.wFormatTag = WAVE_FORMAT_PCM;
     }
     else


### PR DESCRIPTION
When compiling FluidSynth for Windows, it raises these warning:

```
fluid_dsound.c:230:31: warning: missing braces around initializer [-Wmissing-braces]
  230 |             GUID guid_float = {DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_IEEE_FLOAT)};
      |                               ^
```
This happens because `DEFINE_WAVEFORMATEX_GUID()` macro is not intended to be used directly for declaring a variable, but to be used together with `DEFINE_GUID()`.
I adjusted this thing into the DSound and WaveOut driver.

After that, the build process still prints this message:

```
fluid_midi.c: In function ‘fluid_player_set_bpm’:
fluid_midi.c:2432:5: warning: ‘fluid_player_set_midi_tempo’ is deprecated [-Wdeprecated-declarations]
 2432 |     return fluid_player_set_midi_tempo(player, 60000000L / bpm);
      |     ^~~~~~
```
But this is unrelated to the port for Windows.


EDIT: from the checks below, I discovered that, unlike GCC, MSVC does not allow to do it.
Probably, the best possible things to do are:
1) use `DEFINE_GUID` with the right number of parameters or
2) use `KSDATAFORMAT_SUBTYPE_IEEE_FLOAT` and `KSDATAFORMAT_SUBTYPE_PCM` for the sub-formats and link `libfluidsynth.dll` with `ksuser` library, which provides static values for those GUIDs. (BETTER).