### PR TITLE
Fix bad router behaviour.

### DIFF
--- a/src/midi/fluid_midi_router.c
+++ b/src/midi/fluid_midi_router.c
@@ -700,20 +700,20 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
         chan = rule->chan_add + (int)((fluid_real_t)event->channel * rule->chan_mul
                      + (fluid_real_t)0.5);
 
-        /* We skip the rule if chan is out of range */
+        /* We skip the event if chan is out of range */
         if((chan < 0) || (chan >= router->nr_midi_channels))
         {
-           continue;
+           continue; /* go to next rule */
         }
 
         /* Par 1 scaling / offset */
         par1 = rule->par1_add + (int)((fluid_real_t)event_par1 * rule->par1_mul
                      + (fluid_real_t)0.5);
 
-        /* We skip the rule if par1 is out of range */
+        /* We skip the event if par1 is out of range */
         if((par1 < 0) || (par1 > par1_max))
         {
-           continue;
+           continue; /* go to next rule */
         }
 
         /* Par 2 scaling / offset, if applicable */
@@ -722,10 +722,10 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
             par2 = rule->par2_add + (int)((fluid_real_t)event_par2 * rule->par2_mul
                          + (fluid_real_t)0.5);
 
-            /* We skip the rule if par2 is out of range */
+            /* We skip the event if par2 is out of range */
             if((par2 < 0) || (par2 > par2_max))
             {
-                continue;
+                continue; /* go to next rule */
             }
         }
         else

--- a/src/midi/fluid_midi_router.c
+++ b/src/midi/fluid_midi_router.c
@@ -700,52 +700,37 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
         chan = rule->chan_add + (int)((fluid_real_t)event->channel * rule->chan_mul
                      + (fluid_real_t)0.5);
 
+        /* We skip the rule if chan is out of range */
+        if((chan < 0) || (chan >= router->nr_midi_channels))
+        {
+           continue;
+        }
+
         /* Par 1 scaling / offset */
         par1 = rule->par1_add + (int)((fluid_real_t)event_par1 * rule->par1_mul
                      + (fluid_real_t)0.5);
+
+        /* We skip the rule if par1 is out of range */
+        if((par1 < 0) || (par1 > par1_max))
+        {
+           continue;
+        }
 
         /* Par 2 scaling / offset, if applicable */
         if(event_has_par2)
         {
             par2 = rule->par2_add + (int)((fluid_real_t)event_par2 * rule->par2_mul
                          + (fluid_real_t)0.5);
+
+            /* We skip the rule if par2 is out of range */
+            if((par2 < 0) || (par2 > par2_max))
+            {
+                continue;
+            }
         }
         else
         {
             par2 = 0;
-        }
-
-        /* Channel range limiting */
-        if(chan < 0)
-        {
-            chan = 0;
-        }
-        else if(chan >= router->nr_midi_channels)
-        {
-            chan = router->nr_midi_channels - 1;
-        }
-
-        /* Par1 range limiting */
-        if(par1 < 0)
-        {
-            par1 = 0;
-        }
-        else if(par1 > par1_max)
-        {
-            par1 = par1_max;
-        }
-
-        /* Par2 range limiting */
-        if(event_has_par2)
-        {
-            if(par2 < 0)
-            {
-                par2 = 0;
-            }
-            else if(par2 > par2_max)
-            {
-                par2 = par2_max;
-            }
         }
 
         /* At this point we have to create an event of event->type on 'chan' with par1 (maybe par2).

--- a/src/midi/fluid_midi_router.c
+++ b/src/midi/fluid_midi_router.c
@@ -564,9 +564,10 @@ fluid_midi_router_rule_set_param2(fluid_midi_router_rule_t *rule, int min, int m
  * - To get full benefice of the rule the value is clamped and the event passed to the output.
  * - To avoid MIDI messages conflicts at the output, the event is ignored
  *   (i.e not passed to the output).
- * chan value: event is ignored regardless of the event type
- * par1: event is ignored for PROG_CHANGE or CONTROL_CHANGE type, par1 is clamped otherwise.
- * par2: par2 is clamped regardless of the event type.
+ * chan out of range: event is ignored regardless of the event type.
+ * par1 out of range: event is ignored for PROG_CHANGE or CONTROL_CHANGE type,
+ *                    par1 is clamped otherwise.
+ * par2 out of range: par2 is clamped regardless of the event type.
  */
 int
 fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
@@ -739,7 +740,7 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
             continue; /* go to next rule */
         }
 
-        /* Par 1 scaling / offset */
+        /* par 1 scaling / offset */
         par1 = rule->par1_add + (int)((fluid_real_t)event_par1 * rule->par1_mul
                      + (fluid_real_t)0.5);
 
@@ -754,7 +755,7 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
         }
         else
         {
-            /* Par1 range clamping */
+            /* par1 range clamping */
             if(par1 < 0)
             {
                 par1 = 0;
@@ -765,13 +766,13 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
             }
         }
 
