### PR TITLE
autoconnect all available effects ports

### DIFF
--- a/src/drivers/fluid_jack.c
+++ b/src/drivers/fluid_jack.c
@@ -639,7 +639,7 @@ new_fluid_jack_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func
             }
 
             o = 0;
-            for(i = 0; jack_ports[i] && i < 2 * dev->num_fx_ports; ++i)
+            for(i = 0; i < 2 * dev->num_fx_ports; ++i)
             {
                 err = jack_connect(client, jack_port_name(dev->fx_ports[i]), jack_ports[o++]);
 


### PR DESCRIPTION
Step through all available effects outputs and connect them to jack inputs, and wrap around if there are fewer input ports than effects outputs.