### PR TITLE
Initialize Pipewire with pw_init()

### DIFF
--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -155,6 +155,8 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     float *buffer = NULL;
     const struct spa_pod *params[1];
 
+    pw_init(NULL, NULL);
+
     drv = FLUID_NEW(fluid_pipewire_audio_driver_t);
 
     if(!drv)


### PR DESCRIPTION
Before you can use any PipeWire functions, you need to call pw_init() (e.g. https://docs.pipewire.org/page_tutorial1.html)

> fluidsynth -a pipewire /usr/share/soundfonts/YamahaGrand.sf2 Queen_-_Bohemian_Rhapsody.mid
> FluidSynth runtime version 2.2.4
> Copyright (C) 2000-2021 Peter Hanappe and others.
> Distributed under the LGPL license.
> SoundFont(R) is a registered trademark of Creative Technology Ltd.
> 
> [E] pw.context [pipewire.c:256 load_spa_handle()] load lib: plugin directory undefined, set SPA_PLUGIN_DIR
> [E] pw.loop [loop.c:86 pw_loop_new()] 0x5555558478a0: can't make support.system handle: No such file or directory
> fluidsynth: error: Failed to allocate PipeWire loop
> Failed to create the audio driver. Giving up.


After the fix, it works perfectly.