### PR TITLE
Remove systemd hardening options for system services

### DIFF
--- a/fluidsynth.service.in
+++ b/fluidsynth.service.in
@@ -4,16 +4,7 @@ Documentation=man:fluidsynth(1)
 After=sound.target
 
 [Service]
-# added automatically, for details please see
-# https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort
 ProtectSystem=full
-ProtectHome=read-only
-ProtectHostname=true
-ProtectKernelTunables=true
-ProtectKernelModules=true
-ProtectKernelLogs=true
-ProtectControlGroups=true
-# end of automatic additions
 Type=notify
 NotifyAccess=main
 EnvironmentFile=@FLUID_DAEMON_ENV_FILE@


### PR DESCRIPTION
fluidsynth.service.in:
As fluidsynth is run as a systemd user service, applying sandboxing options only available to systemd system services will prevent the user service from starting, thus we remove the ones only available to system services.

Fixes #1147 