### PR TITLE
Port the Sequencer to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ mark_as_advanced ( LIB_SUFFIX )
 set(CMAKE_C_STANDARD 90)
 
 # the default C++ standard to use for all targets
-set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD 11)
 
 # whether to use gnu extensions
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/include/fluidsynth/seq.h
+++ b/include/fluidsynth/seq.h
@@ -71,7 +71,7 @@ fluid_seq_id_t fluid_sequencer_register_client(fluid_sequencer_t *seq, const cha
 FLUIDSYNTH_API void fluid_sequencer_unregister_client(fluid_sequencer_t *seq, fluid_seq_id_t id);
 FLUIDSYNTH_API int fluid_sequencer_count_clients(fluid_sequencer_t *seq);
 FLUIDSYNTH_API fluid_seq_id_t fluid_sequencer_get_client_id(fluid_sequencer_t *seq, int index);
-FLUIDSYNTH_API char *fluid_sequencer_get_client_name(fluid_sequencer_t *seq, fluid_seq_id_t id);
+FLUIDSYNTH_API const char *fluid_sequencer_get_client_name(fluid_sequencer_t *seq, fluid_seq_id_t id);
 FLUIDSYNTH_API int fluid_sequencer_client_is_dest(fluid_sequencer_t *seq, fluid_seq_id_t id);
 FLUIDSYNTH_API void fluid_sequencer_process(fluid_sequencer_t *seq, unsigned int msec);
 FLUIDSYNTH_API void fluid_sequencer_send_now(fluid_sequencer_t *seq, fluid_event_t *evt);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,7 +214,7 @@ set ( libfluidsynth_SOURCES
     midi/fluid_midi_router.h
     midi/fluid_seqbind.c
     midi/fluid_seqbind_notes.cpp
-    midi/fluid_seq.c
+    midi/fluid_seq.cpp
     midi/fluid_seq_queue.cpp
     drivers/fluid_adriver.c
     drivers/fluid_adriver.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,6 +156,7 @@ set ( config_SOURCES ${CMAKE_BINARY_DIR}/config.h )
 set ( libfluidsynth_SOURCES
     utils/fluid_conv.c
     utils/fluid_conv.h
+    utils/fluid_cxx_wrapper.hpp
     utils/fluid_hash.c
     utils/fluid_hash.h
     utils/fluid_list.c

--- a/src/midi/fluid_seq.cpp
+++ b/src/midi/fluid_seq.cpp
@@ -116,9 +116,9 @@ struct _fluid_sequencer_t
     ~_fluid_sequencer_t()
     {
         /* cleanup clients */
-        for(auto& client : this->clients)
+        while(!this->clients.empty())
         {
-            this->unregister_client(client->id);
+            this->unregister_client(this->clients.back()->id);
         }
         delete_fluid_seq_queue(this->queue);
     }

--- a/src/midi/fluid_seq.cpp
+++ b/src/midi/fluid_seq.cpp
@@ -27,18 +27,11 @@
   http://www.infiniteCD.org/
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "fluid_seq.h"
 #include "fluid_event.h"
 #include "fluid_seq_queue.h"
 #include "fluid_sys.h"
-
-#ifdef __cplusplus
-}
-#endif
 
 #include "fluid_cxx_wrapper.hpp"
 

--- a/src/midi/fluid_seq.h
+++ b/src/midi/fluid_seq.h
@@ -1,0 +1,29 @@
+/* FluidSynth - A Software Synthesizer
+ *
+ * Copyright (C) 2003  Peter Hanappe and others.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ */
+
+#ifndef _FLUID_SEQ_H
+#define _FLUID_SEQ_H
+
+#include "fluidsynth.h"
+#include "fluid_event.h"
+
+extern void fluid_sequencer_invalidate_note(fluid_sequencer_t *seq, fluid_seq_id_t dest, fluid_note_id_t id);
+
+#endif /* _FLUID_SEQ_H */

--- a/src/midi/fluid_seq.h
+++ b/src/midi/fluid_seq.h
@@ -24,6 +24,14 @@
 #include "fluidsynth.h"
 #include "fluid_event.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void fluid_sequencer_invalidate_note(fluid_sequencer_t *seq, fluid_seq_id_t dest, fluid_note_id_t id);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLUID_SEQ_H */

--- a/src/midi/fluid_seq_queue.h
+++ b/src/midi/fluid_seq_queue.h
@@ -22,13 +22,12 @@
 #define _FLUID_SEQ_QUE_H
 
 #include "fluidsynth.h"
+#include "fluid_event.h"
+#include "fluid_seqbind_notes.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "fluid_event.h"
-#include "fluid_seqbind_notes.h"
 
 void* new_fluid_seq_queue(int nbEvents);
 void delete_fluid_seq_queue(void *queue);

--- a/src/midi/fluid_seqbind.c
+++ b/src/midi/fluid_seqbind.c
@@ -32,6 +32,7 @@
 #include "fluid_midi.h"
 #include "fluid_event.h"
 #include "fluid_seqbind_notes.h"
+#include "fluid_seq.h"
 
 /***************************************************************
 *
@@ -47,8 +48,6 @@ struct _fluid_seqbind_t
     void* note_container;
 };
 typedef struct _fluid_seqbind_t fluid_seqbind_t;
-
-extern void fluid_sequencer_invalidate_note(fluid_sequencer_t *seq, fluid_seq_id_t dest, fluid_note_id_t id);
 
 int fluid_seqbind_timer_callback(void *data, unsigned int msec);
 void fluid_seq_fluidsynth_callback(unsigned int time, fluid_event_t *event, fluid_sequencer_t *seq, void *data);
@@ -338,7 +337,7 @@ static fluid_seq_id_t get_fluidsynth_dest(fluid_sequencer_t *seq)
 {
     int i;
     fluid_seq_id_t id;
-    char *name;
+    const char *name;
     int j = fluid_sequencer_count_clients(seq);
 
     for(i = 0; i < j; i++)

--- a/src/utils/fluid_cxx_wrapper.hpp
+++ b/src/utils/fluid_cxx_wrapper.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+/* FluidSynth - A Software Synthesizer
+ *
+ * Copyright (C) 2021 Tom Moebert and others.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "fluid_sys.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <sstream>
+
+template<typename T>
+auto guardedCall (T&& func, decltype(func()) errorReturnValue) -> decltype(func())
+{
+    std::stringstream ss;
+    try
+    {
+        return func();
+    }
+    catch( const std::bad_alloc& e )
+    {
+        FLUID_LOG(FLUID_PANIC, "Out of memory\n");
+    }
+    catch( const std::exception& e )
+    {
+        ss << e.what();
+        FLUID_LOG(FLUID_ERR, "%s\n", ss.str().c_str());
+    }
+    catch(...)
+    {
+        FLUID_LOG(FLUID_ERR, "Unknown exception occurred\n");
+    }
+
+    return std::move(errorReturnValue);
+}

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -159,6 +159,10 @@ typedef gintptr  intptr_t;
 
 #include <glib/gstdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Macro used for safely accessing a message from a GError and using a default
  * message if it is NULL.
@@ -767,5 +771,9 @@ static FLUID_INLINE void *fluid_align_ptr(const void *ptr, unsigned int alignmen
 }
 
 #define FLUID_DEFAULT_ALIGNMENT (64U)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLUID_SYS_H */

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -48,6 +48,9 @@
 
 #include "fluidsynth.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /***************************************************************
  *
@@ -318,5 +321,8 @@ else \
 #define fluid_return_val_if_fail(cond, val) \
  fluid_return_if_fail(cond) (val)
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLUIDSYNTH_PRIV_H */


### PR DESCRIPTION
This is an MVP-like example of how a port of fluidsynth to C++11 may look like. See related discussion #847.

TODOs

- [x] restructure `extern C` crap to fix MacOS build
- [ ] MinGW fails to compile (could be related to https://stackoverflow.com/a/17986785)
- [ ] better integration of `fluid_seq_queue`
- [ ] remove `std::find_if` code duplication

Update: In the discussion I mentioned that porting to C++ will keep the API stable. This may not completely hold true:

* At least one function in the sequencer currently returns `char*` – in C++ this function must return a `const char*` (must have)
* Many functions in the sequencer currently return `void` – since in C++ an exception may be thrown pretty much everywhere, it would be helpful when those functions would return FLUID_OK / FLUID_FAILED (nice-to-have though)

However, I'd consider those API changes to be pretty cosmetic though.