### PR TITLE
cmake macos frameworks update

### DIFF
--- a/cmake_admin/DefaultDirs.cmake
+++ b/cmake_admin/DefaultDirs.cmake
@@ -15,12 +15,12 @@ endif ( WIN32 )
 mark_as_advanced (DEFAULT_SOUNDFONT)
 
 # BUNDLE_INSTALL_DIR - Mac only: the directory for application bundles 
-set (BUNDLE_INSTALL_DIR "/Applications" CACHE STRING 
+set (BUNDLE_INSTALL_DIR "Applications" CACHE STRING
      "The install dir for application bundles")
 mark_as_advanced (BUNDLE_INSTALL_DIR)
      
 # FRAMEWORK_INSTALL_DIR - Mac only: the directory for framework bundles
-set (FRAMEWORK_INSTALL_DIR "/Library/Frameworks" CACHE STRING 
+set (FRAMEWORK_INSTALL_DIR "Library/Frameworks" CACHE STRING
      "The install dir for framework bundles")
 mark_as_advanced (FRAMEWORK_INSTALL_DIR) 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -278,11 +278,15 @@ endif ( LIBFLUID_CPPFLAGS )
 
 # note: by default this target creates a shared object (or dll). To build a
 # static library instead, set the option BUILD_SHARED_LIBS to FALSE.
-add_library ( libfluidsynth $<TARGET_OBJECTS:libfluidsynth-OBJ> )
+add_library ( libfluidsynth
+    $<TARGET_OBJECTS:libfluidsynth-OBJ>
+    ${public_main_HEADER}
+    ${public_HEADERS}
+)
 
 if ( MACOSX_FRAMEWORK )
-     set_property ( SOURCE ${public_HEADERS}
-         PROPERTY MACOSX_PACKAGE_LOCATION Headers/fluidsynth
+    set_source_files_properties ( ${public_HEADERS}
+         PROPERTIES MACOSX_PACKAGE_LOCATION Headers/fluidsynth
      )
     set_target_properties ( libfluidsynth
       PROPERTIES


### PR DESCRIPTION
The framework target needs to know about the headers, so cmake tries to copy the framework files into the bundle.
The macro set_source_files_properties() is a modern (cmake >= 3.0) replacement of the general set_property().

This hopefully...
Closes #1024 