### PR TITLE
Multi-channel output for the CoreAudio driver.

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -453,6 +453,27 @@ Developers:
             </desc>
         </setting>
         <setting>
+            <name>coreaudio.channel-map</name>
+            <type>str</type>
+            <def>0,1</def>
+            <desc>
+                This setting is a comma-separated integer list that maps CoreAudio channels
+                to output device channels. The value of each position in the list, up to the number of
+                output channels available on your device, is the zero-based index of the fluidsynth
+                output channel to route there. Additionally, the special value of -1 will turn off
+                an output.
+
+                For example, the default map for a single stereo output is "0,1". A value of "0,0" will
+                copy the left channel to the right, a value of "1,0" will flip left and right, and a
+                value of "-1,1" will play only the right channel.
+
+                With a six channel output device, and the synth.audio-channels and synth.audio-groups
+                settings both set to "2", a channel map of "-1,-1,0,1,2,3" will result in notes from odd
+                MIDI channels being sent to outputs 3 and 4, and even MIDI channels being send to
+                outputs 5 and 6.
+            </desc>
+        </setting>
+        <setting>
             <name>dart.device</name>
             <type>str</type>
             <def>default</def>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -467,10 +467,14 @@ Developers:
                 copy the left channel to the right, a value of "1,0" will flip left and right, and a
                 value of "-1,1" will play only the right channel.
 
-                With a six channel output device, and the synth.audio-channels and synth.audio-groups
+                With a six-channel output device, and the synth.audio-channels and synth.audio-groups
                 settings both set to "2", a channel map of "-1,-1,0,1,2,3" will result in notes from odd
-                MIDI channels being sent to outputs 3 and 4, and even MIDI channels being send to
-                outputs 5 and 6.
+                MIDI channels (audible on the first stereo channel, i.e. mono-indices 0,1) being sent to
+                outputs 3 and 4, and even MIDI channels (audible on the second stereo channel, i.e. mono-indices 2,3)
+                being sent to outputs 5 and 6.
+
+                If the list specifies fewer than the number of available outputs channels, outputs
+                beyond those specified will maintain the default channel mapping.
             </desc>
         </setting>
         <setting>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -455,6 +455,7 @@ Developers:
         <setting>
             <name>coreaudio.channel-map</name>
             <type>str</type>
+            <def>(empty string)</def>
             <desc>
                 This setting is a comma-separated integer list that maps CoreAudio channels
                 to output device channels. The value of each position in the list, up to the number of

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -455,7 +455,6 @@ Developers:
         <setting>
             <name>coreaudio.channel-map</name>
             <type>str</type>
-            <def>0,1</def>
             <desc>
                 This setting is a comma-separated integer list that maps CoreAudio channels
                 to output device channels. The value of each position in the list, up to the number of

--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -167,6 +167,7 @@ set_channel_map(AudioUnit outputUnit, int audio_channels, const char *map_string
     {
         if(channel_map[i] < -1 || channel_map[i] >= audio_channels)
         {
+            FLUID_LOG(FLUID_DBG, "Channel map of output channel %d is out-of-range. Silencing.", i);
             channel_map[i] = -1;
         }
     }

--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -148,7 +148,7 @@ set_channel_map(AudioUnit outputUnit, int audio_channels, const char *map_string
         return;
     }
 
-    FLUID_MEMSET(channel_map, 0, property_size);
+    FLUID_MEMSET(channel_map, 0xff, property_size);
 
     status = AudioUnitGetProperty(outputUnit,
                                   kAudioOutputUnitProperty_ChannelMap,

--- a/src/drivers/fluid_coreaudio.c
+++ b/src/drivers/fluid_coreaudio.c
@@ -52,6 +52,7 @@ typedef struct
     fluid_audio_func_t callback;
     void *data;
     unsigned int buffer_size;
+    unsigned int buffer_count;
     float **buffers;
     double phase;
 } fluid_core_audio_driver_t;
@@ -435,6 +436,8 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func
         goto error_recovery;
     }
 
+    dev->buffer_count = (unsigned int) audio_channels;
+
     // Initialize the audio unit
     status = AudioUnitInitialize(dev->outputUnit);
 
@@ -497,7 +500,7 @@ fluid_core_audio_callback(void *data,
     UInt32 i, nBuffers = ioData->mNumberBuffers;
     fluid_audio_func_t callback = (dev->callback != NULL) ? dev->callback : (fluid_audio_func_t) fluid_synth_process;
 
-    for(i = 0; i < ioData->mNumberBuffers; i++)
+    for(i = 0; i < ioData->mNumberBuffers && i < dev->buffer_count; i++)
     {
         dev->buffers[i] = ioData->mBuffers[i].mData;
         FLUID_MEMSET(dev->buffers[i], 0, len * sizeof(float));


### PR DESCRIPTION
Hi, this pull request does two things:

* Enable the _synth.audio-channels_ and _synth.audio-groups_ settings to work with CoreAudio as they do on other platforms.

    * This required modifying the `AudioStreamBasicDescription`, which was hardcoded as interleaved stereo. A nice efficiency improvement we can make here is adding the `kAudioFormatFlagIsNonInterleaved` flag, which allows us to skip the allocation and interleave + copy step and pass the buffers filled by the fluidsynth render callback directly.

* Adds a _audio.coreaudio.channel-map_ setting to make use of CoreAudio's standard [channel mapping](https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/ARoadmaptoCommonTasks/ARoadmaptoCommonTasks.html#//apple_ref/doc/uid/TP40003577-CH6-SW16) facility to arbitrarily route output channels.

As an example of why these changes are helpful, I use them for live performances to route MIDI instruments, samples, and cues to different channels on a digital rack mixer where they can be adjusted by a front-of-house sound engineer as if they were separate instruments.