### PR TITLE
Include header files in Android Artifacts

### DIFF
--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -601,11 +601,14 @@ jobs:
 
     - script: |
         set -ex
-        mkdir -p $(Build.ArtifactStagingDirectory)/$(ARCH)
-        cd $(Build.ArtifactStagingDirectory)/$(ARCH)
+        mkdir -p $(Build.ArtifactStagingDirectory)/lib/$(ARCH)
+        cd $(Build.ArtifactStagingDirectory)/lib/$(ARCH)
         cp -a $(PREFIX)/lib/* .
         ls -Rg .
         rm -rf *.dll *.alias gettext/ libtextstyle.* *.a *.la
+        mkdir -p $(Build.ArtifactStagingDirectory)/include
+        cd $(Build.ArtifactStagingDirectory)/include
+        cp -a $(PREFIX)/include/fluidsynth* .
       displayName: 'Collecting artifacts'
     
     - script: |

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -601,8 +601,8 @@ jobs:
 
     - script: |
         set -ex
-        mkdir -p $(Build.ArtifactStagingDirectory)/lib/$(ARCH)
-        cd $(Build.ArtifactStagingDirectory)/lib/$(ARCH)
+        mkdir -p $(Build.ArtifactStagingDirectory)/lib/$(ANDROID_ABI_CMAKE)
+        cd $(Build.ArtifactStagingDirectory)/lib/$(ANDROID_ABI_CMAKE)
         cp -LR $(PREFIX)/lib/* .
         ls -Rg .
         rm -rf *.dll *.alias gettext/ libtextstyle.* *.a *.la
@@ -638,7 +638,7 @@ jobs:
       workingDirectory: '$(PREFIX)/lib'
 
     - task: PublishBuildArtifacts@1
-      displayName: 'Publishing Artefacts for Android API$(ANDROID_API) $(ARCH)'
+      displayName: 'Publishing Artefacts for Android API$(ANDROID_API) $(ANDROID_ABI_CMAKE)'
       inputs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: '$(ARTIFACT_NAME)'

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -603,9 +603,10 @@ jobs:
         set -ex
         mkdir -p $(Build.ArtifactStagingDirectory)/lib/$(ARCH)
         cd $(Build.ArtifactStagingDirectory)/lib/$(ARCH)
-        cp -a $(PREFIX)/lib/* .
+        cp -LR $(PREFIX)/lib/* .
         ls -Rg .
         rm -rf *.dll *.alias gettext/ libtextstyle.* *.a *.la
+        rm -f .so.*
         mkdir -p $(Build.ArtifactStagingDirectory)/include
         cd $(Build.ArtifactStagingDirectory)/include
         cp -a $(PREFIX)/include/fluidsynth* .

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -606,7 +606,7 @@ jobs:
         cp -LR $(PREFIX)/lib/* .
         ls -Rg .
         rm -rf *.dll *.alias gettext/ libtextstyle.* *.a *.la
-        rm -f .so.*
+        rm -f *.so.*
         mkdir -p $(Build.ArtifactStagingDirectory)/include
         cd $(Build.ArtifactStagingDirectory)/include
         cp -a $(PREFIX)/include/fluidsynth* .

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -601,6 +601,7 @@ jobs:
 
     - script: |
         set -ex
+        # use ANDROID_ABI_CMAKE so libs can be simply copied to the archive contents in src/main/jniLibs
         mkdir -p $(Build.ArtifactStagingDirectory)/lib/$(ANDROID_ABI_CMAKE)
         cd $(Build.ArtifactStagingDirectory)/lib/$(ANDROID_ABI_CMAKE)
         cp -LR $(PREFIX)/lib/* .


### PR DESCRIPTION
Include header files and remove symbolic links to `so.x.y`. I had to change the folder structure a bit, it should be self-explaining though.

Resolves #894.