### PR TITLE
RFC: Support for auto-suspend / idle-handling

### DIFF
--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -607,6 +607,23 @@ static fluid_thread_return_t fluid_alsa_audio_run_s16(void *d)
                     offset += n;    /* no error occurred */
                 }
             }	/* while (offset < buffer_size) */
+
+            if (fluid_synth_is_idle(synth)) {
+                fluid_log(FLUID_ERR, "pausing rendering\n"); // FIXME: remove debug output
+                if(snd_pcm_drain(dev->pcm) != 0)
+                {
+                    FLUID_LOG(FLUID_ERR, "Failed to stop the audio device");
+                    goto error_recovery;
+                }
+                fluid_synth_idle_wait(synth);
+                fluid_log(FLUID_ERR, "resuming rendering\n"); // FIXME: remove debug output
+                if(snd_pcm_prepare(dev->pcm) != 0)
+                {
+                    FLUID_LOG(FLUID_ERR, "Failed to prepare the audio device");
+                    goto error_recovery;
+                }
+                continue;
+            }
         }	/* while (dev->cont) */
     }
 

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -1687,7 +1687,15 @@ new_fluid_player(fluid_synth_t *synth)
     fluid_player_set_playback_callback(player, fluid_synth_handle_midi_event, synth);
     fluid_player_set_tick_callback(player, NULL, NULL);
     player->use_system_timer = fluid_settings_str_equal(synth->settings,
-                               "player.timing-source", "system") || synth->idle_timeout;
+                               "player.timing-source", "system");
+
+    if (synth->idle_timeout && !player->use_system_timer)
+    {
+        fluid_log(FLUID_ERR,
+                "MIDI players with sample timers are incompatible with idle-timeout "
+                "handling, use system timers (player.timing-source=system) instead");
+        goto err;
+    }
 
     if(player->use_system_timer)
     {

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -1687,7 +1687,8 @@ new_fluid_player(fluid_synth_t *synth)
     fluid_player_set_playback_callback(player, fluid_synth_handle_midi_event, synth);
     fluid_player_set_tick_callback(player, NULL, NULL);
     player->use_system_timer = fluid_settings_str_equal(synth->settings,
-                               "player.timing-source", "system");
+                               "player.timing-source", "system") || synth->idle_timeout;
+
     if(player->use_system_timer)
     {
         player->system_timer = new_fluid_timer((int) player->deltatime,

--- a/src/midi/fluid_seqbind.c
+++ b/src/midi/fluid_seqbind.c
@@ -115,6 +115,15 @@ fluid_sequencer_register_fluidsynth(fluid_sequencer_t *seq, fluid_synth_t *synth
     fluid_return_val_if_fail(seq != NULL, FLUID_FAILED);
     fluid_return_val_if_fail(synth != NULL, FLUID_FAILED);
 
+    if (synth->idle_timeout && !fluid_sequencer_get_use_system_timer(seq))
+    {
+        fluid_log(FLUID_ERR,
+                "Sequencers with sample timers are incompatible with idle-timeout "
+                "handling, use system timers instead.");
+        return FLUID_FAILED;
+
+    }
+
     seqbind = FLUID_NEW(fluid_seqbind_t);
 
     if(seqbind == NULL)

--- a/src/rvoice/fluid_rvoice_event.h
+++ b/src/rvoice/fluid_rvoice_event.h
@@ -63,7 +63,6 @@ void delete_fluid_rvoice_eventhandler(fluid_rvoice_eventhandler_t *);
 
 int fluid_rvoice_eventhandler_dispatch_all(fluid_rvoice_eventhandler_t *);
 int fluid_rvoice_eventhandler_dispatch_count(fluid_rvoice_eventhandler_t *);
-int fluid_rvoice_eventhandler_pending_events(fluid_rvoice_eventhandler_t *handler);
 void fluid_rvoice_eventhandler_finished_voice_callback(fluid_rvoice_eventhandler_t *eventhandler,
         fluid_rvoice_t *rvoice);
 

--- a/src/rvoice/fluid_rvoice_event.h
+++ b/src/rvoice/fluid_rvoice_event.h
@@ -46,18 +46,30 @@ struct _fluid_rvoice_eventhandler_t
     fluid_atomic_int_t queue_stored; /**< Extras pushed but not flushed */
     fluid_ringbuffer_t *finished_voices; /**< return queue from handler, list of fluid_rvoice_t* */
     fluid_rvoice_mixer_t *mixer;
+
+    int idle_blocks_threshold;
+    int idle_blocks;
+
+    int idle;
+    fluid_cond_t *pending_events;
+    fluid_cond_mutex_t *pending_events_m;
 };
 
 fluid_rvoice_eventhandler_t *new_fluid_rvoice_eventhandler(
     int queuesize, int finished_voices_size, int bufs,
-    int fx_bufs, int fx_units, fluid_real_t sample_rate_max, fluid_real_t sample_rate, int, int);
+    int fx_bufs, int fx_units, fluid_real_t sample_rate_max, fluid_real_t sample_rate, int, int, int);
 
 void delete_fluid_rvoice_eventhandler(fluid_rvoice_eventhandler_t *);
 
 int fluid_rvoice_eventhandler_dispatch_all(fluid_rvoice_eventhandler_t *);
 int fluid_rvoice_eventhandler_dispatch_count(fluid_rvoice_eventhandler_t *);
+int fluid_rvoice_eventhandler_pending_events(fluid_rvoice_eventhandler_t *handler);
 void fluid_rvoice_eventhandler_finished_voice_callback(fluid_rvoice_eventhandler_t *eventhandler,
         fluid_rvoice_t *rvoice);
+
+int  fluid_rvoice_eventhandler_is_idle(fluid_rvoice_eventhandler_t *handler);
+void fluid_rvoice_eventhandler_update_idle_state(fluid_rvoice_eventhandler_t *handler, int blockcount);
+void fluid_rvoice_eventhandler_wait_for_events(fluid_rvoice_eventhandler_t *handler);
 
 static FLUID_INLINE void
 fluid_rvoice_eventhandler_flush(fluid_rvoice_eventhandler_t *handler)

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -1289,12 +1289,10 @@ int fluid_rvoice_mixer_get_bufcount(fluid_rvoice_mixer_t *mixer)
     return FLUID_MIXER_MAX_BUFFERS_DEFAULT;
 }
 
