### PR TITLE
Emscripten: Fix CMake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(POLICY CMP0091)
 endif()
 
 project ( FluidSynth C CXX )
-set ( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_admin )
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_admin )
 
 # FluidSynth package name
 set ( PACKAGE "fluidsynth" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,12 +200,12 @@ unset ( FLUID_LIBS CACHE )
 unset ( ENABLE_UBSAN CACHE )
 
 if ( CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "Intel" )
-  if ( NOT APPLE AND NOT OS2 )
+  if ( NOT APPLE AND NOT OS2 AND NOT EMSCRIPTEN )
     set ( CMAKE_EXE_LINKER_FLAGS
           "${CMAKE_EXE_LINKER_FLAGS} -Wl,--as-needed" )
     set ( CMAKE_SHARED_LINKER_FLAGS
           "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined" )
-  endif ( NOT APPLE AND NOT OS2 )
+  endif ( NOT APPLE AND NOT OS2 AND NOT EMSCRIPTEN )
 
   # define some warning flags
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wno-unused-parameter -Wdeclaration-after-statement -Werror=implicit-function-declaration" )


### PR DESCRIPTION
Two small fixes to the CMakeLists to make fluidsynth build when using emscripten (WASM).

---

Not included (obviously):

Another major problem is glib because glib does not compile when using emscripten (it needs custom patches), so I patched out glib. With glib removed I can confirm that it works.
