### PR TITLE
cmake modernization, tasks 1 & 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # CMake based build system. Pedro Lopez-Cabanillas <plcl@users.sf.net>
 
-cmake_minimum_required ( VERSION 3.13.5 )
+cmake_minimum_required ( VERSION 3.13 )
 # 3.1 because of CMAKE_C_STANDARD
 # 3.11 because COMPATIBILITY SameMinorVersion in CMakePackageConfigHelpers
 # 3.13.5 because it is the latest supported in Windows XP
@@ -415,17 +415,15 @@ if ( enable-profiling )
     
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OPT_FLAGS}" )
     
-    if ( CMAKE_VERSION VERSION_GREATER_EQUAL "3.6.0" )
-        find_program( CLANG_TIDY
-                    NAMES "clang-tidy"
-                    DOC "Path to clang-tidy executable" )
+    find_program( CLANG_TIDY
+                NAMES "clang-tidy"
+                DOC "Path to clang-tidy executable" )
 
-        if ( CLANG_TIDY )
-            message ( STATUS "Found clang-tidy at ${CLANG_TIDY}" )
-            execute_process ( COMMAND ${CLANG_TIDY} "--version" )
-            set ( CMAKE_C_CLANG_TIDY ${CLANG_TIDY} )
-        endif ( CLANG_TIDY )
-    endif ( CMAKE_VERSION VERSION_GREATER_EQUAL "3.6.0" )
+    if ( CLANG_TIDY )
+        message ( STATUS "Found clang-tidy at ${CLANG_TIDY}" )
+        execute_process ( COMMAND ${CLANG_TIDY} "--version" )
+        set ( CMAKE_C_CLANG_TIDY ${CLANG_TIDY} )
+    endif ( CLANG_TIDY )
 
 endif ( enable-profiling )
 
@@ -831,28 +829,22 @@ else ()
   set ( includedir "\${prefix}/${INCLUDE_INSTALL_DIR}" )
 endif ()
 
-if ( CMAKE_VERSION VERSION_GREATER_EQUAL "3.12.0" )
-    # retrieve all the private libs we depend on
-    get_target_property ( LIBS_PRIVATE libfluidsynth-OBJ INTERFACE_LINK_LIBRARIES)
-    # make a copy
-    set ( LIBS_PRIVATE_WITH_PATH ${LIBS_PRIVATE} )
+# retrieve all the private libs we depend on
+get_target_property ( LIBS_PRIVATE libfluidsynth-OBJ INTERFACE_LINK_LIBRARIES)
+# make a copy
+set ( LIBS_PRIVATE_WITH_PATH ${LIBS_PRIVATE} )
 
-    # this matches any path and any flag entries (starting with '-')
-    set ( LIB_LIST_REGEX "(^(.+)\/([^\/]+)$)|(^\-.*$)" )
-    # remove all entries from the list which are specified by path and which already have -l
-    list ( FILTER LIBS_PRIVATE EXCLUDE REGEX ${LIB_LIST_REGEX} )
-    # include only entries specifed by path
-    list ( FILTER LIBS_PRIVATE_WITH_PATH INCLUDE REGEX ${LIB_LIST_REGEX} )
+# this matches any path and any flag entries (starting with '-')
+set ( LIB_LIST_REGEX "(^(.+)\/([^\/]+)$)|(^\-.*$)" )
+# remove all entries from the list which are specified by path and which already have -l
+list ( FILTER LIBS_PRIVATE EXCLUDE REGEX ${LIB_LIST_REGEX} )
+# include only entries specifed by path
+list ( FILTER LIBS_PRIVATE_WITH_PATH INCLUDE REGEX ${LIB_LIST_REGEX} )
 
