### PR TITLE
Enable MSVC math constants for gen_tables

### DIFF
--- a/src/gentables/make_tables.h
+++ b/src/gentables/make_tables.h
@@ -2,11 +2,14 @@
 #ifndef _FLUID_MAKE_TABLES_H
 #define _FLUID_MAKE_TABLES_H
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES // Enable M_LN10 and M_PI constants under VisualStudio
+#endif
+#include <math.h>
+
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
-
 
 #define EMIT_ARRAY(__fp__, __arr__) emit_array(__fp__, #__arr__, __arr__, sizeof(__arr__)/sizeof(*__arr__))
 


### PR DESCRIPTION
VisualStudio's math header only activates constants if the `_USE_MATH_DEFINES` preprocessor definition exists.

Prior to this, MSVC builds will fail with undefined math constants:

``` text
fluidsynth/src/gentables/gen_rvoice_dsp.c(56): error C2065: 'M_PI': undeclared identifier
fluidsynth/src/gentables/gen_conv.c(57): error C2065: 'M_LN10': undeclared identifier
fluidsynth/src/gentables/gen_conv.c(63): error C2065: 'M_PI': undeclared identifier
```

Ref: https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-160