### PR TITLE
Make ALSA default audio driver on supported platforms

### DIFF
--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -40,16 +40,6 @@ struct _fluid_audriver_definition_t
 /* Available audio drivers, listed in order of preference */
 static const fluid_audriver_definition_t fluid_audio_drivers[] =
 {
-#if JACK_SUPPORT
-    {
-        "jack",
-        new_fluid_jack_audio_driver,
-        new_fluid_jack_audio_driver2,
-        delete_fluid_jack_audio_driver,
-        fluid_jack_audio_driver_settings
-    },
-#endif
-
 #if ALSA_SUPPORT
     {
         "alsa",
@@ -57,6 +47,16 @@ static const fluid_audriver_definition_t fluid_audio_drivers[] =
         new_fluid_alsa_audio_driver2,
         delete_fluid_alsa_audio_driver,
         fluid_alsa_audio_driver_settings
+    },
+#endif
+
+#if JACK_SUPPORT
+    {
+        "jack",
+        new_fluid_jack_audio_driver,
+        new_fluid_jack_audio_driver2,
+        delete_fluid_jack_audio_driver,
+        fluid_jack_audio_driver_settings
     },
 #endif
 


### PR DESCRIPTION
As the jack driver has a potential side-effect of starting a new server, it's not the ideal default audio driver.
ALSA does not have such side-effects and is available on many (if not all) platforms that support it. It therefore makes a better default audio driver. And having ALSA as default also makes audio and midi driver order more consistent (ALSA is already the default MIDI driver on supported platforms).

This PR is the (much) smaller solution to the problem explained in #838, that led to #843.