### PR TITLE
WinXP CI build: use x87 FPU

### DIFF
--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -24,11 +24,15 @@ jobs:
         gtk-bundle: $(gtk-bundle-x86)
         libsndfile-url: $(libsndfile-url-x86)
         artifact-prefix: "fluidsynth"
+        CFLAGS: "/arch:IA32"
+        CXXFLAGS: "/arch:IA32"
       x64:
         platform: x64
         gtk-bundle: $(gtk-bundle-x64)
         libsndfile-url: $(libsndfile-url-x64)
         artifact-prefix: "fluidsynth"
+        CFLAGS: ""
+        CXXFLAGS: ""
   pool:
     vmImage: 'windows-2019'
   steps:

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -42,7 +42,7 @@ jobs:
         # https://dev.azure.com/tommbrt/_apis/projects?api-version=5.0
         project: 'd3638885-de4a-4ce7-afe7-f237ae461c07'
         pipeline: 1
-        artifactName: libinstpatch-$(platform)
+        artifactName: libinstpatch-XP-$(platform)
         downloadPath: '$(Build.ArtifactStagingDirectory)'
       displayName: 'Get libinstpatch'
     - script: |
@@ -56,11 +56,11 @@ jobs:
         REM need to fix the naming of libsndfile otherwise the linker won't find it
         mv lib\libsndfile-1.lib lib\sndfile.lib || exit -1
         mv lib\libsndfile-1.def lib\sndfile.def || exit -1
-        cd $(Build.ArtifactStagingDirectory)\libinstpatch-$(platform)
+        cd $(Build.ArtifactStagingDirectory)\libinstpatch-XP-$(platform)
         cp -rf * d:\deps\
         mv -f * ..
         cd ..
-        rmdir $(Build.ArtifactStagingDirectory)\libinstpatch-$(platform)\
+        rmdir $(Build.ArtifactStagingDirectory)\libinstpatch-XP-$(platform)\
         DEL /F C:\Strawberry\perl\bin\pkg-config.bat
       displayName: 'Prerequisites'
     - script: |


### PR DESCRIPTION
This resolves the issue observed in #1079. In addition, libinstpatch binaries for x87 are now being used.