### PR TITLE
Fix fluid_curtime() returning very incorrect timings

### DIFF
--- a/src/drivers/fluid_aufile.c
+++ b/src/drivers/fluid_aufile.c
@@ -39,7 +39,6 @@
 typedef struct
 {
     fluid_audio_driver_t driver;
-    fluid_audio_func_t callback;
     void *data;
     fluid_file_renderer_t *renderer;
     int period_size;
@@ -49,7 +48,7 @@ typedef struct
 } fluid_file_audio_driver_t;
 
 
-static int fluid_file_audio_run_s16(void *d, unsigned int msec);
+static int fluid_file_audio_run(void *d, unsigned int msec);
 
 /**************************************************************
  *
@@ -78,7 +77,6 @@ new_fluid_file_audio_driver(fluid_settings_t *settings,
     fluid_settings_getnum(settings, "synth.sample-rate", &dev->sample_rate);
 
     dev->data = synth;
-    dev->callback = (fluid_audio_func_t) fluid_synth_process;
     dev->samples = 0;
 
     dev->renderer = new_fluid_file_renderer(synth);
@@ -89,7 +87,7 @@ new_fluid_file_audio_driver(fluid_settings_t *settings,
     }
 
     msec = (int)(0.5 + dev->period_size / dev->sample_rate * 1000.0);
-    dev->timer = new_fluid_timer(msec, fluid_file_audio_run_s16, (void *) dev, TRUE, FALSE, TRUE);
+    dev->timer = new_fluid_timer(msec, fluid_file_audio_run, (void *) dev, TRUE, FALSE, TRUE);
 
     if(dev->timer == NULL)
     {
@@ -115,7 +113,7 @@ void delete_fluid_file_audio_driver(fluid_audio_driver_t *p)
     FLUID_FREE(dev);
 }
 
-static int fluid_file_audio_run_s16(void *d, unsigned int clock_time)
+static int fluid_file_audio_run(void *d, unsigned int clock_time)
 {
     fluid_file_audio_driver_t *dev = (fluid_file_audio_driver_t *) d;
     unsigned int sample_time;

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -387,17 +387,17 @@ void fluid_msleep(unsigned int msecs)
  */
 unsigned int fluid_curtime(void)
 {
-    float now;
-    static float initial_time = 0;
+    double now;
+    static double initial_time = 0;
 
     if(initial_time == 0)
     {
-        initial_time = (float)fluid_utime();
+        initial_time = fluid_utime();
     }
 
-    now = (float)fluid_utime();
+    now = fluid_utime();
 
-    return (unsigned int)((now - initial_time) / 1000.0f);
+    return (unsigned int)((now - initial_time) / 1000.0);
 }
 
 /**


### PR DESCRIPTION
The return value of `fluid_utime()` was truncated to `float` in `fluid_curtime()`.

On Windows, `fluid_utime()` seems to return very big numbers (ca. `1e15`). Truncating that to float makes the mantissa very inaccurate. This causes `fluid_curtime()` to often return zero (i.e. no time has elapsed since the initial call) in the following line:

https://github.com/FluidSynth/fluidsynth/blob/8b00644751578ba67b709a827cbe5133d849d339/src/utils/fluid_sys.c#L400

This zero will be passed as `clock_time` onto the timer callback function which is running the audio rendering, causing the following if-clause to become tautological, causing it to return without rendering anything:

https://github.com/FluidSynth/fluidsynth/blob/5dcae73657559f1606d56f0a8b5cde8d53c79ebd/src/drivers/fluid_aufile.c#L125-L128

Resolves #1074 
