### PR TITLE
Modify select drivers to pass system realtime messages

### DIFF
--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -53,6 +53,7 @@ variables:
   # This is a symlink pointing to the real Android NDK
   # Must be the same as $ANDROID_NDK_HOME see:
   # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+  # We cannot use $ANDROID_NDK_HOME because this is an environment variable, but here, we need a compile-time constant.
   NDK: '/usr/local/lib/android/sdk/ndk-bundle'
 
   # All the built binaries, libs and their headers will be installed here
@@ -209,6 +210,11 @@ jobs:
         sudo -E apt-get -y --no-install-suggests --no-install-recommends install gettext cmake zlib1g-dev autogen automake autoconf libtool pkg-config autotools-dev build-essential meson ninja-build python3-distutils
       displayName: 'apt-get install build-tools'
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
+
+    - script: |
+        set -ex
+        ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK_ROOT
+      displayName: 'Use NDK r22'
 
     - script: |
         set -e

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,7 +62,6 @@ jobs:
         echo Can execute `nproc` make jobs in parallel
         cmake --version
         cmake -E make_directory ${{github.workspace}}/build
-        sudo ln -s /usr/bin/clang-tidy-10 /usr/bin/clang-tidy
         which clang-tidy || true
         ls -la `which clang-tidy` || true
         echo $PATH

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -1339,13 +1339,33 @@ fluid_alsa_seq_run(void *d)
                     break;
 
                 case SND_SEQ_EVENT_PORT_START:
-                {
-                    if(dev->autoconn_inputs)
                     {
-                        fluid_alsa_seq_autoconnect_port(dev, seq_ev->data.addr.client, seq_ev->data.addr.port);
+                        if(dev->autoconn_inputs)
+                        {
+                            fluid_alsa_seq_autoconnect_port(dev, seq_ev->data.addr.client, seq_ev->data.addr.port);
+                        }
                     }
-                }
-                break;
+                    break;
+
+                case SND_SEQ_EVENT_START:
+                    evt.type = MIDI_START;
+                    break;
+
+                case SND_SEQ_EVENT_CONTINUE:
+                    evt.type = MIDI_CONTINUE;
+                    break;
+
+                case SND_SEQ_EVENT_STOP:
+                    evt.type = MIDI_STOP;
+                    break;
+
+                case SND_SEQ_EVENT_CLOCK:
+                    evt.type = MIDI_SYNC;
+                    break;
+
+                case SND_SEQ_EVENT_RESET:
+                    evt.type = MIDI_SYSTEM_RESET;
+                    break;
 
                 default:
                     continue;		/* unhandled event, next loop iteration */

--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -145,22 +145,29 @@ fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
         break;
 
     case MIM_DATA:
-        event.type = msg_type(msg_param);
-        event.channel = msg_chan(msg_param) + dev_infos->channel_map;
+		if(msg_param < 0xF0)      /* Voice category message */
+		{
+			event.type = msg_type(msg_param);
+			event.channel = msg_chan(msg_param) + dev_infos->channel_map;
 
-        FLUID_LOG(FLUID_DBG, "\ndevice at index %d sending MIDI message on channel %d, forwarded on channel: %d",
-                  dev_infos->dev_idx, msg_chan(msg_param), event.channel);
+			FLUID_LOG(FLUID_DBG, "\ndevice at index %d sending MIDI message on channel %d, forwarded on channel: %d",
+					  dev_infos->dev_idx, msg_chan(msg_param), event.channel);
 
-        if(event.type != PITCH_BEND)
-        {
-            event.param1 = msg_p1(msg_param);
-            event.param2 = msg_p2(msg_param);
-        }
-        else      /* Pitch bend is a 14 bit value */
-        {
-            event.param1 = (msg_p2(msg_param) << 7) | msg_p1(msg_param);
-            event.param2 = 0;
-        }
+			if(event.type != PITCH_BEND)
+			{
+				event.param1 = msg_p1(msg_param);
+				event.param2 = msg_p2(msg_param);
+			}
+			else      /* Pitch bend is a 14 bit value */
+			{
+				event.param1 = (msg_p2(msg_param) << 7) | msg_p1(msg_param);
+				event.param2 = 0;
+			}
+		}
+		else                    /* System message */
+		{
+			event.type = msg_param;
+		}
 
         (*dev->driver.handler)(dev->driver.data, &event);
         break;

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2642,14 +2642,9 @@ fluid_midi_parser_parse(fluid_midi_parser_t *parser, unsigned char c)
      * of another message. */
     if(c >= 0xF8)
     {
-        if(c == MIDI_SYSTEM_RESET)
-        {
-            parser->event.type = c;
-            parser->status = 0; /* clear the status */
-            return &parser->event;
-        }
-
-        return NULL;
+        parser->event.type = c;
+        parser->status = 0; /* clear the status */
+        return &parser->event;
     }
 
     /* Status byte? - If previous message not yet complete, it is discarded (re-sync). */


### PR DESCRIPTION
FluidSynth's various MIDI drivers don't appear to pass along system realtime messages (i.e. MIDI clock, start, stop, etc.) to the driver's handler/callback. These messages could be useful if, for example, the user writes a custom callback that can use these messages to synchronize a fluid_sequencer to an external clock.

This pull modifies the _alsa_seq_ and _winmidi_ drivers, as well as any that use `fluid_midi_parser_parse`, to pass along system realtime messages (status byte F8-FF) to the callback. I don't think it will cause problems further down the chain, since `fluid_midi_router_handle_midi_event` will just [return them as NULL](https://github.com/FluidSynth/fluidsynth/blob/eda2fb21b0c41114add966dbaae009dd443dfc94/src/midi/fluid_midi_router.c#L661). This behavior could be added to other drivers in future if desired.