### PR TITLE
Use int64_t as fluid_long_long_t in C99

### DIFF
--- a/include/fluidsynth/types.h
+++ b/include/fluidsynth/types.h
@@ -27,6 +27,9 @@
 extern "C" {
 #endif
 
+#if !(defined(_MSC_VER) && (_MSC_VER < 1800))
+#include <stdint.h>
+#endif
 
 /**
  * @defgroup Types Types
@@ -73,7 +76,6 @@ typedef __int64 fluid_long_long_t; // even on 32bit windows
  * A typedef for C99's type long long, which is at least 64-bit wide, as guaranteed by the C99.
  * @p __int64 will be used as replacement for VisualStudio 2010 and older.
  */
-#include <stdint.h>
 typedef int64_t fluid_long_long_t;
 #endif
 

--- a/include/fluidsynth/types.h
+++ b/include/fluidsynth/types.h
@@ -73,7 +73,8 @@ typedef __int64 fluid_long_long_t; // even on 32bit windows
  * A typedef for C99's type long long, which is at least 64-bit wide, as guaranteed by the C99.
  * @p __int64 will be used as replacement for VisualStudio 2010 and older.
  */
-typedef long long fluid_long_long_t;
+#include <stdint.h>
+typedef int64_t fluid_long_long_t;
 #endif
 
 /* @} */


### PR DESCRIPTION
Currently, fixed type of long long is used for fluid_long_long_t, as it is guranteed to have 64-bit wide in C99.
However, stdint.h defines int64_t as long, so it has posibillity to break codes which uses 64-bit type with stdint.
For example, jni.h defines jlong with int64_t, so some functions which uses fluid_long_long_t as parameter type breaks when binding them into jlong.

So, even though using long long as 64-bit type is reasonable, I suggest you to use int64_t since it has potential to break in some build targets.

Thanks in advance.