### PR TITLE
Fix typos

### DIFF
--- a/cmake_admin/PkgConfigHelpers.cmake
+++ b/cmake_admin/PkgConfigHelpers.cmake
@@ -45,7 +45,7 @@ macro ( generate_pkgconfig_spec template outfile target )
         set ( LIB_LIST_REGEX "(^(.+)\/([^\/]+)$)|(^\-.*$)" )
         # remove all entries from the list which are specified by path and which already have -l
         list ( FILTER LIBS_PRIVATE EXCLUDE REGEX ${LIB_LIST_REGEX} )
-        # include only entries specifed by path
+        # include only entries specified by path
         list ( FILTER LIBS_PRIVATE_WITH_PATH INCLUDE REGEX ${LIB_LIST_REGEX} )
 
         # prepend the linker flag to all entries except the ones that already have it

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -446,7 +446,7 @@ delete_fluid_audio_driver(fluid_audio_driver_t *driver)
  *
  * @warning This function may only be called if no thread is residing in fluidsynth's API and no instances of any kind
  * are alive (e.g. as it would be the case right after fluidsynth's initial creation). Else the behaviour is undefined.
- * Furtermore any attempt of using audio drivers that have not been registered is undefined behaviour!
+ * Furthermore any attempt of using audio drivers that have not been registered is undefined behaviour!
  *
  * @note This function is not thread safe and will never be!
  *

--- a/src/rvoice/fluid_iir_filter.c
+++ b/src/rvoice/fluid_iir_filter.c
@@ -380,7 +380,7 @@ void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
        between 20khz cutoff and 0 Q? */
 
     /* I removed the optimization of turning the filter off when the
-     * resonance frequence is above the maximum frequency. Instead, the
+     * resonance frequency is above the maximum frequency. Instead, the
      * filter frequency is set to a maximum of 0.45 times the sampling
      * rate. For a 44100 kHz sampling rate, this amounts to 19845
      * Hz. The reason is that there were problems with anti-aliasing when the

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -231,7 +231,7 @@ a flatter response on comb filter. So the input gain is set to 0.1 rather 1.0. *
 /*-- Reverberation time settings ----------------------------------
  MIN_DC_REV_TIME est defined egal to the minimum value of freeverb:
  MAX_DC_REV_TIME est defined egal to the maximum value of freeverb:
- T60DC is computed from gi and the longuest delay line in freeverb: L8 = 1617
+ T60DC is computed from gi and the longest delay line in freeverb: L8 = 1617
  T60 = -3 * Li * T / log10(gi)
  T60 = -3 * Li *  / (log10(gi) * sr)
 
@@ -314,7 +314,7 @@ a flatter response on comb filter. So the input gain is set to 0.1 rather 1.0. *
 
   N: the matrix dimension (i.e NBR_DELAYS).
   P: permutation matrix.
-  u: is a colomn vector of 1.
+  u: is a column vector of 1.
 
 */
 #define FDN_MATRIX_FACTOR (fluid_real_t)(-2.0 / NBR_DELAYS)

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -746,7 +746,7 @@ fluid_defpreset_next(fluid_defpreset_t *defpreset)
 
 /*
  * Adds global and local modulators list to the voice. This is done in 2 steps:
- * - Step 1: Local modulators replace identic global modulators.
+ * - Step 1: Local modulators replace identical global modulators.
  * - Step 2: global + local modulators are added to the voice using mode.
  *
  * Instrument zone list (local/global) must be added using FLUID_VOICE_OVERWRITE.
@@ -779,7 +779,7 @@ fluid_defpreset_noteon_add_mod_to_voice(fluid_voice_t *voice,
      */
     int identity_limit_count;
 
-    /* Step 1: Local modulators replace identic global modulators. */
+    /* Step 1: Local modulators replace identical global modulators. */
 
     /* local (instrument zone/preset zone), modulators: Put them all into a list. */
     mod_list_count = 0;
@@ -800,7 +800,7 @@ fluid_defpreset_noteon_add_mod_to_voice(fluid_voice_t *voice,
      * (Preset zone:     SF 2.01 page 69, second-last bullet).
      *
      * mod_list contains local modulators. Now we know that there
-     * is no global modulator identic to another global modulator (this has
+     * is no global modulator identical to another global modulator (this has
      * been checked at soundfont loading time). So global modulators
      * are only checked against local modulators number.
      */
@@ -850,8 +850,8 @@ fluid_defpreset_noteon_add_mod_to_voice(fluid_voice_t *voice,
 
     /*
      * mod_list contains local and global modulators, we know that:
-     * - there is no global modulator identic to another global modulator,
-     * - there is no local modulator identic to another local modulator,
+     * - there is no global modulator identical to another global modulator,
+     * - there is no local modulator identical to another local modulator,
      * So these local/global modulators are only checked against
      * actual number of voice modulators.
      */
@@ -1309,25 +1309,25 @@ static int fluid_preset_zone_create_voice_zones(fluid_preset_zone_t *preset_zone
 }
 
 /**
- * Checks if modulator mod is identic to another modulator in the list
+ * Checks if modulator mod is identical to another modulator in the list
  * (specs SF 2.0X  7.4, 7.8).
  * @param mod, modulator list.
  * @param name, if not NULL, pointer on a string displayed as warning.
- * @return TRUE if mod is identic to another modulator, FALSE otherwise.
+ * @return TRUE if mod is identical to another modulator, FALSE otherwise.
  */
 static int
-fluid_zone_is_mod_identic(fluid_mod_t *mod, char *name)
+fluid_zone_is_mod_identical(fluid_mod_t *mod, char *name)
 {
     fluid_mod_t *next = mod->next;
 
     while(next)
     {
-        /* is mod identic to next ? */
+        /* is mod identical to next ? */
         if(fluid_mod_test_identity(mod, next))
         {
             if(name)
             {
-                FLUID_LOG(FLUID_WARN, "Ignoring identic modulator %s", name);
+                FLUID_LOG(FLUID_WARN, "Ignoring identical modulator %s", name);
             }
 
             return TRUE;
@@ -1382,7 +1382,7 @@ static void fluid_limit_mod_list(char *zone_name, fluid_mod_t **list_mod)
 /**
  * Checks and remove invalid modulators from a zone modulators list.
  * - checks valid modulator sources (specs SF 2.01  7.4, 7.8, 8.2.1).
- * - checks identic modulators in the list (specs SF 2.01  7.4, 7.8).
+ * - checks identical modulators in the list (specs SF 2.01  7.4, 7.8).
  * @param zone_name, zone name.
  * @param list_mod, address of pointer on modulators list.
  */
@@ -1403,8 +1403,8 @@ fluid_zone_check_mod(char *zone_name, fluid_mod_t **list_mod)
 
         /* has mod invalid sources ? */
         if(!fluid_mod_check_sources(mod,  zone_mod_name)
-                /* or is mod identic to any following modulator ? */
-                || fluid_zone_is_mod_identic(mod, zone_mod_name))
+                /* or is mod identical to any following modulator ? */
+                || fluid_zone_is_mod_identical(mod, zone_mod_name))
         {
             /* the modulator is useless so we remove it */
             if(prev_mod)

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -592,9 +592,9 @@ void fluid_clear_fpe_i386(void)
   -----------------------------------------------------------------------------
   Shell task side |    Profiling interface              |  Audio task side
   -----------------------------------------------------------------------------
-  profiling       |    Internal    |      |             |      Audio
-  command   <---> |<-- profling -->| Data |<--macros -->| <--> rendering
-  shell           |    API         |      |             |      API
+  profiling       |    Internal     |      |             |      Audio
+  command   <---> |<-- profiling -->| Data |<--macros -->| <--> rendering
+  shell           |    API          |      |             |      API
 
 */
 /* default parameters for shell command "prof_start" in fluid_sys.c */

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -526,9 +526,9 @@ fluid_long_long_t fluid_file_tell(FILE* f);
   -----------------------------------------------------------------------------
   Shell task side |    Profiling interface              |  Audio task side
   -----------------------------------------------------------------------------
-  profiling       |    Internal    |      |             |      Audio
-  command   <---> |<-- profling -->| Data |<--macros -->| <--> rendering
-  shell           |    API         |      |             |      API
+  profiling       |    Internal     |      |             |      Audio
+  command   <---> |<-- profiling -->| Data |<--macros -->| <--> rendering
+  shell           |    API          |      |             |      API
 
 */
 
@@ -730,7 +730,7 @@ enum
     Floating point exceptions
 
     fluid_check_fpe() checks for "unnormalized numbers" and other
-    exceptions of the floating point processsor.
+    exceptions of the floating point processor.
 */
 #ifdef FPE_CHECK
 #define fluid_check_fpe(expl) fluid_check_fpe_i386(expl)

--- a/test-android/build-scripts/build.sh
+++ b/test-android/build-scripts/build.sh
@@ -240,7 +240,7 @@ EOF
 
         # FIXME: On arm64 it fails to build fluidsynth executable due to a bunch of library resolution failures...
         # To avoid the entire build failures, we ignore the 
-        # exit coode here and go on with fake executable file.
+        # exit code here and go on with fake executable file.
         # It is not runnable on Android anyways.
         parameters_cmakeArgs="-Denable-opensles=1 -Denable-floats=1 -Denable-oboe=1 -Denable-dbus=0 -Denable-oss=0" parameters_sourceDir=../.. parameters_workDir=  parameters_condition=  parameters_installCommand='echo success' bash ./build-call-cmake.sh || echo "Failed to build fluidsynth, but it is expected. We continue build..." && touch ../../build_$ANDROID_ABI_CMAKE/src/fluidsynth
 


### PR DESCRIPTION
Found via `codespell -q 3 -S ChangeLog -L bloc,blocs,capela,datas,egal,parms,readd,seh`