### PR TITLE
Fix minor bugs in fluid_player_callback()

### DIFF
--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2116,6 +2116,7 @@ fluid_player_callback(void *data, unsigned int msec)
                 {
                     fluid_midi_event_set_channel(&mute_event, i);
                     player->playback_callback(player->playback_userdata, &mute_event);
+                    player->channel_isplaying[i] = FALSE;
                 }
             }
             fluid_atomic_int_set(&player->stopping, 0);
@@ -2153,6 +2154,7 @@ fluid_player_callback(void *data, unsigned int msec)
                 {
                     fluid_midi_event_set_channel(&mute_event, i);
                     player->playback_callback(player->playback_userdata, &mute_event);
+                    player->channel_isplaying[i] = FALSE;
                 }
             }
         }

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2161,10 +2161,10 @@ fluid_player_callback(void *data, unsigned int msec)
 
         for(i = 0; i < player->ntracks; i++)
         {
+            fluid_track_send_events(player->track[i], synth, player, player->cur_ticks, seek_ticks);
             if(!fluid_track_eot(player->track[i]))
             {
                 status = FLUID_PLAYER_PLAYING;
-                fluid_track_send_events(player->track[i], synth, player, player->cur_ticks, seek_ticks);
             }
         }
 


### PR DESCRIPTION
This modifies `fluid_player_callback()` to call `fluid_track_send_events()` _before_ checking if `!fluid_track_eot()`, so that if the user is seeking backward `fluid_track_send_events()` can reset the track. After returning, `!fluid_track_eot()` is checked to see if there are events left in the track to play, and if so `status` is set to `FLUID_PLAYER_PLAYING` as normal.

Similarly, this also modifies `fluid_player_callback()` to set the respective `channel_isplaying` flags back to FALSE after sending an ALL_SOUNDS_OFF control change, to avoid sending unnecessary messages if the player is stopped again before notes are played on a channel, or after beginning a new song in the playlist (which might use completely different channels).