### PR TITLE
Adopting GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,20 +115,6 @@ if ( CMAKE_SYSTEM MATCHES "OS2" )
     set ( enable-ipv6 off )
 endif ( CMAKE_SYSTEM MATCHES "OS2" )
 
-# Initialize the library directory name suffix.
-if (NOT MINGW AND NOT MSVC AND NOT CMAKE_SYSTEM_NAME MATCHES "FreeBSD|DragonFly")
-if ( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-  set ( _init_lib_suffix "64" )
-else ( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-  set ( _init_lib_suffix "" )
-endif ( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-else ()
-  set ( _init_lib_suffix "" )
-endif()
-set ( LIB_SUFFIX ${_init_lib_suffix} CACHE STRING
-      "library directory name suffix (32/64/nothing)" )
-mark_as_advanced ( LIB_SUFFIX )
-
 # the default C standard to use for all targets
 set(CMAKE_C_STANDARD 90)
 
@@ -156,7 +142,7 @@ if ( POLICY CMP0063 ) # since version 3.3, CMake version 3.21.2 warns when the p
   cmake_policy ( SET CMP0063 NEW )
 endif ( POLICY CMP0063 )
 
-# Default install directory names
+# Default install directory names, some provided by GNUInstallDirs
 include ( DefaultDirs )
 
 # Basic C library checks
@@ -373,7 +359,7 @@ unset ( MACOSX_FRAMEWORK CACHE )
 if ( CMAKE_SYSTEM MATCHES "Darwin" )
   set ( DARWIN 1 )
   set ( CMAKE_INSTALL_NAME_DIR
-        ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR} )
+        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR} )
   if ( enable-coreaudio )
     check_include_file ( CoreAudio/AudioHardware.h COREAUDIO_FOUND )
     if ( COREAUDIO_FOUND )
@@ -835,20 +821,20 @@ add_subdirectory ( doc )
 # pkg-config support
 set ( prefix "${CMAKE_INSTALL_PREFIX}" )
 set ( exec_prefix "\${prefix}" )
-if ( IS_ABSOLUTE "${LIB_INSTALL_DIR}" )
-  set ( libdir "${LIB_INSTALL_DIR}" )
+if ( IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}" )
+  set ( libdir "${CMAKE_INSTALL_LIBDIR}" )
 else ()
-  set ( libdir "\${exec_prefix}/${LIB_INSTALL_DIR}" )
+  set ( libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}" )
 endif ()
-if ( IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}" )
-  set ( includedir "${INCLUDE_INSTALL_DIR}" )
+if ( IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}" )
+  set ( includedir "${CMAKE_INSTALL_INCLUDEDIR}" )
 else ()
-  set ( includedir "\${prefix}/${INCLUDE_INSTALL_DIR}" )
+  set ( includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}" )
 endif ()
 
 generate_pkgconfig_spec(fluidsynth.pc.in ${CMAKE_BINARY_DIR}/fluidsynth.pc libfluidsynth-OBJ)
 install ( FILES ${CMAKE_BINARY_DIR}/fluidsynth.pc
-	DESTINATION ${LIB_INSTALL_DIR}/pkgconfig )
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 
 # Exported targets for cmake: find_package(FluidSynth)
 # when installed, use CMAKE_PREFIX_PATH=fluidsynth-prefix;...
