### PR TITLE
Fix broken SF3 support for Android binaries

### DIFF
--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -43,6 +43,7 @@ variables:
   INSTPATCH_VERSION: '1.1.6'
   VORBIS_VERSION: '1.3.7'
   OGG_VERSION: '1.3.4'
+  OPUS_VERSION: '1.3.1'
   # flac 1.3.3 is completely broken: pkgconfig is incorrectly installed, compilation failure, etc.; use recent master instead
   FLAC_VERSION: '27c615706cedd252a206dd77e3910dfa395dcc49'
 
@@ -157,6 +158,9 @@ jobs:
 
         wget -O flac-${FLAC_VERSION}.tar.gz https://github.com/xiph/flac/archive/${FLAC_VERSION}.tar.gz
         tar xf flac-${FLAC_VERSION}.tar.gz
+
+        wget -O opus-${OPUS_VERSION}.tar.gz https://github.com/xiph/opus/archive/refs/tags/v${OPUS_VERSION}.tar.gz
+        tar xf opus-${OPUS_VERSION}.tar.gz
 
       displayName: 'Download Dependencies'
       workingDirectory: $(DEV)
@@ -492,6 +496,18 @@ jobs:
         cat flac-${FLAC_VERSION}/build/CMakeFiles/CMakeError.log
         true
       displayName: 'Print FLAC Cmake Error Log'
+      condition: always()
+      workingDirectory: $(DEV)
+
+    - template: cmake-android.yml
+      parameters:
+        sourceDir: 'opus-$(OPUS_VERSION)'
+
+    - script: |
+        ls -la opus-${OPUS_VERSION}/build/CMakeFiles/
+        cat opus-${OPUS_VERSION}/build/CMakeFiles/CMakeError.log
+        true
+      displayName: 'Print OPUS Cmake Error Log'
       condition: always()
       workingDirectory: $(DEV)
 

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -499,10 +499,11 @@ jobs:
       condition: always()
       workingDirectory: $(DEV)
 
+    # another broken xiph project that doesn't specify the C standard and keeps complaining of you don't have C99
     - template: cmake-android.yml
       parameters:
         sourceDir: 'opus-$(OPUS_VERSION)'
-        cmakeArgs: '-DBUILD_PROGRAMS=0 -DOPUS_MAY_HAVE_NEON=1'
+        cmakeArgs: '-DBUILD_PROGRAMS=0 -DOPUS_MAY_HAVE_NEON=1 -DCMAKE_C_STANDARD=99 -DCMAKE_C_STANDARD_REQUIRED=1'
 
     - script: |
         ls -la opus-${OPUS_VERSION}/build/CMakeFiles/

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -502,7 +502,7 @@ jobs:
     - template: cmake-android.yml
       parameters:
         sourceDir: 'opus-$(OPUS_VERSION)'
-        cmakeArgs: '-DBUILD_PROGRAMS=0'
+        cmakeArgs: '-DBUILD_PROGRAMS=0 -DOPUS_MAY_HAVE_NEON=1'
 
     - script: |
         ls -la opus-${OPUS_VERSION}/build/CMakeFiles/
@@ -511,29 +511,6 @@ jobs:
       displayName: 'Print OPUS Cmake Error Log'
       condition: always()
       workingDirectory: $(DEV)
-
-    - script: |
-        set -ex
-
-        pushd opus-${OPUS_VERSION}
-        NOCONFIGURE=true ./autogen.sh
-        ./configure \
-          --host=${AUTOTOOLS_TARGET} \
-          --prefix=${PREFIX} \
-          --disable-rpath \
-          --disable-static \
-          --enable-shared \
-          --with-pic \
-          --disable-maintainer-mode \
-          --disable-silent-rules \
-          --disable-nls
-        make -j$((`nproc`+1))
-        make install
-        popd
-
-      displayName: 'Compile opus'
-      workingDirectory: $(DEV)
-      condition: ne(variables.CACHE_RESTORED, 'true')
 
     - template: cmake-android.yml
       parameters:

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -77,7 +77,7 @@ variables:
   # Tell configure what flags Android requires.
   # Turn Wimplicit-function-declaration into errors. Else autotools will be fooled when checking for available functions (that in fact are NOT available) and compilation will fail later on.
   # Also disable clangs integrated assembler, as the hand written assembly of libffi is not recognized by it, cf. https://crbug.com/801303
-  CFLAGS: "-fPIE -fPIC -I$(PREFIX)/include --sysroot=$(NDK_TOOLCHAIN)/sysroot -I$(NDK_TOOLCHAIN)/sysroot/usr/include -std=gnu99 -Werror=implicit-function-declaration -fno-integrated-as"
+  CFLAGS: "-fPIE -fPIC -I$(PREFIX)/include --sysroot=$(NDK_TOOLCHAIN)/sysroot -I$(NDK_TOOLCHAIN)/sysroot/usr/include -Werror=implicit-function-declaration -fno-integrated-as"
   CXXFLAGS: $(CFLAGS)
   CPPFLAGS: $(CXXFLAGS)
 

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -625,6 +625,7 @@ jobs:
         ls libintl.so
         ls liboboe.so
         ls libogg.so
+        ls libopus.so
         ls libsndfile.so
         ls libvorbis.so
         ls libvorbisenc.so

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -77,7 +77,7 @@ variables:
   # Tell configure what flags Android requires.
   # Turn Wimplicit-function-declaration into errors. Else autotools will be fooled when checking for available functions (that in fact are NOT available) and compilation will fail later on.
   # Also disable clangs integrated assembler, as the hand written assembly of libffi is not recognized by it, cf. https://crbug.com/801303