-        /* Par 2 scaling / offset, if applicable */
+        /* par 2 scaling / offset, if applicable */
         if(event_has_par2)
         {
             par2 = rule->par2_add + (int)((fluid_real_t)event_par2 * rule->par2_mul
                          + (fluid_real_t)0.5);
 
-            /* Par2 range clamping */
+            /* par2 range clamping */
             if(par2 < 0)
             {
                 par2 = 0;

--- a/src/midi/fluid_midi_router.c
+++ b/src/midi/fluid_midi_router.c
@@ -703,7 +703,8 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
         /* We skip the event if chan is out of range */
         if((chan < 0) || (chan >= router->nr_midi_channels))
         {
-           continue; /* go to next rule */
+            ret_val = FLUID_FAILED;
+            continue; /* go to next rule */
         }
 
         /* Par 1 scaling / offset */
@@ -713,7 +714,8 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
         /* We skip the event if par1 is out of range */
         if((par1 < 0) || (par1 > par1_max))
         {
-           continue; /* go to next rule */
+            ret_val = FLUID_FAILED;
+            continue; /* go to next rule */
         }
 
         /* Par 2 scaling / offset, if applicable */
@@ -725,6 +727,7 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
             /* We skip the event if par2 is out of range */
             if((par2 < 0) || (par2 > par2_max))
             {
+                ret_val = FLUID_FAILED;
                 continue; /* go to next rule */
             }
         }

--- a/src/midi/fluid_midi_router.c
+++ b/src/midi/fluid_midi_router.c
@@ -558,16 +558,16 @@ fluid_midi_router_rule_set_param2(fluid_midi_router_rule_t *rule, int min, int m
  * - get rid of aftertouch
  * - ...
  *
- * Note: Each input event have values (chan, par1, par2) that could be changed by a rule.
- * After a rule had been applied on any value and the value is out of range, the event
- * can be ignored or the value can be clamped depending of the type of the event:
+ * @note Each input event has values (ch, par1, par2) that could be changed by a rule.
+ * After a rule has been applied on any value and the value is out of range, the event
+ * can be either ignored or the value can be clamped depending on the type of the event:
  * - To get full benefice of the rule the value is clamped and the event passed to the output.
  * - To avoid MIDI messages conflicts at the output, the event is ignored
  *   (i.e not passed to the output).
- * chan out of range: event is ignored regardless of the event type.
- * par1 out of range: event is ignored for PROG_CHANGE or CONTROL_CHANGE type,
- *                    par1 is clamped otherwise.
- * par2 out of range: par2 is clamped regardless of the event type.
+ *   - ch out of range: event is ignored regardless of the event type.
+ *   - par1 out of range: event is ignored for PROG_CHANGE or CONTROL_CHANGE type,
+ *     par1 is clamped otherwise.
+ *   - par2 out of range: par2 is clamped regardless of the event type.
  */
 int
 fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)

--- a/src/midi/fluid_midi_router.c
+++ b/src/midi/fluid_midi_router.c
@@ -536,7 +536,10 @@ fluid_midi_router_rule_set_param2(fluid_midi_router_rule_t *rule, int min, int m
  *   this function can be used as a callback for other subsystems
  *   (new_fluid_midi_driver() for example).
  * @param event MIDI event to handle
- * @return #FLUID_OK on success, #FLUID_FAILED otherwise
+ * @return #FLUID_OK if all rules were applied successfully, #FLUID_FAILED if
+ *  an error occurred while applying a rule or (since 2.2.2) the event was
+ *  ignored because a parameter was out-of-range after the rule had been applied.
+ *  See the note below.
  *
  * Purpose: The midi router is called for each event, that is received
  * via the 'physical' midi input. Each event can trigger an arbitrary number
@@ -554,6 +557,16 @@ fluid_midi_router_rule_set_param2(fluid_midi_router_rule_t *rule, int min, int m
  * - velocity switching ("v <=100: Angel Choir; V > 100: Hell's Bells")
  * - get rid of aftertouch
  * - ...
+ *
+ * Note: Each input event have values (chan, par1, par2) that could be changed by a rule.
+ * After a rule had been applied on any value and the value is out of range, the event
+ * can be ignored or the value can be clamped depending of the type of the event:
+ * - To get full benefice of the rule the value is clamped and the event passed to the output.
+ * - To avoid MIDI messages conflicts at the output, the event is ignored
+ *   (i.e not passed to the output).
+ * chan value: event is ignored regardless of the event type
+ * par1: event is ignored for PROG_CHANGE or CONTROL_CHANGE type, par1 is clamped otherwise.
+ * par2: par2 is clamped regardless of the event type.
  */
 int
 fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
@@ -561,6 +574,9 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
     fluid_midi_router_t *router = (fluid_midi_router_t *)data;
     fluid_midi_router_rule_t **rulep, *rule, *next_rule, *prev_rule = NULL;
     int event_has_par2 = 0; /* Flag, indicates that current event needs two parameters */
+    int is_par1_ignored = 0; /* Flag, indicates that current event should be
+                                ignored/clamped when par1 is getting out of range
+                                value after the rule had been applied:1:ignored, 0:clamped */
     int par1_max = 127;     /* Range limit for par1 */
     int par2_max = 127;     /* Range limit for par2 */
     int ret_val = FLUID_OK;
@@ -585,34 +601,50 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
     /* Depending on the event type, choose the correct list of rules. */
     switch(event->type)
     {
+    /* For NOTE_ON event, par1(pitch) and par2(velocity) will be clamped if
+       they are out of range after the rule had been applied */
     case NOTE_ON:
         rulep = &router->rules[FLUID_MIDI_ROUTER_RULE_NOTE];
         event_has_par2 = 1;
         break;
 
+    /* For NOTE_OFF event, par1(pitch) and par2(velocity) will be clamped if
+       they are out of range after the rule had been applied */
     case NOTE_OFF:
         rulep = &router->rules[FLUID_MIDI_ROUTER_RULE_NOTE];
         event_has_par2 = 1;
         break;
 
+    /* CONTROL_CHANGE event will be ignored if par1 (ctrl num) is out
+       of range after the rule had been applied */
     case CONTROL_CHANGE:
         rulep = &router->rules[FLUID_MIDI_ROUTER_RULE_CC];
         event_has_par2 = 1;
+        is_par1_ignored = 1;
         break;
 
+    /* PROGRAM_CHANGE event will be ignored if par1 (program num) is out
+       of range after the rule had been applied */
     case PROGRAM_CHANGE:
         rulep = &router->rules[FLUID_MIDI_ROUTER_RULE_PROG_CHANGE];
+        is_par1_ignored = 1;
         break;
 
+    /* For PITCH_BEND event, par1(bend value) will be clamped if
+       it is out of range after the rule had been applied */
     case PITCH_BEND:
         rulep = &router->rules[FLUID_MIDI_ROUTER_RULE_PITCH_BEND];
         par1_max = 16383;
         break;
 
+    /* For CHANNEL_PRESSURE event, par1(pressure value) will be clamped if
+       it is out of range after the rule had been applied */
     case CHANNEL_PRESSURE:
         rulep = &router->rules[FLUID_MIDI_ROUTER_RULE_CHANNEL_PRESSURE];
         break;
 
+    /* For KEY_PRESSURE event, par1(pitch) and par2(pressure value) will be
+       clamped if they are out of range after the rule had been applied */
     case KEY_PRESSURE:
         rulep = &router->rules[FLUID_MIDI_ROUTER_RULE_KEY_PRESSURE];
         event_has_par2 = 1;
@@ -700,7 +732,7 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
         chan = rule->chan_add + (int)((fluid_real_t)event->channel * rule->chan_mul
                      + (fluid_real_t)0.5);
 
-        /* We skip the event if chan is out of range */
+        /* We ignore the event if chan is out of range */
         if((chan < 0) || (chan >= router->nr_midi_channels))
         {
             ret_val = FLUID_FAILED;
@@ -711,11 +743,26 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
         par1 = rule->par1_add + (int)((fluid_real_t)event_par1 * rule->par1_mul
                      + (fluid_real_t)0.5);
 
-        /* We skip the event if par1 is out of range */
-        if((par1 < 0) || (par1 > par1_max))
+        if(is_par1_ignored)
         {
-            ret_val = FLUID_FAILED;
-            continue; /* go to next rule */
+            /* We ignore the event if par1 is out of range */
+            if((par1 < 0) || (par1 > par1_max))
+            {
+                ret_val = FLUID_FAILED;
+                continue; /* go to next rule */
+            }
+        }
+        else
+        {
+            /* Par1 range clamping */
+            if(par1 < 0)
+            {
+                par1 = 0;
+            }
+            else if(par1 > par1_max)
+            {
+                par1 = par1_max;
+            }
         }
 
         /* Par 2 scaling / offset, if applicable */
@@ -724,11 +771,14 @@ fluid_midi_router_handle_midi_event(void *data, fluid_midi_event_t *event)
             par2 = rule->par2_add + (int)((fluid_real_t)event_par2 * rule->par2_mul
                          + (fluid_real_t)0.5);
 
-            /* We skip the event if par2 is out of range */
-            if((par2 < 0) || (par2 > par2_max))
+            /* Par2 range clamping */
+            if(par2 < 0)
             {
-                ret_val = FLUID_FAILED;
-                continue; /* go to next rule */
+                par2 = 0;
+            }
+            else if(par2 > par2_max)
+            {
+                par2 = par2_max;
             }
         }
         else


### PR DESCRIPTION
Actually, while passing an input event through a rule, if `chan, par1, par2` fields are out of range they are silently bounded to internal valid limit. This leads to an incorrect MIDI message forwarded to the router output which could interfere with previous message forwarded on the same MIDI channel.

To fix this issue, if `chan, par1, par2` fields are out of range than the rule is simply skipped.