### PR TITLE
Use project-specific SOURCE_DIR and BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,6 @@ cmake_minimum_required ( VERSION 3.13 )
 # 3.11 because COMPATIBILITY SameMinorVersion in CMakePackageConfigHelpers
 # 3.13.5 because it is the latest supported in Windows XP
 
-set ( FLUIDSYNTH_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
-set ( FLUIDSYNTH_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} )
-
 if(POLICY CMP0075) # CMake version 3.13.5 warns when the policy is not set or value is OLD
   cmake_policy(SET CMP0075 NEW)
 endif()
@@ -36,7 +33,7 @@ if(POLICY CMP0091) # new in CMake 3.15, defaults to OLD
 endif()
 
 project ( FluidSynth C CXX )
-list( APPEND CMAKE_MODULE_PATH ${FLUIDSYNTH_SOURCE_DIR}/cmake_admin )
+list( APPEND CMAKE_MODULE_PATH ${FluidSynth_SOURCE_DIR}/cmake_admin )
 
 # FluidSynth package name
 set ( PACKAGE "fluidsynth" )
@@ -452,13 +449,13 @@ endif ( CMAKE_BUILD_TYPE MATCHES "Debug" )
 file(GLOB_RECURSE
      ALL_SOURCE_FILES
      LIST_DIRECTORIES false
-     ${FLUIDSYNTH_SOURCE_DIR}/*.[chi]
-     ${FLUIDSYNTH_SOURCE_DIR}/*.[chi]pp
-     ${FLUIDSYNTH_SOURCE_DIR}/*.[chi]xx
-     ${FLUIDSYNTH_SOURCE_DIR}/*.cc
-     ${FLUIDSYNTH_SOURCE_DIR}/*.hh
-     ${FLUIDSYNTH_SOURCE_DIR}/*.ii
-     ${FLUIDSYNTH_SOURCE_DIR}/*.[CHI]
+     ${FluidSynth_SOURCE_DIR}/*.[chi]
+     ${FluidSynth_SOURCE_DIR}/*.[chi]pp
+     ${FluidSynth_SOURCE_DIR}/*.[chi]xx
+     ${FluidSynth_SOURCE_DIR}/*.cc
+     ${FluidSynth_SOURCE_DIR}/*.hh
+     ${FluidSynth_SOURCE_DIR}/*.ii
+     ${FluidSynth_SOURCE_DIR}/*.[CHI]
      )
 
 find_program ( ASTYLE "astyle" )
@@ -739,11 +736,11 @@ if ( OpenMP_FOUND OR OpenMP_C_FOUND )
 endif()
 
 # manipulate some variables to setup a proper test env
-set(TEST_SOUNDFONT "${FLUIDSYNTH_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf2")
-set(TEST_SOUNDFONT_UTF8_1 "${FLUIDSYNTH_SOURCE_DIR}/sf2/\\xE2\\x96\\xA0VintageDreamsWaves-v2\\xE2\\x96\\xA0.sf2")
-set(TEST_SOUNDFONT_UTF8_2 "${FLUIDSYNTH_SOURCE_DIR}/sf2/VìntàgèDrèàmsWàvès-v2.sf2")
-set(TEST_SOUNDFONT_SF3 "${FLUIDSYNTH_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf3")
-set(TEST_MIDI_UTF8 "${FLUIDSYNTH_SOURCE_DIR}/test/èmpty.mid")
+set(TEST_SOUNDFONT "${FluidSynth_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf2")
+set(TEST_SOUNDFONT_UTF8_1 "${FluidSynth_SOURCE_DIR}/sf2/\\xE2\\x96\\xA0VintageDreamsWaves-v2\\xE2\\x96\\xA0.sf2")
+set(TEST_SOUNDFONT_UTF8_2 "${FluidSynth_SOURCE_DIR}/sf2/VìntàgèDrèàmsWàvès-v2.sf2")
+set(TEST_SOUNDFONT_SF3 "${FluidSynth_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf3")
+set(TEST_MIDI_UTF8 "${FluidSynth_SOURCE_DIR}/test/èmpty.mid")
 
 # Make sure to link against libm before checking for math functions below
 set ( CMAKE_REQUIRED_LIBRARIES "${LIBFLUID_LIBS};${WINDOWS_LIBS}" )
@@ -813,8 +810,8 @@ if ( HAVE_SOCKLEN_T )
 endif ( HAVE_SOCKLEN_T )
 
 # General configuration file
-configure_file ( ${FLUIDSYNTH_SOURCE_DIR}/src/config.cmake
-                 ${FLUIDSYNTH_BINARY_DIR}/config.h )
+configure_file ( ${FluidSynth_SOURCE_DIR}/src/config.cmake
+                 ${FluidSynth_BINARY_DIR}/config.h )
 
 # required to allow ctest to be called from top-level build directory
 ENABLE_TESTING()
@@ -838,8 +835,8 @@ else ()
   set ( includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}" )
 endif ()
 
-generate_pkgconfig_spec(fluidsynth.pc.in ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.pc libfluidsynth-OBJ)
-install ( FILES ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.pc
+generate_pkgconfig_spec(fluidsynth.pc.in ${FluidSynth_BINARY_DIR}/fluidsynth.pc libfluidsynth-OBJ)
+install ( FILES ${FluidSynth_BINARY_DIR}/fluidsynth.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 
 # Exported targets for cmake: find_package(FluidSynth)
@@ -848,7 +845,7 @@ install ( FILES ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.pc
 
 # targets in the build directory
 export(EXPORT FluidSynthTargets
-   FILE "${FLUIDSYNTH_BINARY_DIR}/FluidSynthTargets.cmake"
+   FILE "${FluidSynth_BINARY_DIR}/FluidSynthTargets.cmake"
    NAMESPACE FluidSynth::
 )
 
@@ -864,8 +861,8 @@ write_basic_package_version_file(
 # support generating a config.cmake file for both the installed
 # package and for using the build directory directly.
 configure_file(FluidSynthConfig.cmake.in FluidSynthConfig.cmake @ONLY)
-install(FILES "${FLUIDSYNTH_BINARY_DIR}/FluidSynthConfig.cmake"
-              "${FLUIDSYNTH_BINARY_DIR}/FluidSynthConfigVersion.cmake"
+install(FILES "${FluidSynth_BINARY_DIR}/FluidSynthConfig.cmake"
+              "${FluidSynth_BINARY_DIR}/FluidSynthConfigVersion.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fluidsynth
 )
 
@@ -873,18 +870,18 @@ install(FILES "${FLUIDSYNTH_BINARY_DIR}/FluidSynthConfig.cmake"
 if ( UNIX )
     if ( DEFINED FLUID_DAEMON_ENV_FILE)
         configure_file ( fluidsynth.service.in
-        ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.service @ONLY )
+        ${FluidSynth_BINARY_DIR}/fluidsynth.service @ONLY )
 
         configure_file ( fluidsynth.conf.in
-        ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.conf @ONLY )
+        ${FluidSynth_BINARY_DIR}/fluidsynth.conf @ONLY )
 
     endif ( DEFINED FLUID_DAEMON_ENV_FILE )
 
     # uninstall custom target
-    configure_file ( "${FLUIDSYNTH_SOURCE_DIR}/cmake_admin/cmake_uninstall.cmake.in"
-      "${FLUIDSYNTH_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
+    configure_file ( "${FluidSynth_SOURCE_DIR}/cmake_admin/cmake_uninstall.cmake.in"
+      "${FluidSynth_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
     add_custom_target ( uninstall
-      "${CMAKE_COMMAND}" -P "${FLUIDSYNTH_BINARY_DIR}/cmake_uninstall.cmake")
+      "${CMAKE_COMMAND}" -P "${FluidSynth_BINARY_DIR}/cmake_uninstall.cmake")
 endif ( UNIX )
 
 include ( report )
@@ -892,8 +889,8 @@ include ( report )
 # CPack support
 set ( CPACK_PACKAGE_DESCRIPTION_SUMMARY "FluidSynth real-time synthesizer" )
 set ( CPACK_PACKAGE_VENDOR "fluidsynth.org" )
-set ( CPACK_PACKAGE_DESCRIPTION_FILE "${FLUIDSYNTH_SOURCE_DIR}/README.md" )
-set ( CPACK_RESOURCE_FILE_LICENSE "${FLUIDSYNTH_SOURCE_DIR}/LICENSE" )
+set ( CPACK_PACKAGE_DESCRIPTION_FILE "${FluidSynth_SOURCE_DIR}/README.md" )
+set ( CPACK_RESOURCE_FILE_LICENSE "${FluidSynth_SOURCE_DIR}/LICENSE" )
 set ( CPACK_PACKAGE_VERSION_MAJOR ${FLUIDSYNTH_VERSION_MAJOR} )
 set ( CPACK_PACKAGE_VERSION_MINOR ${FLUIDSYNTH_VERSION_MINOR} )
 set ( CPACK_PACKAGE_VERSION_PATCH ${FLUIDSYNTH_VERSION_MICRO} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ cmake_minimum_required ( VERSION 3.13 )
 # 3.11 because COMPATIBILITY SameMinorVersion in CMakePackageConfigHelpers
 # 3.13.5 because it is the latest supported in Windows XP
 
+set ( FLUIDSYNTH_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
+set ( FLUIDSYNTH_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} )
+
 if(POLICY CMP0075) # CMake version 3.13.5 warns when the policy is not set or value is OLD
   cmake_policy(SET CMP0075 NEW)
 endif()
@@ -33,7 +36,7 @@ if(POLICY CMP0091) # new in CMake 3.15, defaults to OLD
 endif()
 
 project ( FluidSynth C CXX )
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_admin )
+list( APPEND CMAKE_MODULE_PATH ${FLUIDSYNTH_SOURCE_DIR}/cmake_admin )
 
 # FluidSynth package name
 set ( PACKAGE "fluidsynth" )
@@ -449,13 +452,13 @@ endif ( CMAKE_BUILD_TYPE MATCHES "Debug" )
 file(GLOB_RECURSE
      ALL_SOURCE_FILES
      LIST_DIRECTORIES false
-     ${CMAKE_SOURCE_DIR}/*.[chi]
-     ${CMAKE_SOURCE_DIR}/*.[chi]pp
-     ${CMAKE_SOURCE_DIR}/*.[chi]xx
-     ${CMAKE_SOURCE_DIR}/*.cc
-     ${CMAKE_SOURCE_DIR}/*.hh
-     ${CMAKE_SOURCE_DIR}/*.ii
-     ${CMAKE_SOURCE_DIR}/*.[CHI]
+     ${FLUIDSYNTH_SOURCE_DIR}/*.[chi]
+     ${FLUIDSYNTH_SOURCE_DIR}/*.[chi]pp
+     ${FLUIDSYNTH_SOURCE_DIR}/*.[chi]xx
+     ${FLUIDSYNTH_SOURCE_DIR}/*.cc
+     ${FLUIDSYNTH_SOURCE_DIR}/*.hh
+     ${FLUIDSYNTH_SOURCE_DIR}/*.ii
+     ${FLUIDSYNTH_SOURCE_DIR}/*.[CHI]
      )
 
 find_program ( ASTYLE "astyle" )
@@ -736,11 +739,11 @@ if ( OpenMP_FOUND OR OpenMP_C_FOUND )
 endif()
 
 # manipulate some variables to setup a proper test env
-set(TEST_SOUNDFONT "${CMAKE_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf2")
-set(TEST_SOUNDFONT_UTF8_1 "${CMAKE_SOURCE_DIR}/sf2/\\xE2\\x96\\xA0VintageDreamsWaves-v2\\xE2\\x96\\xA0.sf2")
-set(TEST_SOUNDFONT_UTF8_2 "${CMAKE_SOURCE_DIR}/sf2/VìntàgèDrèàmsWàvès-v2.sf2")
-set(TEST_SOUNDFONT_SF3 "${CMAKE_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf3")
-set(TEST_MIDI_UTF8 "${CMAKE_SOURCE_DIR}/test/èmpty.mid")
+set(TEST_SOUNDFONT "${FLUIDSYNTH_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf2")
+set(TEST_SOUNDFONT_UTF8_1 "${FLUIDSYNTH_SOURCE_DIR}/sf2/\\xE2\\x96\\xA0VintageDreamsWaves-v2\\xE2\\x96\\xA0.sf2")
+set(TEST_SOUNDFONT_UTF8_2 "${FLUIDSYNTH_SOURCE_DIR}/sf2/VìntàgèDrèàmsWàvès-v2.sf2")
+set(TEST_SOUNDFONT_SF3 "${FLUIDSYNTH_SOURCE_DIR}/sf2/VintageDreamsWaves-v2.sf3")
+set(TEST_MIDI_UTF8 "${FLUIDSYNTH_SOURCE_DIR}/test/èmpty.mid")
 
 # Make sure to link against libm before checking for math functions below
 set ( CMAKE_REQUIRED_LIBRARIES "${LIBFLUID_LIBS};${WINDOWS_LIBS}" )
@@ -810,8 +813,8 @@ if ( HAVE_SOCKLEN_T )
 endif ( HAVE_SOCKLEN_T )
 
 # General configuration file
-configure_file ( ${CMAKE_SOURCE_DIR}/src/config.cmake
-                 ${CMAKE_BINARY_DIR}/config.h )
+configure_file ( ${FLUIDSYNTH_SOURCE_DIR}/src/config.cmake
+                 ${FLUIDSYNTH_BINARY_DIR}/config.h )
 
 # required to allow ctest to be called from top-level build directory
 ENABLE_TESTING()
@@ -835,8 +838,8 @@ else ()
   set ( includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}" )
 endif ()
 
-generate_pkgconfig_spec(fluidsynth.pc.in ${CMAKE_BINARY_DIR}/fluidsynth.pc libfluidsynth-OBJ)
-install ( FILES ${CMAKE_BINARY_DIR}/fluidsynth.pc
+generate_pkgconfig_spec(fluidsynth.pc.in ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.pc libfluidsynth-OBJ)
+install ( FILES ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 
 # Exported targets for cmake: find_package(FluidSynth)
@@ -845,7 +848,7 @@ install ( FILES ${CMAKE_BINARY_DIR}/fluidsynth.pc
 
 # targets in the build directory
 export(EXPORT FluidSynthTargets
-   FILE "${CMAKE_CURRENT_BINARY_DIR}/FluidSynthTargets.cmake"
+   FILE "${FLUIDSYNTH_BINARY_DIR}/FluidSynthTargets.cmake"
    NAMESPACE FluidSynth::
 )
 
@@ -861,8 +864,8 @@ write_basic_package_version_file(
 # support generating a config.cmake file for both the installed
 # package and for using the build directory directly.
 configure_file(FluidSynthConfig.cmake.in FluidSynthConfig.cmake @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/FluidSynthConfig.cmake"
-              "${CMAKE_CURRENT_BINARY_DIR}/FluidSynthConfigVersion.cmake"
+install(FILES "${FLUIDSYNTH_BINARY_DIR}/FluidSynthConfig.cmake"
+              "${FLUIDSYNTH_BINARY_DIR}/FluidSynthConfigVersion.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fluidsynth
 )
 
@@ -870,18 +873,18 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/FluidSynthConfig.cmake"
 if ( UNIX )
     if ( DEFINED FLUID_DAEMON_ENV_FILE)
         configure_file ( fluidsynth.service.in
-        ${CMAKE_BINARY_DIR}/fluidsynth.service @ONLY )
+        ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.service @ONLY )
 
         configure_file ( fluidsynth.conf.in
-        ${CMAKE_BINARY_DIR}/fluidsynth.conf @ONLY )
+        ${FLUIDSYNTH_BINARY_DIR}/fluidsynth.conf @ONLY )
 
     endif ( DEFINED FLUID_DAEMON_ENV_FILE )
 
     # uninstall custom target
-    configure_file ( "${CMAKE_SOURCE_DIR}/cmake_admin/cmake_uninstall.cmake.in"
-      "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
+    configure_file ( "${FLUIDSYNTH_SOURCE_DIR}/cmake_admin/cmake_uninstall.cmake.in"
+      "${FLUIDSYNTH_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
     add_custom_target ( uninstall
-      "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+      "${CMAKE_COMMAND}" -P "${FLUIDSYNTH_BINARY_DIR}/cmake_uninstall.cmake")
 endif ( UNIX )
 
 include ( report )
@@ -889,8 +892,8 @@ include ( report )
 # CPack support
 set ( CPACK_PACKAGE_DESCRIPTION_SUMMARY "FluidSynth real-time synthesizer" )
 set ( CPACK_PACKAGE_VENDOR "fluidsynth.org" )
-set ( CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.md" )
-set ( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE" )
+set ( CPACK_PACKAGE_DESCRIPTION_FILE "${FLUIDSYNTH_SOURCE_DIR}/README.md" )
+set ( CPACK_RESOURCE_FILE_LICENSE "${FLUIDSYNTH_SOURCE_DIR}/LICENSE" )
 set ( CPACK_PACKAGE_VERSION_MAJOR ${FLUIDSYNTH_VERSION_MAJOR} )
 set ( CPACK_PACKAGE_VERSION_MINOR ${FLUIDSYNTH_VERSION_MINOR} )
 set ( CPACK_PACKAGE_VERSION_PATCH ${FLUIDSYNTH_VERSION_MICRO} )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,7 @@ if ( OBOE_SUPPORT )
   set ( fluid_oboe_SOURCES drivers/fluid_oboe.cpp )
 endif ( OBOE_SUPPORT )
 
-set ( config_SOURCES ${FLUIDSYNTH_BINARY_DIR}/config.h )
+set ( config_SOURCES ${FluidSynth_BINARY_DIR}/config.h )
 
 set ( libfluidsynth_SOURCES
     utils/fluid_conv.c
@@ -183,32 +183,32 @@ set ( libfluidsynth_SOURCES
 )
 
 set ( public_HEADERS
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/audio.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/event.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/gen.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/ladspa.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/log.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/midi.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/misc.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/mod.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/seq.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/seqbind.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/settings.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/sfont.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/shell.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/synth.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/types.h
-    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/voice.h
-    ${FLUIDSYNTH_BINARY_DIR}/include/fluidsynth/version.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/audio.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/event.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/gen.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/ladspa.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/log.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/midi.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/misc.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/mod.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/seq.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/seqbind.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/settings.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/sfont.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/shell.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/synth.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/types.h
+    ${FluidSynth_SOURCE_DIR}/include/fluidsynth/voice.h
+    ${FluidSynth_BINARY_DIR}/include/fluidsynth/version.h
 )
 
 set ( public_main_HEADER
-    ${FLUIDSYNTH_BINARY_DIR}/include/fluidsynth.h
+    ${FluidSynth_BINARY_DIR}/include/fluidsynth.h
 )
 
-configure_file ( ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/version.h.in 
-                 ${FLUIDSYNTH_BINARY_DIR}/include/fluidsynth/version.h )
-configure_file ( ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth.cmake
+configure_file ( ${FluidSynth_SOURCE_DIR}/include/fluidsynth/version.h.in 
+                 ${FluidSynth_BINARY_DIR}/include/fluidsynth/version.h )
+configure_file ( ${FluidSynth_SOURCE_DIR}/include/fluidsynth.cmake
                  ${public_main_HEADER} )
 
 if ( WIN32 )
@@ -258,17 +258,17 @@ add_library ( libfluidsynth-OBJ OBJECT
 )
 
 target_include_directories ( libfluidsynth-OBJ PRIVATE
-    ${FLUIDSYNTH_BINARY_DIR}
-    ${FLUIDSYNTH_BINARY_DIR}/include
-    ${FLUIDSYNTH_SOURCE_DIR}/src
-    ${FLUIDSYNTH_SOURCE_DIR}/src/drivers
-    ${FLUIDSYNTH_SOURCE_DIR}/src/synth
-    ${FLUIDSYNTH_SOURCE_DIR}/src/rvoice
-    ${FLUIDSYNTH_SOURCE_DIR}/src/midi
-    ${FLUIDSYNTH_SOURCE_DIR}/src/utils
-    ${FLUIDSYNTH_SOURCE_DIR}/src/sfloader
-    ${FLUIDSYNTH_SOURCE_DIR}/src/bindings
-    ${FLUIDSYNTH_SOURCE_DIR}/include
+    ${FluidSynth_BINARY_DIR}
+    ${FluidSynth_BINARY_DIR}/include
+    ${FluidSynth_SOURCE_DIR}/src
+    ${FluidSynth_SOURCE_DIR}/src/drivers
+    ${FluidSynth_SOURCE_DIR}/src/synth
+    ${FluidSynth_SOURCE_DIR}/src/rvoice
+    ${FluidSynth_SOURCE_DIR}/src/midi
+    ${FluidSynth_SOURCE_DIR}/src/utils
+    ${FluidSynth_SOURCE_DIR}/src/sfloader
+    ${FluidSynth_SOURCE_DIR}/src/bindings
+    ${FluidSynth_SOURCE_DIR}/include
 )
 
 if ( LIBFLUID_CPPFLAGS )
@@ -457,16 +457,16 @@ if ( FLUID_CPPFLAGS )
 endif ( FLUID_CPPFLAGS )
 
 target_include_directories ( fluidsynth PRIVATE
-    ${FLUIDSYNTH_BINARY_DIR}
-    ${FLUIDSYNTH_BINARY_DIR}/include
-    ${FLUIDSYNTH_SOURCE_DIR}/src/bindings
-    ${FLUIDSYNTH_SOURCE_DIR}/src/midi
-    ${FLUIDSYNTH_SOURCE_DIR}/src/rvoice
-    ${FLUIDSYNTH_SOURCE_DIR}/src/sfloader
-    ${FLUIDSYNTH_SOURCE_DIR}/src/synth
-    ${FLUIDSYNTH_SOURCE_DIR}/src/utils
-    ${FLUIDSYNTH_SOURCE_DIR}/src/
-    ${FLUIDSYNTH_SOURCE_DIR}/include
+    ${FluidSynth_BINARY_DIR}
+    ${FluidSynth_BINARY_DIR}/include
+    ${FluidSynth_SOURCE_DIR}/src/bindings
+    ${FluidSynth_SOURCE_DIR}/src/midi
+    ${FluidSynth_SOURCE_DIR}/src/rvoice
+    ${FluidSynth_SOURCE_DIR}/src/sfloader
+    ${FluidSynth_SOURCE_DIR}/src/synth
+    ${FluidSynth_SOURCE_DIR}/src/utils
+    ${FluidSynth_SOURCE_DIR}/src/
+    ${FluidSynth_SOURCE_DIR}/include
 )
 
 target_link_libraries ( fluidsynth PRIVATE
@@ -551,6 +551,6 @@ ExternalProject_Add(gentables
         "${CMAKE_COMMAND}" -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE} -G "${CMAKE_GENERATOR}" -B "${GENTAB_BDIR}" "${GENTAB_SDIR}"
     BUILD_COMMAND
         "${CMAKE_COMMAND}" --build "${GENTAB_BDIR}"
-    INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${FLUIDSYNTH_BINARY_DIR}/"
+    INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${FluidSynth_BINARY_DIR}/"
 )
 add_dependencies(libfluidsynth-OBJ gentables)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,7 @@ if ( OBOE_SUPPORT )
   set ( fluid_oboe_SOURCES drivers/fluid_oboe.cpp )
 endif ( OBOE_SUPPORT )
 
-set ( config_SOURCES ${CMAKE_BINARY_DIR}/config.h )
+set ( config_SOURCES ${FLUIDSYNTH_BINARY_DIR}/config.h )
 
 set ( libfluidsynth_SOURCES
     utils/fluid_conv.c
@@ -183,32 +183,32 @@ set ( libfluidsynth_SOURCES
 )
 
 set ( public_HEADERS
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/audio.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/event.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/gen.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/ladspa.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/log.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/midi.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/misc.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/mod.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/seq.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/seqbind.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/settings.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/sfont.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/shell.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/synth.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/types.h
-    ${CMAKE_SOURCE_DIR}/include/fluidsynth/voice.h
-    ${CMAKE_BINARY_DIR}/include/fluidsynth/version.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/audio.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/event.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/gen.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/ladspa.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/log.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/midi.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/misc.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/mod.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/seq.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/seqbind.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/settings.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/sfont.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/shell.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/synth.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/types.h
+    ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/voice.h
+    ${FLUIDSYNTH_BINARY_DIR}/include/fluidsynth/version.h
 )
 
 set ( public_main_HEADER
-    ${CMAKE_BINARY_DIR}/include/fluidsynth.h
+    ${FLUIDSYNTH_BINARY_DIR}/include/fluidsynth.h
 )
 
-configure_file ( ${CMAKE_SOURCE_DIR}/include/fluidsynth/version.h.in 
-                 ${CMAKE_BINARY_DIR}/include/fluidsynth/version.h )
-configure_file ( ${CMAKE_SOURCE_DIR}/include/fluidsynth.cmake
+configure_file ( ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth/version.h.in 
+                 ${FLUIDSYNTH_BINARY_DIR}/include/fluidsynth/version.h )
+configure_file ( ${FLUIDSYNTH_SOURCE_DIR}/include/fluidsynth.cmake
                  ${public_main_HEADER} )
 
 if ( WIN32 )
@@ -258,17 +258,17 @@ add_library ( libfluidsynth-OBJ OBJECT
 )
 
 target_include_directories ( libfluidsynth-OBJ PRIVATE
-    ${CMAKE_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/include
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_SOURCE_DIR}/src/drivers
-    ${CMAKE_SOURCE_DIR}/src/synth
-    ${CMAKE_SOURCE_DIR}/src/rvoice
-    ${CMAKE_SOURCE_DIR}/src/midi
-    ${CMAKE_SOURCE_DIR}/src/utils
-    ${CMAKE_SOURCE_DIR}/src/sfloader
-    ${CMAKE_SOURCE_DIR}/src/bindings
-    ${CMAKE_SOURCE_DIR}/include
+    ${FLUIDSYNTH_BINARY_DIR}
+    ${FLUIDSYNTH_BINARY_DIR}/include
+    ${FLUIDSYNTH_SOURCE_DIR}/src
+    ${FLUIDSYNTH_SOURCE_DIR}/src/drivers
+    ${FLUIDSYNTH_SOURCE_DIR}/src/synth
+    ${FLUIDSYNTH_SOURCE_DIR}/src/rvoice
+    ${FLUIDSYNTH_SOURCE_DIR}/src/midi
+    ${FLUIDSYNTH_SOURCE_DIR}/src/utils
+    ${FLUIDSYNTH_SOURCE_DIR}/src/sfloader
+    ${FLUIDSYNTH_SOURCE_DIR}/src/bindings
+    ${FLUIDSYNTH_SOURCE_DIR}/include
 )
 
 if ( LIBFLUID_CPPFLAGS )
@@ -457,16 +457,16 @@ if ( FLUID_CPPFLAGS )
 endif ( FLUID_CPPFLAGS )
 
 target_include_directories ( fluidsynth PRIVATE
-    ${CMAKE_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/include
-    ${CMAKE_SOURCE_DIR}/src/bindings
-    ${CMAKE_SOURCE_DIR}/src/midi
-    ${CMAKE_SOURCE_DIR}/src/rvoice
-    ${CMAKE_SOURCE_DIR}/src/sfloader
-    ${CMAKE_SOURCE_DIR}/src/synth
-    ${CMAKE_SOURCE_DIR}/src/utils
-    ${CMAKE_SOURCE_DIR}/src/
-    ${CMAKE_SOURCE_DIR}/include
+    ${FLUIDSYNTH_BINARY_DIR}
+    ${FLUIDSYNTH_BINARY_DIR}/include
+    ${FLUIDSYNTH_SOURCE_DIR}/src/bindings
+    ${FLUIDSYNTH_SOURCE_DIR}/src/midi
+    ${FLUIDSYNTH_SOURCE_DIR}/src/rvoice
+    ${FLUIDSYNTH_SOURCE_DIR}/src/sfloader
+    ${FLUIDSYNTH_SOURCE_DIR}/src/synth
+    ${FLUIDSYNTH_SOURCE_DIR}/src/utils
+    ${FLUIDSYNTH_SOURCE_DIR}/src/
+    ${FLUIDSYNTH_SOURCE_DIR}/include
 )
 
 target_link_libraries ( fluidsynth PRIVATE
@@ -551,6 +551,6 @@ ExternalProject_Add(gentables
         "${CMAKE_COMMAND}" -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE} -G "${CMAKE_GENERATOR}" -B "${GENTAB_BDIR}" "${GENTAB_SDIR}"
     BUILD_COMMAND
         "${CMAKE_COMMAND}" --build "${GENTAB_BDIR}"
-    INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${CMAKE_BINARY_DIR}/"
+    INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${FLUIDSYNTH_BINARY_DIR}/"
 )
 add_dependencies(libfluidsynth-OBJ gentables)


### PR DESCRIPTION
This change is for compatibility of adding fluidsynth as subdirectory in other cmakefiles.
If fluidsynth is added as subdirectory of other projects, it would produce error since CMAKE_SOURCE_DIR is different from the value when built solely.
I have nothing to complain about even if you don't accept it, but it would be grateful if you consider it.

Thanks in advance.