-    # prepend the linker flag to all entries except the ones that already have it
-    list ( TRANSFORM LIBS_PRIVATE PREPEND "-l")
-    list ( JOIN LIBS_PRIVATE " " LIBS_PRIVATE_JOINED )
-    list ( JOIN LIBS_PRIVATE_WITH_PATH " " LIBS_PRIVATE_WITH_PATH_JOINED )
-else ()
-    set ( LIBS_PRIVATE "" )
-    set ( LIBS_PRIVATE_WITH_PATH "" )
-    message ( DEPRECATION "Your version of CMake is old. A complete pkg-config file can not created. Get cmake 3.13.5 or newer." )
-endif ()
+# prepend the linker flag to all entries except the ones that already have it
+list ( TRANSFORM LIBS_PRIVATE PREPEND "-l")
+list ( JOIN LIBS_PRIVATE " " LIBS_PRIVATE_JOINED )
+list ( JOIN LIBS_PRIVATE_WITH_PATH " " LIBS_PRIVATE_WITH_PATH_JOINED )
 
 configure_file ( fluidsynth.pc.in
 	${CMAKE_BINARY_DIR}/fluidsynth.pc IMMEDIATE @ONLY )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,16 @@
 
 # CMake based build system. Pedro Lopez-Cabanillas <plcl@users.sf.net>
 
-cmake_minimum_required ( VERSION 3.1.0 ) # because of CMAKE_C_STANDARD
+cmake_minimum_required ( VERSION 3.13.5 )
+# 3.1 because of CMAKE_C_STANDARD
+# 3.11 because COMPATIBILITY SameMinorVersion in CMakePackageConfigHelpers
+# 3.13.5 because it is the latest supported in Windows XP
 
-if(POLICY CMP0075)
+if(POLICY CMP0075) # CMake version 3.13.5 warns when the policy is not set or value is OLD
   cmake_policy(SET CMP0075 NEW)
 endif()
 
-if(POLICY CMP0091)
+if(POLICY CMP0091) # new in CMake 3.15, defaults to OLD
   cmake_policy(SET CMP0091 NEW)
 endif()
 
@@ -149,7 +152,7 @@ if ( NOT OS2 )
 endif ( NOT OS2 )
 
 # enforce visibility control for all types of cmake targets
-if ( POLICY CMP0063 )
+if ( POLICY CMP0063 ) # since version 3.3, CMake version 3.21.2 warns when the policy is not set and uses OLD behavior.
   cmake_policy ( SET CMP0063 NEW )
 endif ( POLICY CMP0063 )
 
@@ -828,9 +831,9 @@ else ()
   set ( includedir "\${prefix}/${INCLUDE_INSTALL_DIR}" )
 endif ()
 
-if ( CMAKE_VERSION VERSION_EQUAL "3.12.0" OR CMAKE_VERSION VERSION_GREATER "3.12.0" )
+if ( CMAKE_VERSION VERSION_GREATER_EQUAL "3.12.0" )
     # retrieve all the private libs we depend on
-    get_target_property ( LIBS_PRIVATE libfluidsynth INTERFACE_LINK_LIBRARIES)
+    get_target_property ( LIBS_PRIVATE libfluidsynth-OBJ INTERFACE_LINK_LIBRARIES)
     # make a copy
     set ( LIBS_PRIVATE_WITH_PATH ${LIBS_PRIVATE} )
 
