### PR TITLE
Proper version check. validated on macOS 11.6.1 and macOS 12.2.1

### DIFF
--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -73,7 +73,7 @@ OSStatus fluid_core_audio_callback(void *data,
 
 #define OK(x) (x == noErr)
 
-#if MAC_OS_X_VERSION < 1200
+#if __MAC_OS_X_VERSION_MAX_ALLOWED < 120000
 #define kAudioObjectPropertyElementMain (kAudioObjectPropertyElementMaster)
 #endif
 


### PR DESCRIPTION
This is a fix for the prior PR that included a patch to silence deprecation warning involving `kAudioObjectPropertyElementMaster`. 