### PR TITLE
only send all_notes_off when stopping player

### DIFF
--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2088,7 +2088,11 @@ fluid_player_callback(void *data, unsigned int msec)
 
     if(fluid_player_get_status(player) != FLUID_PLAYER_PLAYING)
     {
-        fluid_synth_all_notes_off(synth, -1);
+        if (fluid_player_get_status(player) == FLUID_PLAYER_STOPPING)
+        {
+            fluid_synth_all_notes_off(synth, -1);
+            fluid_atomic_int_set(&player->status, FLUID_PLAYER_DONE);
+        }
         return 1;
     }
     do
@@ -2197,7 +2201,7 @@ fluid_player_play(fluid_player_t *player)
 int
 fluid_player_stop(fluid_player_t *player)
 {
-    fluid_atomic_int_set(&player->status, FLUID_PLAYER_DONE);
+    fluid_atomic_int_set(&player->status, FLUID_PLAYER_STOPPING);
     fluid_player_seek(player, fluid_player_get_current_tick(player));
     return FLUID_OK;
 }

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2448,6 +2448,13 @@ int fluid_player_set_bpm(fluid_player_t *player, int bpm)
 int
 fluid_player_join(fluid_player_t *player)
 {
+    if(player->use_system_timer)
+    {
+        if(!fluid_timer_is_running(player->system_timer)) /* player has finished */
+        {
+            return FLUID_OK;
+        }
+    }
     while(fluid_player_get_status(player) != FLUID_PLAYER_DONE)
     {
         fluid_msleep(10);

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -1577,12 +1577,12 @@ fluid_track_send_events(fluid_track_t *track,
             return;
         }
 
-        /* 		printf("track=%02d\tticks=%05u\ttrack=%05u\tdtime=%05u\tnext=%05u\n", */
-        /* 		       track->num, */
-        /* 		       ticks, */
-        /* 		       track->ticks, */
-        /* 		       event->dtime, */
-        /* 		       track->ticks + event->dtime); */
+        /*         printf("track=%02d\tticks=%05u\ttrack=%05u\tdtime=%05u\tnext=%05u\n", */
+        /*                track->num, */
+        /*                ticks, */
+        /*                track->ticks, */
+        /*                event->dtime, */
+        /*                track->ticks + event->dtime); */
 
         if(track->ticks + event->dtime > ticks)
         {
@@ -1651,6 +1651,7 @@ new_fluid_player(fluid_synth_t *synth)
     }
 
     fluid_atomic_int_set(&player->status, FLUID_PLAYER_READY);
+    fluid_atomic_int_set(&player->stopping, 0);
     player->loop = 1;
     player->ntracks = 0;
 
@@ -1786,9 +1787,9 @@ fluid_player_reset(fluid_player_t *player)
         }
     }
 
-    /*	player->current_file = NULL; */
-    /*	player->status = FLUID_PLAYER_READY; */
-    /*	player->loop = 1; */
+    /*    player->current_file = NULL; */
+    /*    player->status = FLUID_PLAYER_READY; */
+    /*    player->loop = 1; */
     player->ntracks = 0;
     player->division = 0;
     player->miditempo = 500000;
@@ -2088,10 +2089,10 @@ fluid_player_callback(void *data, unsigned int msec)
 
     if(fluid_player_get_status(player) != FLUID_PLAYER_PLAYING)
     {
-        if (fluid_player_get_status(player) == FLUID_PLAYER_STOPPING)
+        if(fluid_atomic_int_get(&player->stopping))
         {
             fluid_synth_all_notes_off(synth, -1);
-            fluid_atomic_int_set(&player->status, FLUID_PLAYER_DONE);
+            fluid_atomic_int_set(&player->stopping, 0);
         }
         return 1;
     }
@@ -2201,7 +2202,8 @@ fluid_player_play(fluid_player_t *player)
 int
 fluid_player_stop(fluid_player_t *player)
 {
-    fluid_atomic_int_set(&player->status, FLUID_PLAYER_STOPPING);
+    fluid_atomic_int_set(&player->status, FLUID_PLAYER_DONE);
+    fluid_atomic_int_set(&player->stopping, 1);
     fluid_player_seek(player, fluid_player_get_current_tick(player));
     return FLUID_OK;
 }

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2448,13 +2448,6 @@ int fluid_player_set_bpm(fluid_player_t *player, int bpm)
 int
 fluid_player_join(fluid_player_t *player)
 {
-    if(player->use_system_timer)
-    {
-        if(!fluid_timer_is_running(player->system_timer)) /* player has finished */
-        {
-            return FLUID_OK;
-        }
-    }
     while(fluid_player_get_status(player) != FLUID_PLAYER_DONE)
     {
         fluid_msleep(10);

--- a/src/midi/fluid_midi.h
+++ b/src/midi/fluid_midi.h
@@ -285,6 +285,7 @@ typedef struct
 struct _fluid_player_t
 {
     fluid_atomic_int_t status;
+    fluid_atomic_int_t stopping; /* Flag for sending all_notes_off when player is stopped */
     int ntracks;
     fluid_track_t *track[MAX_NUMBER_OF_TRACKS];
     fluid_synth_t *synth;

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -1263,6 +1263,7 @@ fluid_timer_join(fluid_timer_t *timer)
 int
 fluid_timer_is_running(const fluid_timer_t *timer)
 {
+    // for unit test usage only
     return timer->callback != NULL;
 }
 

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -1263,7 +1263,6 @@ fluid_timer_join(fluid_timer_t *timer)
 int
 fluid_timer_is_running(const fluid_timer_t *timer)
 {
-    // for unit test usage only
     return timer->callback != NULL;
 }
 


### PR DESCRIPTION
Repurposes the unused `FLUID_PLAYER_STOPPING` state as a flag to tell the player callback to send `fluid_synth_all_notes_off` only once after `fluid_player_stop` is called.