### PR TITLE
Fix oboe driver build issue in latest glib

### DIFF
--- a/src/drivers/fluid_adriver.h
+++ b/src/drivers/fluid_adriver.h
@@ -23,6 +23,10 @@
 
 #include "fluidsynth_priv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * fluid_audio_driver_t
  */
@@ -175,6 +179,8 @@ fluid_audio_driver_t *new_fluid_file_audio_driver(fluid_settings_t *settings,
 void delete_fluid_file_audio_driver(fluid_audio_driver_t *p);
 #endif
 
-
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* _FLUID_AUDRIVER_H */

--- a/src/drivers/fluid_oboe.cpp
+++ b/src/drivers/fluid_oboe.cpp
@@ -25,12 +25,8 @@
  * This file may make use of C++14, because it's required by oboe anyway.
  */
 
-extern "C" {
-
 #include "fluid_adriver.h"
 #include "fluid_settings.h"
-
-} // extern "C"
 
 #if OBOE_SUPPORT
 

--- a/src/utils/fluid_settings.h
+++ b/src/utils/fluid_settings.h
@@ -22,6 +22,10 @@
 #ifndef _FLUID_SETTINGS_H
 #define _FLUID_SETTINGS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int fluid_settings_add_option(fluid_settings_t *settings, const char *name, const char *s);
 int fluid_settings_remove_option(fluid_settings_t *settings, const char *name, const char *s);
 
@@ -53,5 +57,9 @@ int fluid_settings_callback_int(fluid_settings_t *settings, const char *name,
 int fluid_settings_split_csv(const char *str, int *buf, int buf_len);
 
 void* fluid_settings_get_user_data(fluid_settings_t * settings, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLUID_SETTINGS_H */

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -48,6 +48,9 @@
 
 #include "fluidsynth.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /***************************************************************
  *
@@ -318,5 +321,8 @@ else \
 #define fluid_return_val_if_fail(cond, val) \
  fluid_return_if_fail(cond) (val)
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLUIDSYNTH_PRIV_H */


### PR DESCRIPTION
I recently managed to build latest glib(2.71.2) on Android with meson, and found that oboe driver is not building well on it.

It is because glib is included (indirectly in `fluidsynth_priv.h`) in the scope of `extern "C"`. In glib header `glib-2.0/glib/glib-typeof.h`, `<cstddef>` is included, which has cpp template code. So it generates following error:

> error: templates must have C++ linkage
> `template <class _Tp> struct __libcpp_is_integral                     { enum { value = 0 }; };`

I think this error is not generated in usual since oboe driver is not used in desktop environments, and it is the only driver that is written in cpp. But to consider updating glib in Android, I think the code should be changed to prevent further issues.

I hope this change does not make a big issue to other platform builds...

Thanks in advance.