### PR TITLE
Fix system-wide config file not loaded

### DIFF
--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -891,13 +891,13 @@ int main(int argc, char **argv)
     if(config_file == NULL)
     {
         config_file = fluid_get_userconf(buf, sizeof(buf));
-        if(config_file == NULL)
+        if(config_file == NULL || !g_file_test(config_file, G_FILE_TEST_EXISTS))
         {
             config_file = fluid_get_sysconf(buf, sizeof(buf));
         }
 
         /* if the automatically selected command file does not exist, do not even attempt to open it */
-        if(!g_file_test(config_file, G_FILE_TEST_EXISTS))
+        if(config_file != NULL && !g_file_test(config_file, G_FILE_TEST_EXISTS))
         {
             config_file = NULL;
         }


### PR DESCRIPTION
Fallback to the system-wide config file if user-specific config doesn't exist. This will make it consistent with the behavior mentioned in the UserManual.

Fixes #1118 