@@ -848,8 +851,8 @@ if ( CMAKE_VERSION VERSION_EQUAL "3.12.0" OR CMAKE_VERSION VERSION_GREATER "3.12
 else ()
     set ( LIBS_PRIVATE "" )
     set ( LIBS_PRIVATE_WITH_PATH "" )
-    message ( DEPRECATION "Your version of CMake is old. A complete pkg-config file can not created. Get cmake 3.13.3 or newer." )
-endif ( CMAKE_VERSION VERSION_EQUAL "3.12.0" OR CMAKE_VERSION VERSION_GREATER "3.12.0" )
+    message ( DEPRECATION "Your version of CMake is old. A complete pkg-config file can not created. Get cmake 3.13.5 or newer." )
+endif ()
 
 configure_file ( fluidsynth.pc.in
 	${CMAKE_BINARY_DIR}/fluidsynth.pc IMMEDIATE @ONLY )
@@ -866,7 +869,7 @@ export(EXPORT FluidSynthTargets
    NAMESPACE FluidSynth::
 )
 
-include(CMakePackageConfigHelpers)
+include(CMakePackageConfigHelpers) # SameMinorVersion requires CMake 3.11
 write_basic_package_version_file(
     FluidSynthConfigVersion.cmake
     VERSION ${VERSION}

--- a/cmake_admin/FluidUnitTest.cmake
+++ b/cmake_admin/FluidUnitTest.cmake
@@ -8,7 +8,7 @@ macro ( ADD_FLUID_TEST _test )
     if ( FLUID_CPPFLAGS )
         set_target_properties ( ${_test} PROPERTIES COMPILE_FLAGS ${FLUID_CPPFLAGS} )
     endif ( FLUID_CPPFLAGS )
-    TARGET_LINK_LIBRARIES(${_test} $<TARGET_PROPERTY:libfluidsynth,INTERFACE_LINK_LIBRARIES>)
+    TARGET_LINK_LIBRARIES(${_test} $<TARGET_PROPERTY:libfluidsynth-OBJ,INTERFACE_LINK_LIBRARIES>)
 
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed
     target_include_directories(${_test}
@@ -40,7 +40,7 @@ macro ( ADD_FLUID_TEST_UTIL _util )
     if ( FLUID_CPPFLAGS )
         set_target_properties ( ${_util} PROPERTIES COMPILE_FLAGS ${FLUID_CPPFLAGS} )
     endif ( FLUID_CPPFLAGS )
-    TARGET_LINK_LIBRARIES(${_util} $<TARGET_PROPERTY:libfluidsynth,INTERFACE_LINK_LIBRARIES>)
+    TARGET_LINK_LIBRARIES(${_util} $<TARGET_PROPERTY:libfluidsynth-OBJ,INTERFACE_LINK_LIBRARIES>)
 
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed
     target_include_directories(${_util}

--- a/contrib/fluidsynth.dsc
+++ b/contrib/fluidsynth.dsc
@@ -5,4 +5,4 @@ Binary: fluidsynth, libfluidsynth1, libfluidsynth-dev
 Maintainer: Rui Nuno Capela <rncbc@rncbc.org>
 Architecture: any
 Standards-Version: 3.7.2
-Build-Depends: debhelper (>= 5.0.0), cmake, pkg-config, libdb-dev, libjack-dev, libasound2-dev, libsndfile-dev, libglib2.0-dev
+Build-Depends: debhelper (>= 5.0.0), cmake (>= 3.13.0), pkg-config, libdb-dev, libjack-dev, libasound2-dev, libsndfile-dev, libglib2.0-dev

--- a/contrib/fluidsynth.spec
+++ b/contrib/fluidsynth.spec
@@ -32,7 +32,7 @@ Group:          Productivity/Multimedia/Sound/Midi
 Url:            http://www.fluidsynth.org/
 Source:         https://github.com/FluidSynth/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1000:     baselibs.conf
-BuildRequires:  cmake >= 3.1.0
+BuildRequires:  cmake >= 3.13.0
 BuildRequires:  gcc-c++
 %if 0%{?is_opensuse}
 BuildRequires:  ladspa-devel

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -376,7 +376,8 @@ target_link_libraries ( libfluidsynth-OBJ INTERFACE
 )
 
 # Here are applied/linked the OBJECT library dependencies
-target_link_libraries ( libfluidsynth PRIVATE libfluidsynth-OBJ )
+get_target_property ( LIBS_PRIVATE libfluidsynth-OBJ INTERFACE_LINK_LIBRARIES)
+target_link_libraries ( libfluidsynth PRIVATE ${LIBS_PRIVATE} )
 
 # ************ CLI program ************
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -348,7 +348,11 @@ else ( MACOSX_FRAMEWORK )
   )
 endif ( MACOSX_FRAMEWORK )
 
-target_link_libraries ( libfluidsynth PRIVATE
+# Since CMake 3.12, OBJECT libraries can be linked to with target_link_libraries().
+# See https://cmake.org/cmake/help/latest/command/target_link_libraries.html#linking-object-libraries
+# Object Libraries may "link" to other libraries to get usage requirements,
+# but since they do not have a link step nothing is done with their object files.
+target_link_libraries ( libfluidsynth-OBJ INTERFACE
     ${GLIB_LIBRARIES}
     ${GMODULE_LIBRARIES}
     ${LASH_LIBRARIES}
@@ -370,6 +374,9 @@ target_link_libraries ( libfluidsynth PRIVATE
     ${LIBFLUID_LIBS}
     ${LIBINSTPATCH_LIBRARIES}
 )
+
+# Here are applied/linked the OBJECT library dependencies
+target_link_libraries ( libfluidsynth PRIVATE libfluidsynth-OBJ )
 
 # ************ CLI program ************
 


### PR DESCRIPTION
* raised cmake_minimum_required ( VERSION 3.13 )
* fixed overlinking of library, cmdline client, and unit tests