### PR TITLE
Add autoconnect to winmidi driver

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -752,6 +752,21 @@ and commit the results. Refresh with the following command:
             <def>default</def>
             <desc>The hardware device to use for Windows MIDI driver (not to be confused with the MIDI port). Multiple devices can be specified by a list of devices index separated by a semicolon (e.g "2;0", which is equivalent to one device with 32 MIDI channels). Using name "default" with midi.autoconnect set to 1 is equivalent to use all available devices.</desc>
         </setting>
+        <setting>
+            <name>winmidi.mergebox</name>
+            <type>bool</type>
+            <def>1 (TRUE) The driver map the device MIDI channels according the limit of the synth.midi-channels settings.<br />
+                          For example, if the user chooses 2 devices at index 0 and 1 and a default value of 16 for synth.midi-channels:<br />
+                          - MIDI messages from device 0 are mapped to MIDI channels set 0 to 15.<br />
+                          - MIDI messages from device 1 are also mapped to MIDI channels set 0 to 15.<br />
+                          Device 1 MIDI channels are merged with device 0 MIDI channels. This could lead to possible MIDI channels conflicts if both devices transmit at the same time on the same MIDI channel.</def>
+            <desc>
+                If 0 (FALSE), The driver makes an aggregation of the devices on separate MIDI channels to ensure no MIDI channel conflict.<br />
+                          For example, if the user chooses 2 devices at index 0 and 1:<br />
+                          - MIDI messages from device 0 are mapped to MIDI channels set 0 to 15.<br />
+                          - MIDI messages from device 1 are mapped to MIDI channels set 16 to 31.<br />
+            </desc>
+        </setting>
     </midi>
     
     <player label="MIDI player settings">

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -678,7 +678,7 @@ and commit the results. Refresh with the following command:
             <type>bool</type>
             <def>0 (FALSE)</def>
             <desc>
-                If 1 (TRUE), automatically connects FluidSynth to available MIDI input ports. alsa_seq, coremidi and jack are currently the only drivers making use of this.
+                If 1 (TRUE), automatically connects FluidSynth to available MIDI input ports. alsa_seq, coremidi, jack and winmidi are currently the only drivers making use of this.
             </desc>
         </setting>
         <setting>
@@ -750,7 +750,7 @@ and commit the results. Refresh with the following command:
             <name>winmidi.device</name>
             <type>str</type>
             <def>default</def>
-            <desc>The hardware device to use for Windows MIDI driver (not to be confused with the MIDI port). Multiple devices can be specified by a list of devices index separated by a semicolon (e.g "2;0", which is equivalent to one device with 32 MIDI channels).</desc>
+            <desc>The hardware device to use for Windows MIDI driver (not to be confused with the MIDI port). Multiple devices can be specified by a list of devices index separated by a semicolon (e.g "2;0", which is equivalent to one device with 32 MIDI channels). Using name "default" with midi.autoconnect set to 1 is equivalent to use all available devices.</desc>
         </setting>
     </midi>
     

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -33,7 +33,7 @@
  * user trough the settings midi.winmidi.device.
  *
  * If midi.winmidi.mergebox is set to 0 the driver makes an aggregation of the
- * devices on separate MIDI channels to ensure no MIDI channels conflicts.
+ * devices on separate MIDI channels to ensure no MIDI channel conflict.
  * For example, let the following device names:
  * 0:Port MIDI SB Live! [CE00], 1:SB PCI External MIDI, default, x[;y;z;..]
  * Then the driver is able receive MIDI messages comming from distinct devices
@@ -43,13 +43,13 @@
  * We get a fictive device composed of real devices (0,1). This fictive device
  * behaves like a device with 32 MIDI channels whose messages are forwarded to
  * driver output as this:
- * - MIDI messages from real device 0 are output to MIDI channels set 0 to 15.
- * - MIDI messages from real device 1 are output to MIDI channels set 16 to 31.
+ * - MIDI messages from real device 0 are mapped to MIDI channels set 0 to 15.
+ * - MIDI messages from real device 1 are mapped to MIDI channels set 16 to 31.
  *
  * 1.2)Now another example with the name "1;0". The driver will forward
  * MIDI messages as this:
- * - MIDI messages from real device 1 are output to MIDI channels set 0 to 15.
- * - MIDI messages from real device 0 are output to MIDI channels set 16 to 31.
+ * - MIDI messages from real device 1 are mapped to MIDI channels set 0 to 15.
+ * - MIDI messages from real device 0 are mapped to MIDI channels set 16 to 31.
  * So, the device order specified in the setting allows the user to choose the
  * MIDI channel set associated with this real device at the driver output
  * according this formula: output_channel = input_channel + device_order * 16.
@@ -65,14 +65,14 @@
  * any synths that could be a fluid synth and hardware synth(s) as well.
  *
  * If midi.winmidi.mergebox is set to 1 (default value). The driver map the device