@@ -874,7 +860,7 @@ write_basic_package_version_file(
 configure_file(FluidSynthConfig.cmake.in FluidSynthConfig.cmake @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/FluidSynthConfig.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/FluidSynthConfigVersion.cmake"
-    DESTINATION ${LIB_INSTALL_DIR}/cmake/fluidsynth
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fluidsynth
 )
 
 # Extra targets for Unix build environments

--- a/cmake_admin/DefaultDirs.cmake
+++ b/cmake_admin/DefaultDirs.cmake
@@ -1,12 +1,15 @@
+# Provides install directory variables as defined by the GNU Coding Standards
+include ( GNUInstallDirs )
+
 # Several directory names used by FluidSynth to install files
 # the variable names are similar to the KDE4 build system
 
 # DEFAULT_SOUNDFONT - automatically loaded in some use cases
 if ( WIN32 )
-  set (DEFAULT_SOUNDFONT "C:\\\\soundfonts\\\\default.sf2" CACHE STRING
+  set (DEFAULT_SOUNDFONT "C:\\\\ProgramData\\\\soundfonts\\\\default.sf2" CACHE STRING
        "Default soundfont file")
 else ( WIN32 )
-  set (DEFAULT_SOUNDFONT "${CMAKE_INSTALL_PREFIX}/share/soundfonts/default.sf2" CACHE STRING
+  set (DEFAULT_SOUNDFONT "${CMAKE_INSTALL_FULL_DATADIR}/soundfonts/default.sf2" CACHE STRING
        "Default soundfont file")
 endif ( WIN32 )
 mark_as_advanced (DEFAULT_SOUNDFONT)
@@ -21,72 +24,28 @@ set (FRAMEWORK_INSTALL_DIR "/Library/Frameworks" CACHE STRING
      "The install dir for framework bundles")
 mark_as_advanced (FRAMEWORK_INSTALL_DIR) 
 
-# BIN_INSTALL_DIR - the directory where executables will be installed
-set (BIN_INSTALL_DIR "bin" CACHE STRING "The install dir for executables")
-mark_as_advanced (BIN_INSTALL_DIR) 
-
-# SBIN_INSTALL_DIR - the directory where system executables will be installed
-set (SBIN_INSTALL_DIR "sbin" CACHE STRING 
-     "The install dir for system executables")
-mark_as_advanced (SBIN_INSTALL_DIR) 
-
-# LIB_INSTALL_DIR - the directory where libraries will be installed
-set (LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE STRING "The install dir for libraries")
-mark_as_advanced (LIB_INSTALL_DIR) 
-
-# INCLUDE_INSTALL_DIR - the install dir for header files
-set (INCLUDE_INSTALL_DIR "include" CACHE STRING "The install dir for headers")
-mark_as_advanced (INCLUDE_INSTALL_DIR) 
-
-# DATA_INSTALL_DIR - the base install directory for data files
-set (DATA_INSTALL_DIR "share" CACHE STRING 
-     "The base install dir for data files")
-mark_as_advanced (DATA_INSTALL_DIR) 
-
-# DOC_INSTALL_DIR - the install dir for documentation
-set (DOC_INSTALL_DIR "share/doc" CACHE STRING 
-     "The install dir for documentation")
-mark_as_advanced (DOC_INSTALL_DIR) 
-
-# INFO_INSTALL_DIR - the info install dir
-set (INFO_INSTALL_DIR "share/info" CACHE STRING "The info install dir")
-mark_as_advanced (INFO_INSTALL_DIR) 
-
-# MAN_INSTALL_DIR - the man pages install dir
-if ( CMAKE_SYSTEM_NAME MATCHES "FreeBSD|DragonFly")
-  set (MAN_INSTALL_DIR "man/man1" CACHE STRING "The man pages install dir")
-else()
-  set (MAN_INSTALL_DIR "share/man/man1" CACHE STRING "The man pages install dir")
-endif()
-mark_as_advanced (MAN_INSTALL_DIR) 
-
-# SYSCONF_INSTALL_DIR - the config file install dir
-set (SYSCONF_INSTALL_DIR "/etc" CACHE PATH 
-     "The sysconfig install dir")
-mark_as_advanced (SYSCONF_INSTALL_DIR) 
-
 # XDG_APPS_INSTALL_DIR - the XDG apps dir, where .desktop files are installed
-set (XDG_APPS_INSTALL_DIR "share/applications" CACHE STRING "The XDG apps dir")
+set (XDG_APPS_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/applications" CACHE STRING "The XDG apps dir")
 mark_as_advanced (XDG_APPS_INSTALL_DIR) 
 
 # XDG_MIME_INSTALL_DIR - the XDG mimetypes install dir
-set (XDG_MIME_INSTALL_DIR "share/mime/packages" CACHE STRING 
+set (XDG_MIME_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/mime/packages" CACHE STRING
      "The install dir for the xdg mimetypes")
 mark_as_advanced (XDG_MIME_INSTALL_DIR)
- 
+
 # DBUS_INTERFACES_INSTALL_DIR - the directory where dbus interfaces are 
 # installed
-set (DBUS_INTERFACES_INSTALL_DIR "share/dbus-1/interfaces" CACHE STRING 
+set (DBUS_INTERFACES_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/dbus-1/interfaces" CACHE STRING
      "The dbus interfaces install dir")
 mark_as_advanced (DBUS_INTERFACES_INSTALL_DIR) 
 
 # DBUS_SERVICES_INSTALL_DIR  - the directory where dbus services are installed
-set (DBUS_SERVICES_INSTALL_DIR "share/dbus-1/services" CACHE STRING 
+set (DBUS_SERVICES_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/dbus-1/services" CACHE STRING
      "The dbus services install dir")
 mark_as_advanced (DBUS_SERVICES_INSTALL_DIR) 
 
 # DBUS_SYSTEM_SERVICES_INSTALL_DIR - the directory where dbus system services 
 # are installed 
-set (DBUS_SYSTEM_SERVICES_INSTALL_DIR "share/dbus-1/system-services" 
+set (DBUS_SYSTEM_SERVICES_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/dbus-1/system-services"
      CACHE STRING "The dbus system services install dir")
 mark_as_advanced (DBUS_SYSTEM_SERVICES_INSTALL_DIR) 

--- a/contrib/debian.libfluidsynth-dev.install
+++ b/contrib/debian.libfluidsynth-dev.install
@@ -1,3 +1,4 @@
 debian/tmp/usr/include/*
-debian/tmp/usr/lib*/*.so
-debian/tmp/usr/lib*/pkgconfig/*.pc
+debian/tmp/usr/lib/*/*.so
+debian/tmp/usr/lib/*/pkgconfig/*.pc
+debian/tmp/usr/lib/*/cmake/fluidsynth/*.cmake

--- a/contrib/debian.libfluidsynth1.install
+++ b/contrib/debian.libfluidsynth1.install
@@ -1,1 +1,1 @@
-debian/tmp/usr/lib*/lib*.so.*
+debian/tmp/usr/lib/*/lib*.so.*

--- a/contrib/debian.rules
+++ b/contrib/debian.rules
@@ -26,7 +26,7 @@ config.status: CMakeLists.txt
 	dh_testdir
 
 	# Add here commands to configure the package.
-	cmake -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_DIR=/usr/lib .
+	cmake -DCMAKE_INSTALL_PREFIX=/usr .
 
 build: build-stamp
 build-stamp:  config.status

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -45,7 +45,7 @@ endif ( DOXYGEN_FOUND )
 
 if ( UNIX )
   install ( FILES fluidsynth.1
-    DESTINATION ${MAN_INSTALL_DIR} )
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 )
 endif ( UNIX )
 
 add_subdirectory ( examples )

--- a/fluidsynth.service.in
+++ b/fluidsynth.service.in
@@ -8,7 +8,7 @@ Type=notify
 NotifyAccess=main
 EnvironmentFile=@FLUID_DAEMON_ENV_FILE@
 EnvironmentFile=-%h/.config/fluidsynth
-ExecStart=@CMAKE_INSTALL_PREFIX@/@BIN_INSTALL_DIR@/fluidsynth -is $OTHER_OPTS $SOUND_FONT
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/fluidsynth -is $OTHER_OPTS $SOUND_FONT
 
 [Install]
 WantedBy=default.target

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -485,19 +485,19 @@ endif()
 if ( MACOSX_FRAMEWORK )
   install ( TARGETS fluidsynth libfluidsynth
     EXPORT FluidSynthTargets
-    RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     FRAMEWORK DESTINATION ${FRAMEWORK_INSTALL_DIR}
     ARCHIVE DESTINATION ${FRAMEWORK_INSTALL_DIR}
 )
 else ( MACOSX_FRAMEWORK )
   install ( TARGETS fluidsynth libfluidsynth
     EXPORT FluidSynthTargets
-    RUNTIME DESTINATION ${BIN_INSTALL_DIR}
-    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
-    PUBLIC_HEADER DESTINATION ${INCLUDE_INSTALL_DIR}/fluidsynth 
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fluidsynth
 )
-   install ( FILES ${public_main_HEADER} DESTINATION ${INCLUDE_INSTALL_DIR} )
+   install ( FILES ${public_main_HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
 endif ( MACOSX_FRAMEWORK )
 
 # Exported targets.
@@ -506,14 +506,14 @@ endif ( MACOSX_FRAMEWORK )
 # install_interface: for the target when imported from the installed directory.
 target_include_directories(libfluidsynth PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/;${PROJECT_BINARY_DIR}/include/>"
-    "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
 # installation of the exported targets
 install(EXPORT FluidSynthTargets
         FILE FluidSynthTargets.cmake
         NAMESPACE FluidSynth::
-        DESTINATION ${LIB_INSTALL_DIR}/cmake/fluidsynth
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fluidsynth
 )
 
 # ******* Auto Generated Lookup Tables ******


### PR DESCRIPTION
This PR has the following effects:
* removed and/or replaced most definitions from DefaultDirs.cmake and getting the values from GNUInstallDirs.cmake 
* fixed DEFAULT_SOUNDFOUNT in Windows, now in "C:/ProgramData/soundfonts"
* removed LIB_SUFFIX
* replaced LIB_INSTALL_DIR by CMAKE_INSTALL_LIBDIR. Same for INCLUDE_INSTALL_DIR, etc.

This issue may look somewhat cosmetic, but has some important implications. The key is that, most of the time, the variables like CMAKE_INSTALL_LIBDIR will be correctly and automatically computed for each distribution and architecture, ruling out the need of assigning a custom value. Depending on the kind of downstream user...
* if he is a packager, he already knows how and when to populate the CMAKE_INSTALL_* variables, and FS is just another package using well known variable names.
* if he is a final user compiling FS by himself, he gets the correct install directories automatically, without having to worry about it anymore.  See for instance #411 and #476