### PR TITLE
Make building executables, documentation and tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ option ( enable-readline "compile readline lib line editing (if it is available)
 option ( enable-threads "enable multi-threading support (such as parallel voice synthesis)" on )
 option ( enable-openmp "enable OpenMP support (parallelization of soundfont decoding, vectorization of voice mixing, etc.)" on )
 
+# Options for build components
+option ( build-bins "build binary programs" on )
+option ( build-docs "build docs" on )
+option ( build-tests "build tests" on )
+
 # Platform specific options
 if ( CMAKE_SYSTEM MATCHES "Linux|FreeBSD|DragonFly" )
     option ( enable-lash "compile LASH support (if it is available)" on )
@@ -812,8 +817,12 @@ ENABLE_TESTING()
 
 # Process subdirectories
 add_subdirectory ( src )
-add_subdirectory ( test )
-add_subdirectory ( doc )
+if ( build-tests )
+    add_subdirectory ( test )
+endif ()
+if ( build-docs )
+    add_subdirectory ( doc )
+endif ()
 
 # pkg-config support
 set ( prefix "${CMAKE_INSTALL_PREFIX}" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -373,38 +373,41 @@ target_link_libraries ( libfluidsynth
 
 # ************ CLI program ************
 
-set ( fluidsynth_SOURCES fluidsynth.c )
+if ( build-bins )
+  set ( fluidsynth_bin "fluidsynth" )
+  set ( fluidsynth_SOURCES ${fluidsynth_SOURCES} fluidsynth.c )
 
-if ( WASAPI_SUPPORT )
-  set ( fluidsynth_SOURCES ${fluidsynth_SOURCES} fluid_wasapi_device_enumerate.c )
-endif ( WASAPI_SUPPORT )
+  if ( WASAPI_SUPPORT )
+    set ( fluidsynth_SOURCES ${fluidsynth_SOURCES} fluid_wasapi_device_enumerate.c )
+  endif ( WASAPI_SUPPORT )
 
-add_executable ( fluidsynth
+  add_executable ( fluidsynth
     ${fluidsynth_SOURCES}
-)
+  )
 
-set_target_properties ( fluidsynth
+  set_target_properties ( fluidsynth
     PROPERTIES IMPORT_PREFIX "" )
 
-if ( FLUID_CPPFLAGS )
-  set_target_properties ( fluidsynth
-    PROPERTIES COMPILE_FLAGS ${FLUID_CPPFLAGS} )
-endif ( FLUID_CPPFLAGS )
+  if ( FLUID_CPPFLAGS )
+    set_target_properties ( fluidsynth
+      PROPERTIES COMPILE_FLAGS ${FLUID_CPPFLAGS} )
+  endif ( FLUID_CPPFLAGS )
 
-target_link_libraries ( fluidsynth
+  target_link_libraries ( fluidsynth
     libfluidsynth
     ${SYSTEMD_LIBRARIES}
     ${FLUID_LIBS}
-)
+  )
+endif ()
 
 if ( MACOSX_FRAMEWORK )
-  install ( TARGETS fluidsynth libfluidsynth
+  install ( TARGETS ${fluidsynth_bin} libfluidsynth
     RUNTIME DESTINATION ${BIN_INSTALL_DIR}
     FRAMEWORK DESTINATION ${FRAMEWORK_INSTALL_DIR}
     ARCHIVE DESTINATION ${FRAMEWORK_INSTALL_DIR}
 )
 else ( MACOSX_FRAMEWORK )
-  install ( TARGETS fluidsynth libfluidsynth
+  install ( TARGETS ${fluidsynth_bin} libfluidsynth
     RUNTIME DESTINATION ${BIN_INSTALL_DIR}
     LIBRARY DESTINATION ${LIB_INSTALL_DIR}
     ARCHIVE DESTINATION ${LIB_INSTALL_DIR}


### PR DESCRIPTION
This is very useful for cross-compiling. For example with mingw on Linux. It's also useful when we're only interested in building libfluidsynth as a dependency of another program.