### PR TITLE
Fix regression from #969

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -836,6 +836,8 @@ else ()
 endif ()
 
 generate_pkgconfig_spec(fluidsynth.pc.in ${CMAKE_BINARY_DIR}/fluidsynth.pc libfluidsynth-OBJ)
+install ( FILES ${CMAKE_BINARY_DIR}/fluidsynth.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 
 # Exported targets for cmake: find_package(FluidSynth)
 # when installed, use CMAKE_PREFIX_PATH=fluidsynth-prefix;...


### PR DESCRIPTION
In the previous CMake change the pkgconfig file was accidentally not installed anymore. Didn't recognized this earlier, because the OBS CI workflow was broken and therefore not running.