- * according the limit of the synth.midi-channels setting.
+ * MIDI channels according the limit of the synth.midi-channels setting.
  * For example, if the user chooses 2 devices at index 0 and 1 and a default value
  * of 16 for synth.midi-channels setting:
  * - MIDI messages from real device 0 are output to MIDI channels set 0 to 15.
  * - MIDI messages from real device 1 are output to MIDI channels set 0 to 15.
  * Device 1 MIDI channels are merged with device 0 MIDI channel. This could lead
  * to possible MIDI channels conflicts if both MIDI devices transmit at the same
- * on the same MIDI channels.
+ * time on the same MIDI channel.
  *
  * 2)Note also that the driver handles single device by putting the device name
  * in midi.winmidi.device setting.

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -28,28 +28,40 @@
  * on the Internet.  Some MIDI devices will deadlock.  Therefore we add MIDIHDR
  * pointers to a queue and re-add them in a separate thread.  Lame-o API! :(
  *
- * Multiple/single devices handling capabilities:
- * This driver is able to handle multiple devices chosen by the user trough
- * the settings midi.winmidi.device.
+ * 1)Multiple/single devices handling capabilities:
+ * This driver is able to handle multiple MIDI input devices chosen by the
+ * user trough the settings midi.winmidi.device.
+ * The driver makes an aggregation of the devices on separate MIDI channels
+ * to ensure no MIDI channels conflicts.
  * For example, let the following device names:
  * 0:Port MIDI SB Live! [CE00], 1:SB PCI External MIDI, default, x[;y;z;..]
  * Then the driver is able receive MIDI messages comming from distinct devices
  * and forward these messages on distinct MIDI channels set.
  * 1.1)For example, if the user chooses 2 devices at index 0 and 1, the user
  * must specify this by putting the name "0;1" in midi.winmidi.device setting.
- * We get a fictif device composed of real devices (0,1). This fictif device
+ * We get a fictive device composed of real devices (0,1). This fictive device
  * behaves like a device with 32 MIDI channels whose messages are forwarded to
  * driver output as this:
  * - MIDI messages from real device 0 are output to MIDI channels set 0 to 15.
- * - MIDI messages from real device 1 are output to MIDI channels set 15 to 31.
+ * - MIDI messages from real device 1 are output to MIDI channels set 16 to 31.
  *
  * 1.2)Now another example with the name "1;0". The driver will forward
  * MIDI messages as this:
  * - MIDI messages from real device 1 are output to MIDI channels set 0 to 15.
- * - MIDI messages from real device 0 are output to MIDI channels set 15 to 31.
+ * - MIDI messages from real device 0 are output to MIDI channels set 16 to 31.
  * So, the device order specified in the setting allows the user to choose the
  * MIDI channel set associated with this real device at the driver output
  * according this formula: output_channel = input_channel + device_order * 16.
+ *
+ * Note the driver ignores the setting synth.midi-channels which default value
+ * for this setting is 16, in which case the second MIDI device will not be hear
+ * on the fluid synth instance.
+ * a) You have to rise the setting synth.midi-channels to accept the number
+ * of MIDI channels provided by the MIDI driver.
+ * b) You can also keep the default value of 16 for synth.midi-channels
+ * and have your application connected between the MIDI driver and the fluid synth.
+ * This way your application is able to map any MIDI channel from the driver to
+ * any synths that could be a fluid synth and hardware synth(s).
  *
  * 2)Note also that the driver handles single device by putting the device name
  * in midi.winmidi.device setting.

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -69,7 +69,7 @@
  * or use the multi device naming "0" (specifying only device index 0).
  * Both naming choice allows the driver to handle the same single device.
  *
- 3)If the setting "midi.autoconnect" is enabled and the device name is "default",
+ * 3)If the setting "midi.autoconnect" is enabled and the device name is "default",
  * then all the available devices are opened, applying the appropriate channel
  * mappings to each device (the first device is mapped to the 16 first channels
  * (0-15), the second one to the next 16 channels (16-31), and so on with the limit

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -514,9 +514,9 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     }
 
     fluid_settings_getint(settings, "midi.autoconnect", &autoconnect);
+    fluid_settings_getint(settings, "synth.midi-channels", &synth_midi_channels);
     if ((autoconnect) && (FLUID_STRCASECMP(dev_name, "default") == 0))
     {
-        fluid_settings_getint(settings, "synth.midi-channels", &synth_midi_channels);
         max_devices = midiInGetNumDevs(); /* get number of real devices installed */
     }
     else

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -514,7 +514,7 @@ new_fluid_winmidi_driver(fluid_settings_t *settings,
     }
 
     fluid_settings_getint(settings, "midi.autoconnect", &autoconnect);
-    if ((autoconnect) && (strcmp(dev_name, "default") == 0))
+    if ((autoconnect) && (FLUID_STRCASECMP(dev_name, "default") == 0))
     {
         fluid_settings_getint(settings, "synth.midi-channels", &synth_midi_channels);
         max_devices = midiInGetNumDevs(); /* get number of real devices installed */


### PR DESCRIPTION
This PR is an alternative to commit d031d4b of PR https://github.com/FluidSynth/fluidsynth/pull/1023

When midi.autoconnect is set to true it works as commit d031d4b of PR https://github.com/FluidSynth/fluidsynth/pull/1023.
When midi.autoconnect is false it works as actual.