-#if WITH_PROFILING
 int fluid_rvoice_mixer_get_active_voices(fluid_rvoice_mixer_t *mixer)
 {
     return mixer->active_voices;
 }
-#endif
 
 #if ENABLE_MIXER_THREADS
 

--- a/src/rvoice/fluid_rvoice_mixer.h
+++ b/src/rvoice/fluid_rvoice_mixer.h
@@ -34,9 +34,7 @@ int fluid_rvoice_mixer_get_bufs(fluid_rvoice_mixer_t *mixer,
 int fluid_rvoice_mixer_get_fx_bufs(fluid_rvoice_mixer_t *mixer,
                                    fluid_real_t **fx_left, fluid_real_t **fx_right);
 int fluid_rvoice_mixer_get_bufcount(fluid_rvoice_mixer_t *mixer);
-#if WITH_PROFILING
 int fluid_rvoice_mixer_get_active_voices(fluid_rvoice_mixer_t *mixer);
-#endif
 fluid_rvoice_mixer_t *new_fluid_rvoice_mixer(int buf_count, int fx_buf_count, int fx_units,
         fluid_real_t sample_rate_max, fluid_real_t sample_rate,
         fluid_rvoice_eventhandler_t *, int, int);

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -4921,6 +4921,9 @@ fluid_synth_render_blocks(fluid_synth_t *synth, int blockcount)
         };
     };
 #endif
+
+    fluid_rvoice_eventhandler_update_idle_state(synth->eventhandler, blockcount);
+
     fluid_check_fpe("??? Remainder of synth_one_block ???");
     fluid_profile(FLUID_PROF_ONE_BLOCK, prof_ref,
                   fluid_rvoice_mixer_get_active_voices(synth->eventhandler->mixer),
@@ -8409,4 +8412,14 @@ int fluid_synth_get_basic_channel(fluid_synth_t *synth, int chan,
     }
 
     FLUID_API_RETURN(FLUID_OK);
+}
+
+int fluid_synth_is_idle(fluid_synth_t *synth)
+{
+    return fluid_rvoice_eventhandler_is_idle(synth->eventhandler);
+}
+
+void fluid_synth_idle_wait(fluid_synth_t *synth)
+{
+    fluid_rvoice_eventhandler_wait_for_events(synth->eventhandler);
 }

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -251,6 +251,11 @@ fluid_synth_write_float_LOCAL(fluid_synth_t *synth, int len,
 void fluid_synth_settings(fluid_settings_t *settings);
 void fluid_synth_set_sample_rate_immediately(fluid_synth_t *synth, float sample_rate);
 
+/*
+ * idle state / auto-suspend handling
+ */
+int fluid_synth_is_idle(fluid_synth_t *synth);
+void fluid_synth_idle_wait(fluid_synth_t *synth);
 
 /* extern declared in fluid_synth_monopoly.c */
 

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -164,6 +164,8 @@ struct _fluid_synth_t
     fluid_ladspa_fx_t *ladspa_fx;      /**< Effects unit for LADSPA support */
     enum fluid_iir_filter_type custom_filter_type; /**< filter type of the user-defined filter currently used for all voices */
     enum fluid_iir_filter_flags custom_filter_flags; /**< filter type of the user-defined filter currently used for all voices */
+
+    int idle_timeout;                  /**< Seconds until renderer idle timeout */
 };
 
 /**


### PR DESCRIPTION
This is a RFC pull-request that adds experimental support for auto-suspend / idle-handling to FluidSynth.

Motivation behind this change is the fact that quite a few people have already expressed interest in a FluidSynth server process that uses as little CPU time as possible when not "in use", i.e. not actually rendering MIDI. It would also help myself with my musical instrument, as it would help to reduce CPU load and therefore improve battery life if the instrument is switched on but not actually in use at the moment.

The basic approach is based on the assumption that the renderer state only changes with events in the rvoice event queue. So as soon as there are no active voices in the renderer and no events in the queue, we consider it an "idle" run and add the current number of blocks towards the idle_block_threshold. If the threshold is reached, the synth is marked as idle. As soon as another event gets added to the queue, the renderer is marked busy again and any drivers waiting on the idle state get notified.

Example support for this idle handling is added to the ALSA and PulseAudio drivers. ALSA works really well, reducing the CPU time for alsa and FS to 0%. ~~PulseAudio still consumes CPU time in idle wait, probably due to the use of the "simple" PA API. But that could probably be fixed fairly easily.~~ (Edit: I've also changed the PA driver so that the connection to the server is dropped during idle times. This effectively reduces CPU consumption of PA and FS to 0).

Also, sample timers obviously don't work if no renderer calls are made during idle wait, so the player uses the system timer if idle-timeout is set. But having an idle-timeout with midi files passed on the command-line is probably not a sensible use-case anyway.

Again... this is meant as a request-for-comments. I don't think the added calls in the renderer path introduce a noticeable overhead for people not using this feature, but that remains to be tested. And maybe I've missed parts of the synth that definitely require frequent renderer calls even if there is nothing to be rendered at the moment?

Looking forward to your feedback!