### PR TITLE
two more small examples for libfluidsynth

### DIFF
--- a/cmake_admin/FluidUnitTest.cmake
+++ b/cmake_admin/FluidUnitTest.cmake
@@ -13,9 +13,9 @@ macro ( ADD_FLUID_TEST _test )
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed
     target_include_directories(${_test}
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> # include auto generated headers
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> # include "normal" public (sub-)headers
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src> # include private headers
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> # include auto generated headers
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> # include "normal" public (sub-)headers
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src> # include private headers
     $<TARGET_PROPERTY:libfluidsynth-OBJ,INCLUDE_DIRECTORIES> # include all other header search paths needed by libfluidsynth (esp. glib)
     )
 
@@ -34,7 +34,7 @@ macro ( ADD_FLUID_TEST_UTIL _util )
     set_target_properties(${_util} PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
     # append no-op generator expression to avoid VS or XCode from adding per-config subdirectories
-    set_target_properties(${_util} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/utils/$<0:>)
+    set_target_properties(${_util} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/utils/$<0:>)
 
     # import necessary compile flags and dependency libraries
     if ( FLUID_CPPFLAGS )
@@ -45,9 +45,9 @@ macro ( ADD_FLUID_TEST_UTIL _util )
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed
     target_include_directories(${_util}
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> # include auto generated headers
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> # include "normal" public (sub-)headers
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src> # include private headers
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> # include auto generated headers
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> # include "normal" public (sub-)headers
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src> # include private headers
     $<TARGET_PROPERTY:libfluidsynth-OBJ,INCLUDE_DIRECTORIES> # include all other header search paths needed by libfluidsynth (esp. glib)
     )
 
@@ -61,24 +61,37 @@ endmacro ( ADD_FLUID_TEST_UTIL )
 # the content with the file given in _expected_output
 macro ( ADD_FLUID_SF_DUMP_TEST _sfname)
 
-    set( test_args "${CMAKE_SOURCE_DIR}/sf2/${_sfname} ${_sfname}.yml" )
+    set( test_args "${PROJECT_SOURCE_DIR}/sf2/${_sfname} ${_sfname}.yml" )
 
     ADD_TEST(${_sfname}_dump_test
         ${CMAKE_COMMAND}
-        -Dtest_cmd=${CMAKE_BINARY_DIR}/test/utils/dump_sfont${CMAKE_EXECUTABLE_SUFFIX}
+        -Dtest_cmd=${PROJECT_BINARY_DIR}/test/utils/dump_sfont${CMAKE_EXECUTABLE_SUFFIX}
         -Dtest_args=${test_args}
         -Dtest_output=${_sfname}.yml
-        -Dexpected_output=${CMAKE_SOURCE_DIR}/sf2/${_sfname}.yml
-        -P ${CMAKE_SOURCE_DIR}/cmake_admin/RunOutputTest.cmake
+        -Dexpected_output=${PROJECT_SOURCE_DIR}/sf2/${_sfname}.yml
+        -P ${PROJECT_SOURCE_DIR}/cmake_admin/RunOutputTest.cmake
     )
 
 endmacro ( ADD_FLUID_SF_DUMP_TEST )
 
 macro ( ADD_FLUID_DEMO _demo )
-    ADD_EXECUTABLE(${_demo} ${_demo}.c )
+
+    if ( ${ARGC} GREATER 1 )
+        string( TOLOWER "${ARGV1}" _LANGEXT )
+    else ()
+        set( _LANGEXT "c" )
+    endif ()
+
+    ADD_EXECUTABLE(${_demo} ${_demo}.${_LANGEXT} )
 
     # only build this unit test when explicitly requested by "make check"
     set_target_properties(${_demo} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+    # request C++11 features only for the C++ example(s)
+    if ( "${_LANGEXT}" STREQUAL "cxx" )
+        target_compile_features( ${_demo} PUBLIC cxx_std_11 )
+        set_target_properties( ${_demo} PROPERTIES CXX_EXTENSIONS OFF )
+    endif()
 
     # import necessary compile flags and dependency libraries
     if ( FLUID_CPPFLAGS )
@@ -89,9 +102,9 @@ macro ( ADD_FLUID_DEMO _demo )
     # use the local include path to look for fluidsynth.h, as we cannot be sure fluidsynth is already installed
     target_include_directories(${_demo}
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> # include auto generated headers
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> # include "normal" public (sub-)headers
-    $<TARGET_PROPERTY:libfluidsynth,INCLUDE_DIRECTORIES> # include all other header search paths needed by libfluidsynth (esp. glib)
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> # include auto generated headers
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> # include "normal" public (sub-)headers
+        $<TARGET_PROPERTY:libfluidsynth,INCLUDE_DIRECTORIES> # include all other header search paths needed by libfluidsynth (esp. glib)
     )
 
     # append the current unit test to check-target as dependency

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -27,4 +27,5 @@ ADD_FLUID_DEMO ( fluidsynth_arpeggio )
 ADD_FLUID_DEMO ( fluidsynth_fx )
 ADD_FLUID_DEMO ( fluidsynth_metronome )
 ADD_FLUID_DEMO ( fluidsynth_simple )
-
+ADD_FLUID_DEMO ( fluidsynth_instruments )
+ADD_FLUID_DEMO ( fluidsynth_enumsettings CXX )

--- a/doc/examples/fluidsynth_enumsettings.cxx
+++ b/doc/examples/fluidsynth_enumsettings.cxx
@@ -1,0 +1,97 @@
+/* FluidSynth Enum Settings - An example of using fluidsynth in C++
+ * This source uses C++11 features (nullptr, lambda expressions, ...)
+ *
+ * This code is in the public domain.
+ *
+ * To compile:
+ *   g++ -o fluidsynth_enumsettings -lfluidsynth fluidsynth_enumsettings.cpp
+ *
+ * To run:
+ *   fluidsynth_enumsettings
+ *
+ * [Pedro López-Cabanillas <plcl@users.sf.net>]
+ */
+
+#include <list>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fluidsynth.h>
+
+int main(int argc, char**)
+{
+    fluid_settings_t* settings = nullptr;
+    void* context = nullptr;
+
+    std::cout << "C++ enum settings of FluidSynth v" << fluid_version_str() << std::endl;
+
+    if (argc > 1) {
+        std::cerr << "Usage: fluidsynth_enumsettings" << std::endl;
+        return 1;
+    }
+
+    /* Create the settings object. This example uses the default values for the settings. */
+    settings = new_fluid_settings();
+    if (settings == NULL) {
+        std::cerr << "Failed to create the settings" << std::endl;
+        return 2;
+    }
+
+    std::cout << std::left << std::setw(35) << "Setting" << std::setw(16) << "Type" << std::setw(16) << "Value" << "Options" << std::endl;
+    std::cout << std::left << std::setw(35) << "-------" << std::setw(16) << "----" << std::setw(16) << "-----" << "-------" << std::endl;
+
+    context = settings;
+    fluid_settings_foreach(settings, context, [](void *inner_context, const char *name, int type) {
+        int ok = 0;
+        double dValue{0.0};
+        int iValue{0};
+        char *psValue = nullptr;
+        fluid_settings_t* inner_settings = (fluid_settings_t*) inner_context;
+        std::cout << std::left << std::setw(35) << name;
+        switch (type) {
+        case FLUID_NO_TYPE:
+            std::cout << std::setw(16) << "Undefined";
+            break;
+        case FLUID_NUM_TYPE:
+            ok = fluid_settings_getnum(inner_settings, name, &dValue);
+            if (ok == FLUID_OK) {
+                std::cout << std::setw(16) << "Numeric" << std::setw(16) << dValue;
+            }
+            break;
+        case FLUID_INT_TYPE:
+            ok = fluid_settings_getint(inner_settings, name, &iValue);
+            if (ok == FLUID_OK) {
+                std::cout << std::setw(16) << "Integer" << std::setw(16) << iValue;
+            }
+            break;
+        case FLUID_STR_TYPE:
+            ok = fluid_settings_dupstr(inner_settings, name, &psValue);
+            if (ok == FLUID_OK) {
+                std::cout << std::setw(16) << "String" << std::setw(16) << psValue;
+                fluid_free(psValue);
+            }
+            break;
+        case FLUID_SET_TYPE:
+            std::cout << std::setw(16) << "Set";
+            break;
+        }
+        std::list<std::string> options;
+        fluid_settings_foreach_option(inner_settings, name, &options, [](void *context2, const char *, const char *option2){
+            std::list<std::string> *options_list = (std::list<std::string> *) context2;
+            if (!options_list->empty()) {
+                options_list->push_back(", ");
+            }
+            options_list->push_back(option2);
+        });
+        if (!options.empty()) {
+            for(auto it=options.begin(); it != options.end(); ++it) {
+                std::cout << *it;
+            }
+        }
+        std::cout << std::endl;
+    });
+    std::cout << "done" << std::endl;
+
+    delete_fluid_settings(settings);
+    return 0;
+}

--- a/doc/examples/fluidsynth_instruments.c
+++ b/doc/examples/fluidsynth_instruments.c
@@ -1,0 +1,77 @@
+/* FluidSynth Instruments - An example of using fluidsynth >= 2.x
+ *
+ * This code is in the public domain.
+ *
+ * To compile:
+ *   gcc -o fluidsynth_instruments fluidsynth_instruments.c -lfluidsynth
+ *
+ * To run:
+ *   fluidsynth_instruments soundfont
+ *
+ * [Pedro López-Cabanillas <plcl@users.sf.net>]
+ */
+
+#include <stdio.h>
+#include <fluidsynth.h>
+
+int main(int argc, char** argv)
+{
+	fluid_settings_t* settings = NULL;
+	fluid_synth_t* synth = NULL;
+	fluid_sfont_t* sfont = NULL;
+	int err = 0, sfid = -1;
+
+	if (argc != 2) {
+		fprintf(stderr, "Usage: fluidsynth_instr [soundfont]\n");
+		return 1;
+	}
+
+	/* Create the settings object. This example uses the default
+	 * values for the settings. */
+	settings = new_fluid_settings();
+	if (settings == NULL) {
+		fprintf(stderr, "Failed to create the settings\n");
+		err = 2;
+		goto cleanup;
+	}
+
+	/* Create the synthesizer */
+	synth = new_fluid_synth(settings);
+	if (synth == NULL) {
+		fprintf(stderr, "Failed to create the synthesizer\n");
+		err = 3;
+		goto cleanup;
+	}
+
+	/* Load the soundfont */
+	sfid = fluid_synth_sfload(synth, argv[1], 1);
+	if (sfid == -1) {
+		fprintf(stderr, "Failed to load the SoundFont\n");
+		err = 4;
+		goto cleanup;
+	}
+
+    /* Enumeration of banks and programs */
+    sfont = fluid_synth_get_sfont_by_id(synth, sfid);
+    if (sfont != NULL) {
+        fluid_preset_t *preset;
+        fluid_sfont_iteration_start(sfont);
+        while ((preset = fluid_sfont_iteration_next(sfont)) != NULL) {
+            int bank = fluid_preset_get_banknum(preset);
+            int prog = fluid_preset_get_num(preset);
+            const char* name = fluid_preset_get_name(preset);
+			printf("bank: %d prog: %d name: %s\n", bank, prog, name);
+		}
+	}
+
+	printf("done\n");
+
+ cleanup:
+	if (synth) {
+		delete_fluid_synth(synth);
+	}
+	if (settings) {
+		delete_fluid_settings(settings);
+	}
+	return err;
+}


### PR DESCRIPTION
fluidsynth_instruments.c: enumeration of banks and programs of a soundfont to the standard output.

fluidsynth_enumsettings.cxx: enumeration of settings and default values in C++11 to the standard output.