### PR TITLE
Initialize Pipewire with pw_init()

### DIFF
--- a/doc/usage/audio_driver.txt
+++ b/doc/usage/audio_driver.txt
@@ -31,6 +31,7 @@ and a description.
 - file: Driver to output audio to a file
 - sdl2*: Simple DirectMedia Layer (Linux, Windows, Mac OS X, iOS, Android,
   FreeBSD, Haiku, etc.)
+- pipewire**: PipeWire (Linux)
 
 The default audio driver depends on the settings with which FluidSynth was
 compiled. You can get the default driver with
@@ -77,6 +78,12 @@ refer to the \setting{audio} documentation.
 is responsible for initializing SDL (e.g. with SDL_Init()). This must be done
 <strong>before</strong> the first call to <code>new_fluid_settings()</code>!
 Also make sure to call SDL_Quit() after all fluidsynth instances have been
+destroyed.
+
+<strong>**Note:</strong> In order to use pipeiwre as audio driver, the application
+is responsible for initializing PipeWire (e.g. with pw_init()). This must be done
+<strong>before</strong> the first call to <code>new_fluid_settings()</code>!
+Also make sure to call pw_deinit() after all fluidsynth instances have been
 destroyed.
 
 */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -484,6 +484,10 @@ if ( TARGET PkgConfig::SDL2 AND SDL2_SUPPORT ) # because SDL_Init() etc.
     target_link_libraries ( fluidsynth PRIVATE PkgConfig::SDL2 )
 endif()
 
+if ( TARGET PkgConfig::PIPEWIRE AND PIPEWIRE_SUPPORT ) # because pw_init() etc.
+    target_link_libraries ( fluidsynth PRIVATE PkgConfig::PIPEWIRE )
+endif()
+
 if ( TARGET PkgConfig::LIBINSTPATCH AND LIBINSTPATCH_SUPPORT )
     target_link_libraries ( fluidsynth PRIVATE PkgConfig::LIBINSTPATCH )
 endif()

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -192,7 +192,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
 
     if(!drv->pw_loop)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to allocate PipeWire loop");
+        FLUID_LOG(FLUID_ERR, "Failed to allocate PipeWire loop. Have you called pw_init() ?");
         goto driver_cleanup;
     }
 

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -42,6 +42,10 @@
 #include <SDL.h>
 #endif
 
+#if PIPEWIRE_SUPPORT
+#include <pipewire/pipewire.h>
+#endif
+
 void print_usage(void);
 void print_help(fluid_settings_t *settings);
 void print_welcome(void);
@@ -400,7 +404,6 @@ int main(int argc, char **argv)
 #endif
 
 #if SDL2_SUPPORT
-
     if(SDL_Init(SDL_INIT_AUDIO) != 0)
     {
         fprintf(stderr, "Warning: Unable to initialize SDL2 Audio: %s", SDL_GetError());
@@ -409,7 +412,11 @@ int main(int argc, char **argv)
     {
         atexit(SDL_Quit);
     }
+#endif
 
+#if PIPEWIRE_SUPPORT
+    pw_init(&argc, &argv);
+    atexit(pw_deinit);
 #endif
 
     /* create the settings */


### PR DESCRIPTION
Before using any PipeWire functions, one must call pw_init() (e.g. https://docs.pipewire.org/page_tutorial1.html)

Thanks to @insilications for noticing.