### PR TITLE
Keep pedaling (sustain or sostenuto) effective when the same note is played more than once.

### DIFF
--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -6819,8 +6819,9 @@ fluid_synth_release_voice_on_same_note_LOCAL(fluid_synth_t *synth, int chan,
                 synth->storeid = fluid_voice_get_id(voice);
             }
 
-            /* Force the voice into release stage (pedaling is ignored) */
-            fluid_voice_release(voice);
+            /* Force the voice into release stage except if pedaling
+               (sostenuto or sustain) is active */
+            fluid_voice_noteoff(voice);
         }
     }
 }


### PR DESCRIPTION
When playing the same note more than once the previous note is forced in release stage except if pedaling (sostenuto or sustain) is active. This makes it sound more like a real piano. See https://lists.nongnu.org/archive/html/fluid-dev/2021-06/msg00001.html