### PR TITLE
Add linear interpolation to convex and concave transfer functions

### DIFF
--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -303,13 +303,9 @@ fluid_concave(fluid_real_t val)
     {
         return 0.f;
     }
-    else if (ival == FLUID_VEL_CB_SIZE - 1)
+    else if (ival >= FLUID_VEL_CB_SIZE - 1)
     {
-        return fluid_concave_tab[ival];
-    }
-    else if(ival > FLUID_VEL_CB_SIZE - 1)
-    {
-        return 1.f;
+        return fluid_concave_tab[FLUID_VEL_CB_SIZE - 1];
     }
 
     return fluid_concave_tab[ival] + (fluid_concave_tab[ival + 1] - fluid_concave_tab[ival]) * (val - ival);
@@ -326,13 +322,9 @@ fluid_convex(fluid_real_t val)
     {
         return 0.f;
     }
-    else if (ival == FLUID_VEL_CB_SIZE - 1)
+    else if (ival >= FLUID_VEL_CB_SIZE - 1)
     {
-        return fluid_convex_tab[ival];
-    }
-    else if(ival > FLUID_VEL_CB_SIZE - 1)
-    {
-        return 1.f;
+        return fluid_convex_tab[FLUID_VEL_CB_SIZE - 1];
     }
 
     // interpolation between convex steps: fixes bad sounds with modenv and filter cutoff

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -298,16 +298,21 @@ fluid_real_t fluid_balance(fluid_real_t balance, int left)
 fluid_real_t
 fluid_concave(fluid_real_t val)
 {
+    int ival = (int)val;
     if(val < 0.f)
     {
         return 0.f;
     }
-    else if(val >= (fluid_real_t)FLUID_VEL_CB_SIZE)
+    else if (ival == FLUID_VEL_CB_SIZE - 1)
+    {
+        return fluid_concave_tab[ival];
+    }
+    else if(ival > FLUID_VEL_CB_SIZE - 1)
     {
         return 1.f;
     }
 
-    return fluid_concave_tab[(int) val];
+    return fluid_concave_tab[ival] + (fluid_concave_tab[ival + 1] - fluid_concave_tab[ival]) * (val - ival);
 }
 
 /*
@@ -325,7 +330,7 @@ fluid_convex(fluid_real_t val)
     {
         return fluid_convex_tab[ival] ;
     }
-    else if(val > (fluid_real_t)(FLUID_VEL_CB_SIZE - 1))
+    else if(ival > FLUID_VEL_CB_SIZE - 1)
     {
         return 1.f;
     }

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -316,20 +316,21 @@ fluid_concave(fluid_real_t val)
 fluid_real_t
 fluid_convex(fluid_real_t val)
 {
-    
+    int ival = (int)val;
     if(val < 0.f)
     {
         return 0.f;
     }
-    else if(val >= (fluid_real_t)FLUID_VEL_CB_SIZE)
+    else if (ival == FLUID_VEL_CB_SIZE - 1)
+    {
+        return fluid_convex_tab[ival] ;
+    }
+    else if(val > (fluid_real_t)(FLUID_VEL_CB_SIZE - 1))
     {
         return 1.f;
-    } 
-    else if ((int)val == 127) 
-    {
-        return fluid_convex_tab[(int) val] ;
     }
+
     // interpolation between convex steps: fixes bad sounds with modenv and filter cutoff
-    return fluid_convex_tab[(int) val]  + (fluid_convex_tab[(int)val + 1] - fluid_convex_tab[(int) val] ) * (val - (int)val);;     
+    return fluid_convex_tab[ival] + (fluid_convex_tab[ival + 1] - fluid_convex_tab[ival]) * (val - ival);
 }
 

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -316,6 +316,7 @@ fluid_concave(fluid_real_t val)
 fluid_real_t
 fluid_convex(fluid_real_t val)
 {
+    
     if(val < 0.f)
     {
         return 0.f;
@@ -323,8 +324,12 @@ fluid_convex(fluid_real_t val)
     else if(val >= (fluid_real_t)FLUID_VEL_CB_SIZE)
     {
         return 1.f;
+    } 
+    else if ((int)val == 127) 
+    {
+        return fluid_convex_tab[(int) val] ;
     }
-
-    return fluid_convex_tab[(int) val];
+    // interpolation between convex steps: fixes bad sounds with modenv and filter cutoff
+    return fluid_convex_tab[(int) val]  + (fluid_convex_tab[(int)val + 1] - fluid_convex_tab[(int) val] ) * (val - (int)val);;     
 }
 

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -328,7 +328,7 @@ fluid_convex(fluid_real_t val)
     }
     else if (ival == FLUID_VEL_CB_SIZE - 1)
     {
-        return fluid_convex_tab[ival] ;
+        return fluid_convex_tab[ival];
     }
     else if(ival > FLUID_VEL_CB_SIZE - 1)
     {


### PR DESCRIPTION
While looking through forks, I found a development branch from @md1872b. I don't understand most of the changes there, but this one here makes complete sense to me. Originally only applied to `fluid_convex` I also applied it to `fluid_concave`.

@mawe42 FYI