### PR TITLE
Prevent samples accidentally having their loops disabled

### DIFF
--- a/src/sfloader/fluid_sfont.c
+++ b/src/sfloader/fluid_sfont.c
@@ -793,7 +793,7 @@ int fluid_sample_sanitize_loop(fluid_sample_t *sample, unsigned int buffer_size)
          * ensure that those two pointers are within the sampledata by setting
          * them to 0. Don't report the modification, as this change has no audible
          * effect. */
-        sample->loopstart = sample->loopend = 0;
+        sample->loopstart = sample->loopend = sample->start;
         return FALSE;
     }
     else if(sample->loopstart > sample->loopend)


### PR DESCRIPTION
If a SoundFont sets `loopstart == loopend` and then uses loop-offset-modulators to fix up those loops assigning them with a valid position, the sample was previously switched to unlooped mode erroneously.

For the long story, see #1017.