### PR TITLE
Fix universal MacOS CI build

### DIFF
--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -120,17 +120,21 @@ jobs:
         echo $PATH
         which codesign
         which port
+        cmake --version || true
 
         echo "+universal" | sudo tee -a /opt/local/etc/macports/variants.conf
-        
         sudo sh -c 'cat << EOF >> /opt/local/etc/macports/macports.conf
-        buildfromsource     	always
-        universal_archs     	x86_64 arm64
+        universal_archs     	arm64 x86_64
         ui_interactive     		no
         EOF'
         
-        cmake --version || true
-        sudo port clean cmake
+        sudo port clean cmake cmake-bootstrap
+        sudo port install cmake-bootstrap
+        
+        sudo sh -c 'cat << EOF >> /opt/local/etc/macports/macports.conf
+        buildfromsource     	always
+        EOF'
+        
         sudo port install glib2-devel libsndfile dbus-glib libomp-devel readline
         # remove all extended attributes, as they cannot be restored when restoring the pipeline cache
         sudo xattr -rcv /opt/local

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -152,7 +152,9 @@ jobs:
       displayName: 'port install fluidsynth +universal'
       condition: failed()
     - script: |
+        set -x
         cat /opt/local/var/macports/logs/*cmake-bootstrap/cmake-bootstrap/main.log
+        cat /opt/local/var/macports/build/*cmake-bootstrap/cmake-bootstrap/work/cmake-3.9.4-arm64/Bootstrap.cmk/*.log
         cat /opt/local/var/macports/logs/*_fluidsynth/fluidsynth/main.log
       condition: failed()
       displayName: 'Print fluidsynth error log'

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -155,6 +155,7 @@ jobs:
         sudo port -v install fluidsynth +universal
       displayName: 'port install fluidsynth +universal'
       condition: failed()
+      enabled: false
     - script: |
         set -x
         cat /opt/local/var/macports/logs/*cmake-bootstrap/cmake-bootstrap/main.log

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -130,7 +130,7 @@ jobs:
         ui_interactive     		no
         EOF'
 
-        sudo port install glib2-devel libsndfile dbus-glib libomp-devel
+        sudo port install glib2-devel libsndfile dbus-glib libomp readline
         # fixup permissions to allow non-priv pipeline user access every directory, to make the caching step succeed at the end
         sudo chown -R $(id -u):$(id -g) /opt/local
         # remove all extended attributes, as they cannot be restored when restoring the pipeline cache

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -125,7 +125,7 @@ jobs:
         
         sudo sh -c 'cat << EOF >> /opt/local/etc/macports/macports.conf
         buildfromsource     	always
-        universal_archs     	arm64 x86_64
+        universal_archs     	x86_64 arm64
         ui_interactive     		no
         EOF'
         

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -115,7 +115,7 @@ jobs:
         path: '/opt/local'
         cacheHitVar: CACHE_RESTORED
     - script: |
-        set -x
+        set -ex
         export PATH=$PATH:/opt/local/bin
         echo $PATH
         which codesign
@@ -129,10 +129,8 @@ jobs:
         ui_interactive     		no
         EOF'
         
-        sudo port deps glib2-devel
-        sudo port deps libsndfile
-        sudo port deps dbus-glib
-        sudo port deps libomp-devel
+        cmake --version || true
+        sudo port clean cmake
         sudo port install glib2-devel libsndfile dbus-glib libomp-devel readline
         # remove all extended attributes, as they cannot be restored when restoring the pipeline cache
         sudo xattr -rcv /opt/local
@@ -154,6 +152,7 @@ jobs:
       displayName: 'port install fluidsynth +universal'
       condition: failed()
     - script: |
+        cat /opt/local/var/macports/logs/*cmake-bootstrap/cmake-bootstrap/main.log
         cat /opt/local/var/macports/logs/*_fluidsynth/fluidsynth/main.log
       condition: failed()
       displayName: 'Print fluidsynth error log'

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -123,23 +123,18 @@ jobs:
         cmake --version || true
 
         echo "+universal" | sudo tee -a /opt/local/etc/macports/variants.conf
+
         sudo sh -c 'cat << EOF >> /opt/local/etc/macports/macports.conf
+        buildfromsource     	always
         universal_archs     	arm64 x86_64
         ui_interactive     		no
         EOF'
-        
-        sudo port clean cmake cmake-bootstrap
-        sudo port install cmake-bootstrap
-        
-        sudo sh -c 'cat << EOF >> /opt/local/etc/macports/macports.conf
-        buildfromsource     	always
-        EOF'
-        
-        sudo port install glib2-devel libsndfile dbus-glib libomp-devel readline
-        # remove all extended attributes, as they cannot be restored when restoring the pipeline cache
-        sudo xattr -rcv /opt/local
+
+        sudo port install glib2-devel libsndfile dbus-glib libomp-devel
         # fixup permissions to allow non-priv pipeline user access every directory, to make the caching step succeed at the end
         sudo chown -R $(id -u):$(id -g) /opt/local
+        # remove all extended attributes, as they cannot be restored when restoring the pipeline cache
+        sudo xattr -rcv /opt/local
       displayName: 'Port install universal'
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
     - script: |

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -133,7 +133,7 @@ jobs:
         sudo port deps libsndfile
         sudo port deps dbus-glib
         sudo port deps libomp-devel
-        sudo port install glib2-devel libsndfile dbus-glib libomp-devel
+        sudo port install glib2-devel libsndfile dbus-glib libomp-devel readline
         # remove all extended attributes, as they cannot be restored when restoring the pipeline cache
         sudo xattr -rcv /opt/local
         # fixup permissions to allow non-priv pipeline user access every directory, to make the caching step succeed at the end

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -119,8 +119,8 @@ jobs:
         export PATH=$PATH:/opt/local/bin
         echo $PATH
         which codesign
-        codesign --help
         which port
+
         echo "+universal" | sudo tee -a /opt/local/etc/macports/variants.conf
         
         sudo sh -c 'cat << EOF >> /opt/local/etc/macports/macports.conf

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -130,7 +130,7 @@ jobs:
         ui_interactive     		no
         EOF'
 
-        sudo port install glib2-devel libsndfile dbus-glib libomp readline
+        sudo port install glib2-devel libsndfile dbus-glib readline
         # fixup permissions to allow non-priv pipeline user access every directory, to make the caching step succeed at the end
         sudo chown -R $(id -u):$(id -g) /opt/local
         # remove all extended attributes, as they cannot be restored when restoring the pipeline cache

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -134,7 +134,7 @@ jobs:
         # fixup permissions to allow non-priv pipeline user access every directory, to make the caching step succeed at the end
         sudo chown -R $(id -u):$(id -g) /opt/local
         # remove all extended attributes, as they cannot be restored when restoring the pipeline cache
-        sudo xattr -rcv /opt/local
+        #sudo xattr -rcv /opt/local
       displayName: 'Port install universal'
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
     - script: |


### PR DESCRIPTION
Do not build libomp, because it depends on cmake-bootstrap, which for some reason tries to execute a unit test compiled for arm64, which obviously fails on a x86_64 host.