### PR TITLE
Avoid unnecessary pipeline runs

### DIFF
--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -1,3 +1,18 @@
+
+trigger:
+  paths:
+    include:
+      - '*'
+    exclude:
+      - '.azure/azure-pipelines-mac.yml'
+      - '.azure/azure-pipelines-vcpkg.yml'
+      - '.azure/azure-pipelines-win.yml'
+      - '.circleci/config.yml'
+      - '.github/workflows/linux.yml'
+      - '.github/workflows/sonarcloud.yml'
+      - '.cirrus.yml'
+      - 'README.md'
+
 parameters:
 - name: UseCache
   displayName: Use Dependency Cache

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -1,7 +1,17 @@
-# C/C++ with GCC
-# Build your C/C++ project with GCC using make.
-# Add steps that publish test results, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
+
+trigger:
+  paths:
+    include:
+      - '*'
+    exclude:
+      - '.azure/azure-pipelines-android.yml'
+      - '.azure/azure-pipelines-vcpkg.yml'
+      - '.azure/azure-pipelines-win.yml'
+      - '.circleci/config.yml'
+      - '.github/workflows/linux.yml'
+      - '.github/workflows/sonarcloud.yml'
+      - '.cirrus.yml'
+      - 'README.md'
 
 jobs:
 - job: macOS

--- a/.azure/azure-pipelines-vcpkg.yml
+++ b/.azure/azure-pipelines-vcpkg.yml
@@ -1,4 +1,18 @@
 
+trigger:
+  paths:
+    include:
+      - '*'
+    exclude:
+      - '.azure/azure-pipelines-android.yml'
+      - '.azure/azure-pipelines-mac.yml'
+      - '.azure/azure-pipelines-win.yml'
+      - '.circleci/config.yml'
+      - '.github/workflows/linux.yml'
+      - '.github/workflows/sonarcloud.yml'
+      - '.cirrus.yml'
+      - 'README.md'
+
 variables:
   toolset: 'v142'
   generator: 'Visual Studio 16 2019'

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -3,6 +3,20 @@
 # Add steps that publish test results, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
 
+trigger:
+  paths:
+    include:
+      - '*'
+    exclude:
+      - '.azure/azure-pipelines-android.yml'
+      - '.azure/azure-pipelines-mac.yml'
+      - '.azure/azure-pipelines-vcpkg.yml'
+      - '.circleci/config.yml'
+      - '.github/workflows/linux.yml'
+      - '.github/workflows/sonarcloud.yml'
+      - '.cirrus.yml'
+      - 'README.md'
+
 jobs:
 - job: WindowsXP
   variables:

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -1,7 +1,3 @@
-# C/C++ with GCC
-# Build your C/C++ project with GCC using make.
-# Add steps that publish test results, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
 
 trigger:
   paths:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,14 @@
 name: FluidSynth Linux
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - '.azure/**'
+      - '.circleci/**'
+      - '.github/workflows/sonarcloud.yml'
+      - '.cirrus.yml'
+      - 'README.md'
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '.azure/**'
+      - '.circleci/**'
+      - '.github/workflows/linux.yml'
+      - '.cirrus.yml'
+      - 'README.md'
   pull_request:
       types: [opened, synchronize, reopened]
-      
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   # Use Debug build for better code coverage results


### PR DESCRIPTION
Pipelines should not be triggered when other pipelines are modified. This saves many resources when messing around with a single pipeline, because other pipelines won't run.