-  CFLAGS: "-fPIE -fPIC -I$(PREFIX)/include --sysroot=$(NDK_TOOLCHAIN)/sysroot -I$(NDK_TOOLCHAIN)/sysroot/usr/include -Werror=implicit-function-declaration -fno-integrated-as"
+  CFLAGS: "-fPIE -fPIC -I$(PREFIX)/include --sysroot=$(NDK_TOOLCHAIN)/sysroot -I$(NDK_TOOLCHAIN)/sysroot/usr/include -std=gnu99 -Werror=implicit-function-declaration -fno-integrated-as"
   CXXFLAGS: $(CFLAGS)
   CPPFLAGS: $(CXXFLAGS)
 
@@ -167,7 +167,7 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '$(ARCH) | $(DEV)/*.tar.gz | cacheVersion1'
+        key: '$(ARCH) | $(DEV)/*.tar.gz | cacheVersion2'
         path: '$(PREFIX)'
         cacheHitVar: 'CACHE_RESTORED'
       displayName: 'Cache fluidsynth dependency libraries'

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -502,6 +502,7 @@ jobs:
     - template: cmake-android.yml
       parameters:
         sourceDir: 'opus-$(OPUS_VERSION)'
+        cmakeArgs: '-DBUILD_PROGRAMS=0'
 
     - script: |
         ls -la opus-${OPUS_VERSION}/build/CMakeFiles/
@@ -510,6 +511,29 @@ jobs:
       displayName: 'Print OPUS Cmake Error Log'
       condition: always()
       workingDirectory: $(DEV)
+
+    - script: |
+        set -ex
+
+        pushd opus-${OPUS_VERSION}
+        NOCONFIGURE=true ./autogen.sh
+        ./configure \
+          --host=${AUTOTOOLS_TARGET} \
+          --prefix=${PREFIX} \
+          --disable-rpath \
+          --disable-static \
+          --enable-shared \
+          --with-pic \
+          --disable-maintainer-mode \
+          --disable-silent-rules \
+          --disable-nls
+        make -j$((`nproc`+1))
+        make install
+        popd
+
+      displayName: 'Compile opus'
+      workingDirectory: $(DEV)
+      condition: ne(variables.CACHE_RESTORED, 'true')
 
     - template: cmake-android.yml
       parameters:

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -508,6 +508,7 @@ jobs:
     - script: |
         ls -la opus-${OPUS_VERSION}/build/CMakeFiles/
         cat opus-${OPUS_VERSION}/build/CMakeFiles/CMakeError.log
+        cat opus-${OPUS_VERSION}/build/CMakeFiles/CMakeOutput.log
         true
       displayName: 'Print OPUS Cmake Error Log'
       condition: always()

--- a/.azure/cmake-android.yml
+++ b/.azure/cmake-android.yml
@@ -41,7 +41,7 @@ steps:
         -DANDROID_COMPILER_FLAGS="${CFLAGS// /;}" \
         -DANDROID_LINKER_FLAGS="${LDFLAGS// /;}" \
         -DANDROID_STL="c++_shared" \
-        -DCMAKE_REQUIRED_FLAGS="-std=gnu99 ${CFLAGS}" \
+        -DCMAKE_REQUIRED_FLAGS="${CFLAGS}" \
         -DCMAKE_REQUIRED_LINK_OPTIONS="${LDFLAGS// /;}" \
         -DCMAKE_INSTALL_PREFIX=${PREFIX} \
         -DCMAKE_STAGING_PREFIX=${PREFIX} \

--- a/.azure/cmake-android.yml
+++ b/.azure/cmake-android.yml
@@ -41,7 +41,7 @@ steps:
         -DANDROID_COMPILER_FLAGS="${CFLAGS// /;}" \
         -DANDROID_LINKER_FLAGS="${LDFLAGS// /;}" \
         -DANDROID_STL="c++_shared" \
-        -DCMAKE_REQUIRED_FLAGS="${CFLAGS}" \
+        -DCMAKE_REQUIRED_FLAGS="-std=gnu99 ${CFLAGS}" \
         -DCMAKE_REQUIRED_LINK_OPTIONS="${LDFLAGS// /;}" \
         -DCMAKE_INSTALL_PREFIX=${PREFIX} \
         -DCMAKE_STAGING_PREFIX=${PREFIX} \

--- a/.azure/cmake-android.yml
+++ b/.azure/cmake-android.yml
@@ -33,6 +33,7 @@ steps:
     cmake -G "Unix Makefiles" \
         -DCMAKE_MAKE_PROGRAM=make \
         -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DANDROID_NATIVE_API_LEVEL=${ANDROID_API} \
         -DANDROID_ABI=${ANDROID_ABI_CMAKE} \
         -DANDROID_TOOLCHAIN=${CC} \


### PR DESCRIPTION
Libsndfile was unintentionally compiled without OGG/Vorbis support. That's because libopus was missing. When compiling libsndfile with autotools [you get a nice warning](https://github.com/libsndfile/libsndfile/blob/9349a566e298ef6d6bed6c275dc1f5502bb2e028/configure.ac#L381-L386). When using CMake you don't...

Solution: Compile libopus before compiling libsndfile. Now it reports

```
-- The following features have been enabled:

 * ENABLE_EXTERNAL_LIBS, enable FLAC, Vorbis, and Opus codecs
```

Should be merged before #888.