### PR TITLE
Fix regression in WinMIDI driver

### DIFF
--- a/src/drivers/fluid_winmidi.c
+++ b/src/drivers/fluid_winmidi.c
@@ -145,7 +145,7 @@ fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
         break;
 
     case MIM_DATA:
-        if(msg_param < 0xF0)      /* Voice category message */
+        if(msg_type(msg_param) < 0xf0)      /* Voice category message */
         {
             event.type = msg_type(msg_param);
             event.channel = msg_chan(msg_param) + dev_infos->channel_map;
@@ -166,7 +166,7 @@ fluid_winmidi_callback(HMIDIIN hmi, UINT wMsg, DWORD_PTR dwInstance,
         }
         else                    /* System message */
         {
-            event.type = msg_param;
+            event.type = (unsigned char)(msg_param & 0xff);
         }
 
         (*dev->driver.handler)(dev->driver.data, &event);


### PR DESCRIPTION
In #1115 I created a bug in the winmidi driver that causes all incoming voice messages to have channel, param1, and param2 = 0. In fluid_winmidi_callback() the check for `msg_param < 0xf0` fails for all MIDI messages (I had the byte order of dwParam1 backwards, status byte is the lowest byte, not the highest), so the channel and params are never set.

Fixed using the `msg_type` macro to check for voice category message. Also have to mask the status byte with `0xff` for system messages to get the type properly.