### PR TITLE
Remove last references to obsolete CMake option LIB_SUFFIX

### DIFF
--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -85,11 +85,11 @@ jobs:
       #11_0_universal_unixlibs:
       #  macPortsUrl: 'https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2-11-BigSur.pkg'
       #  imageName: 'macos-11'
-      #  CMakeFlags: '-Denable-sdl2=0 -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -Denable-framework=0 -DLIB_SUFFIX=""'
+      #  CMakeFlags: '-Denable-sdl2=0 -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -Denable-framework=0
       12_0_universal_unixlibs:
         macPortsUrl: 'https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2-12-Monterey.pkg'
         imageName: 'macos-12'
-        CMakeFlags: '-Denable-sdl2=0 -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -Denable-framework=0 -DLIB_SUFFIX=""'
+        CMakeFlags: '-Denable-sdl2=0 -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -Denable-framework=0
   pool:
     vmImage: $(imageName)
   steps:

--- a/.azure/cmake-android.yml
+++ b/.azure/cmake-android.yml
@@ -47,7 +47,6 @@ steps:
         -DCMAKE_STAGING_PREFIX=${PREFIX} \
         -DCMAKE_VERBOSE_MAKEFILE=1 \
         -DBUILD_SHARED_LIBS=1 \
-        -DLIB_SUFFIX="" \
         ${{ parameters.cmakeArgs }} ..
     make -j$((`nproc`+1))
     ${{ parameters.installCommand }}

--- a/test-android/build-scripts/build-call-cmake.sh
+++ b/test-android/build-scripts/build-call-cmake.sh
@@ -41,7 +41,6 @@ source ./build-env.sh
         -DCMAKE_INSTALL_PREFIX=${PREFIX} \
         -DCMAKE_STAGING_PREFIX=${PREFIX} \
         -DBUILD_SHARED_LIBS=1 \
-        -DLIB_SUFFIX="" \
         $parameters_cmakeArgs ..
         #-DCMAKE_VERBOSE_MAKEFILE=1 \
     make -j$((`nproc`+1)) || (popd && popd && exit 1)


### PR DESCRIPTION
This option has been ignored since 563592aa3d5e585282877cd454b50369e3b19cdd (2021-09-03) when the project was changed to use GNUInstallDirs instead.