### PR TITLE
Don't stop playing until zero voices are active and reverb has a chance to fade out

### DIFF
--- a/src/midi/fluid_midi.h
+++ b/src/midi/fluid_midi.h
@@ -306,6 +306,7 @@ struct _fluid_player_t
     int begin_msec;           /* the time (msec) of the beginning of the file */
     int start_msec;           /* the start time of the last tempo change */
     int cur_msec;             /* the current time */
+    int end_msec;             /* when >=0, playback is extended until this time (for, e.g., reverb) */
     /* sync mode: indicates the tempo mode the player is driven by (see fluid_player_set_tempo()):
        1, the player is driven by internal tempo (miditempo). This is the default.
        0, the player is driven by external tempo (exttempo)
@@ -329,6 +330,8 @@ struct _fluid_player_t
 
     int channel_isplaying[MAX_NUMBER_OF_CHANNELS]; /* flags indicating channels on which notes have played */
 };
+
+#define FLUID_PLAYER_STOP_GRACE_MS 2000
 
 void fluid_player_settings(fluid_settings_t *settings);
 


### PR DESCRIPTION
In an attempt to alleviate 12-year-old #24 without a deep understanding of FluidSynth internals, this PR adds a `player.extend-playback` setting (and corresponding `-x` / `--extend-playback` CLI option) which takes a number of milliseconds to wait after the last MIDI event before stopping playback.  This PR makes no attempt to solve any of the more complex problems like automatic silence detection; `-x 2000` is more than enough for my use cases, and so I hope this change is useful to others as well.

Reviewers beware: I'm not 100% fluent in C, knew almost nothing about FluidSynth internals a week ago, and have very likely caused a mess of things, so please be careful when reviewing this PR. In particular, I'm not sure whether claiming `-x` was appropriate, whether I've filled in documentation in all the right places/ways, whether the added logic is even in the right place, whether I've caused weird behavior in edge cases involving stopping/restarting/reloading a player or playing multiple files, or how to write tests for any of those situations.