### PR TITLE
Extend MIDI auto connect

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -736,7 +736,7 @@ Developers:
             <name>alsa.device</name>
             <type>str</type>
             <def>default</def>
-            <desc>ALSA MIDI hardware device to use for RAW ALSA MIDI driver (not to be confused with the MIDI port).</desc>
+            <desc>ALSA MIDI hardware device to use for RAW ALSA MIDI driver (not to be confused with the MIDI port). Since fluidsynth 2.3.0 this setting will be populated with available devices when fluidsynth starts up.</desc>
         </setting>
         <setting>
             <name>alsa_seq.device</name>

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -554,7 +554,7 @@ static fluid_thread_return_t fluid_alsa_audio_run_s16(void *d)
         {
             FLUID_MEMSET(left, 0, buffer_size * sizeof(*left));
             FLUID_MEMSET(right, 0, buffer_size * sizeof(*right));
-            
+
             (*dev->callback)(dev->data, buffer_size, 0, NULL, 2, handle);
 
             /* convert floating point data to 16 bit (with dithering) */
@@ -638,15 +638,20 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
 
     /* Enumeration of ALSA Raw MIDI devices */
     err = snd_card_next(&card);
-    while ((err == 0) && (card >= 0)) {
+
+    while((err == 0) && (card >= 0))
+    {
         int device = -1;
         snd_ctl_t *ctl;
         char card_name[32];
 
         sprintf(card_name, "hw:%d", card);
         err = snd_ctl_open(&ctl, card_name, 0);
-        if (err == 0) {
-            for (;;) {
+
+        if(err == 0)
+        {
+            for(;;)
+            {
                 int num_subs;
                 int subdevice;
                 char newoption[64];
@@ -655,27 +660,44 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
                 const char *sub_name;
 
                 err = snd_ctl_rawmidi_next_device(ctl, &device);
-                if ((err < 0) || (device < 0))
+
+                if((err < 0) || (device < 0))
+                {
                     break;
+                }
+
                 snd_rawmidi_info_alloca(&info);
                 snd_rawmidi_info_set_device(info, device);
                 snd_rawmidi_info_set_stream(info, SND_RAWMIDI_STREAM_INPUT);
                 err = snd_ctl_rawmidi_info(ctl, info);
-                if (err == 0)
+
+                if(err == 0)
+                {
                     num_subs = snd_rawmidi_info_get_subdevices_count(info);
+                }
                 else
+                {
                     break;
-                for (subdevice = 0; subdevice < num_subs; ++subdevice) {
+                }
+
+                for(subdevice = 0; subdevice < num_subs; ++subdevice)
+                {
                     snd_rawmidi_info_set_subdevice(info, subdevice);
                     err = snd_ctl_rawmidi_info(ctl, info);
-                    if (err == 0) {
+
+                    if(err == 0)
+                    {
                         name = snd_rawmidi_info_get_name(info);
                         sub_name = snd_rawmidi_info_get_subdevice_name(info);
-                        if (subdevice == 0 && sub_name[0] == '\0') {
+
+                        if(subdevice == 0 && sub_name[0] == '\0')
+                        {
                             sprintf(newoption, "hw:%d,%d    %s", card, device, name);
                             fluid_settings_add_option(settings, "midi.alsa.device", newoption);
                             break;
-                        } else {
+                        }
+                        else
+                        {
                             sprintf(newoption, "hw:%d,%d,%d  %s", card, device, subdevice, sub_name);
                             fluid_settings_add_option(settings, "midi.alsa.device", newoption);
                         }
@@ -683,6 +705,7 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
                 }
             }
         }
+
         snd_ctl_close(ctl);
         err = snd_card_next(&card);
     }
@@ -979,7 +1002,9 @@ static void fluid_alsa_seq_autoconnect_port_info(fluid_alsa_seq_driver_t *dev, s
     /* Calculate the next port to be auto-connected. When all ports have been connected
      * in sequence, start again from port 0 for the next auto-connection. */
     dev->autoconn_dest.port++;
-    if (dev->autoconn_dest.port >= dev->port_count) {
+
+    if(dev->autoconn_dest.port >= dev->port_count)
+    {
         dev->autoconn_dest.port  = 0;
     }
 }

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -632,9 +632,12 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
 {
     int card = -1;
     int err = 0;
+    snd_rawmidi_info_t *info;
 
     fluid_settings_register_str(settings, "midi.alsa.device", "default", 0);
     fluid_settings_add_option(settings, "midi.alsa.device", "default");
+
+    snd_rawmidi_info_alloca(&info);
 
     /* Enumeration of ALSA Raw MIDI devices */
     err = snd_card_next(&card);
@@ -645,7 +648,7 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
         snd_ctl_t *ctl;
         char card_name[32];
 
-        sprintf(card_name, "hw:%d", card);
+        FLUID_SNPRINTF(card_name, sizeof(card_name), "hw:%d", card);
         err = snd_ctl_open(&ctl, card_name, 0);
 
         if(err == 0)
@@ -655,7 +658,6 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
                 int num_subs;
                 int subdevice;
                 char newoption[64];
-                snd_rawmidi_info_t *info;
                 const char *name;
                 const char *sub_name;
 
@@ -666,7 +668,6 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
                     break;
                 }
 
-                snd_rawmidi_info_alloca(&info);
                 snd_rawmidi_info_set_device(info, device);
                 snd_rawmidi_info_set_stream(info, SND_RAWMIDI_STREAM_INPUT);
                 err = snd_ctl_rawmidi_info(ctl, info);
@@ -692,13 +693,13 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
 
                         if(subdevice == 0 && sub_name[0] == '\0')
                         {
-                            sprintf(newoption, "hw:%d,%d    %s", card, device, name);
+                            FLUID_SNPRINTF(newoption, sizeof(newoption), "hw:%d,%d    %s", card, device, name);
                             fluid_settings_add_option(settings, "midi.alsa.device", newoption);
                             break;
                         }
                         else
                         {
-                            sprintf(newoption, "hw:%d,%d,%d  %s", card, device, subdevice, sub_name);
+                            FLUID_SNPRINTF(newoption, sizeof(newoption), "hw:%d,%d,%d  %s", card, device, subdevice, sub_name);
                             fluid_settings_add_option(settings, "midi.alsa.device", newoption);
                         }
                     }

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -1190,7 +1190,7 @@ new_fluid_alsa_seq_driver(fluid_settings_t *settings,
     FLUID_MEMSET(port_info, 0, snd_seq_port_info_sizeof());
 
     fluid_settings_getint(settings, "synth.midi-channels", &midi_channels);
-    dev->port_count = ceil(midi_channels / 16);
+    dev->port_count = ceil(midi_channels / 16.0f);
 
     snd_seq_port_info_set_capability(port_info,
                                      SND_SEQ_PORT_CAP_WRITE |

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -476,23 +476,27 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char *dev_name)
 
 static void fluid_winmidi_autoconnect_build_name(char *name)
 {
+    char new_name[MAXPNAMELEN] = { 0 };
     int i, j, n = 0;
     int num = midiInGetNumDevs();
 
-    if(num < 11)
+    for (i = 0; i < num; ++i)
     {
-        FLUID_MEMSET(name, 0, MAXPNAMELEN);
-
-        for(i = 0; i < num; ++i)
+        char x[4];
+        j = FLUID_SNPRINTF(x, sizeof(x), "%d;", i);
+        n += j;
+        if (n >= sizeof(new_name))
         {
-            char x[4];
-            j = FLUID_SNPRINTF(x, sizeof(x), "%d;", i);
-            strncat(name, x, j);
-            n += j;
+            FLUID_LOG(FLUID_DBG, "winmidi: autoconnect dev name exceeds MAXPNAMELEN (%d), num (%d), n (%d)", MAXPNAMELEN, num, n);
+            return;
         }
-
-        name[n - 1] = 0;
+        strncat(new_name, x, j);
     }
+
+    name[n - 1] = 0;
+
+    FLUID_MEMSET(name, 0, MAXPNAMELEN);
+    FLUID_STRCPY(name, new_name);
 }
 
 /*

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -471,15 +471,20 @@ static void fluid_winmidi_autoconnect_build_name(char *name)
 {
     int i, j, n = 0;
     int num = midiInGetNumDevs();
-    if (num < 11) {
+
+    if(num < 11)
+    {
         memset(name, 0, MAXPNAMELEN);
-        for(i=0; i<num; ++i) {
+
+        for(i = 0; i < num; ++i)
+        {
             char x[4];
             j = snprintf(x, 4, "%d;", i);
             strncat(name, x, j);
             n += j;
         }
-        name[n-1] = 0;
+
+        name[n - 1] = 0;
     }
 }
 
@@ -517,7 +522,8 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     fluid_settings_getint(settings, "midi.autoconnect", &autoconnect_inputs);
     fluid_settings_getint(settings, "synth.midi-channels", &midi_channels);
 
-    if ((strcmp(dev_name, "default") == 0) && (autoconnect_inputs != 0)) {
+    if((strcmp(dev_name, "default") == 0) && (autoconnect_inputs != 0))
+    {
         fluid_winmidi_autoconnect_build_name(dev_name);
     }
 
@@ -557,9 +563,12 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
         dev_infos->channel_map = ch_map; /* map from input to output */
         /* calculate the next channel mapping, up to synth.midi-channels */
         ch_map += 16;
-        if (ch_map >= midi_channels) {
+
+        if(ch_map >= midi_channels)
+        {
             ch_map = 0;
         }
+
         FLUID_LOG(FLUID_DBG, "opening device at index %d", dev_infos->dev_idx);
         res = midiInOpen(&dev_infos->hmidiin, dev_infos->dev_idx,
                          (DWORD_PTR) fluid_winmidi_callback,

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -525,6 +525,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     if((strcmp(dev_name, "default") == 0) && (autoconnect_inputs != 0))
     {
         fluid_winmidi_autoconnect_build_name(dev_name);
+        FLUID_LOG(FLUID_DBG, "winmidi: autoconnect device name is now '%s'", dev_name);
     }
 
     /* parse device name, get the maximum number of devices to handle */

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -37,11 +37,13 @@
  * and forward these messages on distinct MIDI channels set.
  * 1.1)For example, if the user chooses 2 devices at index 0 and 1, the user
  * must specify this by putting the name "0;1" in midi.winmidi.device setting.
- * We get a fictif device composed of real devices (0,1). This fictif device
+ * We get a fictive device composed of real devices (0,1). This fictive device
  * behaves like a device with 32 MIDI channels whose messages are forwarded to
  * driver output as this:
  * - MIDI messages from real device 0 are output to MIDI channels set 0 to 15.
  * - MIDI messages from real device 1 are output to MIDI channels set 15 to 31.
+ * The above example assumes the setting synth.midi-channels value 32, but the
+ * default value for this setting is 16, in which case there will be no mapping.
  *
  * 1.2)Now another example with the name "1;0". The driver will forward
  * MIDI messages as this:
@@ -57,6 +59,13 @@
  * or use the multi device naming "0" (specifying only device index 0).
  * Both naming choice allows the driver to handle the same single device.
  *
+ * 3)If the device name is "default" and the setting "midi.autoconnect" is enabled,
+ * then all the available devices are opened, applying the appropriate channel
+ * mappings to each device (the first device is mapped to the 16 first channels,
+ * the second one to the next 16 channels, and so on with the limit of the
+ * synth.midi-channels setting. After arriving to the channels limit, the mapping
+ * restars with the channels 1-16.
+ * If the device name is specified, then midi.autoconnect setting is ignored.
  */
 
 #include "fluidsynth_priv.h"
@@ -458,6 +467,22 @@ fluid_winmidi_parse_device_name(fluid_winmidi_driver_t *dev, char *dev_name)
     return dev_count;
 }
 
+static void fluid_winmidi_autoconnect_build_name(char *name)
+{
+    int i, j, n = 0;
+    int num = midiInGetNumDevs();
+    if (num < 11) {
+        memset(name, 0, MAXPNAMELEN);
+        for(i=0; i<num; ++i) {
+            char x[4];
+            j = snprintf(x, 4, "%d;", i);
+            strncat(name, x, j);
+            n += j;
+        }
+        name[n-1] = 0;
+    }
+}
+
 /*
  * new_fluid_winmidi_driver
  */
@@ -469,6 +494,9 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     MMRESULT res;
     int i, j;
     int max_devices;  /* maximum number of devices to handle */
+    int autoconnect_inputs = 0;
+    int midi_channels = 16;
+    int ch_map = 0;
     char strError[MAXERRORLENGTH];
     char dev_name[MAXPNAMELEN];
 
@@ -484,6 +512,13 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     {
         FLUID_LOG(FLUID_DBG, "No MIDI in device selected, using \"default\"");
         FLUID_STRCPY(dev_name, "default");
+    }
+
+    fluid_settings_getint(settings, "midi.autoconnect", &autoconnect_inputs);
+    fluid_settings_getint(settings, "synth.midi-channels", &midi_channels);
+
+    if ((strcmp(dev_name, "default") == 0) && (autoconnect_inputs != 0)) {
+        fluid_winmidi_autoconnect_build_name(dev_name);
     }
 
     /* parse device name, get the maximum number of devices to handle */
@@ -519,7 +554,12 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
         device_infos_t *dev_infos = &dev->dev_infos[i];
         dev_infos->dev = dev;            /* driver structure */
         dev_infos->midi_num = i;         /* device order number */
-        dev_infos->channel_map = i * 16; /* map from input to output */
+        dev_infos->channel_map = ch_map; /* map from input to output */
+        /* calculate the next channel mapping, up to synth.midi-channels */
+        ch_map += 16;
+        if (ch_map >= midi_channels) {
+            ch_map = 0;
+        }
         FLUID_LOG(FLUID_DBG, "opening device at index %d", dev_infos->dev_idx);
         res = midiInOpen(&dev_infos->hmidiin, dev_infos->dev_idx,
                          (DWORD_PTR) fluid_winmidi_callback,

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -474,12 +474,12 @@ static void fluid_winmidi_autoconnect_build_name(char *name)
 
     if(num < 11)
     {
-        memset(name, 0, MAXPNAMELEN);
+        FLUID_MEMSET(name, 0, MAXPNAMELEN);
 
         for(i = 0; i < num; ++i)
         {
             char x[4];
-            j = snprintf(x, 4, "%d;", i);
+            j = FLUID_SNPRINTF(x, sizeof(x), "%d;", i);
             strncat(name, x, j);
             n += j;
         }


### PR DESCRIPTION
* Add midi auto connect support for winmidi
* Make minor adjustments for alsa_seq driver
* Populate the setting `midi.alsa.device` with available devices

For full context, please see discussion in #414.

Before this patch, all external devices were connected to the last MIDI IN port, applying the same mapping to all events.
After the patch, the external devices are connected in order to each MIDI IN port. When there are more devices than MIDI IN ports, the connections are distributed among all MIDI IN ports, sequentially.

For instance, when `synth.midi-channels` is 32, then 2 MIDI IN ports are created. If the user has 3 controllers: device1, device2 and device3 and nothing more, then autoconnect will do:

MIDI IN port 1 connected to device1 and device3.
MIDI IN port 2 connected to device2.
