### PR TITLE
reorder fx mixing

### DIFF
--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -509,8 +509,8 @@ int fluid_ladspa_reset(fluid_ladspa_fx_t *fx)
  * @param block_count number of blocks to render
  * @param block_size number of samples in a block
  *
- * FluidSynth calls this function during main output mixing, just after
- * the internal reverb and chorus effects have been processed.
+ * FluidSynth calls this function during main output mixing,
+ * just before processing the internal reverb and chorus effects.
  *
  * It copies audio data from the supplied buffers, runs all effects and copies the
  * resulting audio back into the same buffers.

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -150,6 +150,17 @@ fluid_rvoice_mixer_process_fx(fluid_rvoice_mixer_t *mixer, int current_blockcoun
 
     fluid_profile_ref_var(prof_ref);
 
+#ifdef LADSPA
+
+    /* Run the signal through the LADSPA Fx unit. The buffers have already been
+     * set up in fluid_rvoice_mixer_set_ladspa. */
+    if(mixer->ladspa_fx)
+    {
+        fluid_ladspa_run(mixer->ladspa_fx, current_blockcount, FLUID_BUFSIZE);
+        fluid_check_fpe("LADSPA");
+    }
+
+#endif
 
     if(mix_fx_to_out)
     {
@@ -238,17 +249,6 @@ fluid_rvoice_mixer_process_fx(fluid_rvoice_mixer_t *mixer, int current_blockcoun
                       current_blockcount * FLUID_BUFSIZE);
     }
 
-#ifdef LADSPA
-
-    /* Run the signal through the LADSPA Fx unit. The buffers have already been
-     * set up in fluid_rvoice_mixer_set_ladspa. */
-    if(mixer->ladspa_fx)
-    {
-        fluid_ladspa_run(mixer->ladspa_fx, current_blockcount, FLUID_BUFSIZE);
-        fluid_check_fpe("LADSPA");
-    }
-
-#endif
 }
 
 /**


### PR DESCRIPTION
This PR moves mixing of LADSPA effects in _fluid_rvoice_mixer_process_fx()_ before mixing of the internal reverb and chorus effects.

Currently, if a user sets `synth.audio-groups` >1, LADSPA effects can be applied to specific MIDI channels only. The user can then follow @mawe42's great suggestion from the [mailing list](https://lists.nongnu.org/archive/html/fluid-dev/2020-08/msg00001.html) and use a zero-gain amp effect to mix the LADSPA buffers back to the first host port for output to the sound card (This seems like the most proper way to do this IMO - the LADSPA subsystem shouldn't have to figure out what FluidSynth's audio output channels are on its own).

However, since the internal reverb and chorus are applied first and don't care about `synth.audio-groups`, the LADSPA effects will appear in the internal effects buffers regardless of which audio_group the currently-playing MIDI channels are part of. Increasing `synth.effects-groups` is not ideal since it adds a lot of processing load, and also would seem to require that `effects-groups` always be equal to `audio-groups`. A user could disable the internal reverb and chorus and add them as LADSPA effects, but it's nice to be able to have backing instruments or tracks from MIDI files play "normally" (i.e. according to the soundfonts' reverb and chorus settings), while a user plays lead with interesting effects that don't alter the backing voices.

I don't think this PR alters the way the buffers are set up, since that's done by _fluid_rvoice_mixer_set_ladspa()_, and my tests with ALSA and JACK on Linux seem to work fine, but feel free to close if this breaks something I don't understand.