### PR TITLE
Remove MinGW x86 CI Job

### DIFF
--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -202,7 +202,6 @@ jobs:
         cd build || exit -1
         mingw32-make.exe -j4 check || exit -1
       displayName: 'Execute Unittests'
-      continueOnError: 'true'
     - script: |
         @ECHO ON
         cd build

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -146,12 +146,6 @@ jobs:
     artifact-prefix: "fluidsynth-mingw"
   strategy:
     matrix:
-      x86:
-        CMAKE_FLAGS: -DCMAKE_C_FLAGS="-m32"
-        platform: Win32
-        gtk-bundle: $(gtk-bundle-x86)
-        libsndfile-url: $(libsndfile-url-x86)
-        mingw-url: $(mingw-url-x86)
       x64:
         CMAKE_FLAGS: 
         platform: x64


### PR DESCRIPTION
The unit tests keep failing when compiling with MinGW x86 on x64 Windows10. This is related to the change introduced in #629. The exact reason for the failure is unknown. I assume it's a broken MinGW implementation of the function `fgetpos()` or `_fseeki64()`, as the tests run fine for WindowsXP x86. However, I have little interest in further investigation, as I don't consider using MinGWx86 on x64 to be a valid use-case.