### PR TITLE
Disable sustain/sostenuto pedals after last MIDI event

### DIFF
--- a/src/midi/fluid_midi.h
+++ b/src/midi/fluid_midi.h
@@ -307,6 +307,7 @@ struct _fluid_player_t
     int start_msec;           /* the start time of the last tempo change */
     int cur_msec;             /* the current time */
     int end_msec;             /* when >=0, playback is extended until this time (for, e.g., reverb) */
+    char end_pedals_disabled; /* 1 once the pedals have been released after the last midi event, 0 otherwise */
     /* sync mode: indicates the tempo mode the player is driven by (see fluid_player_set_tempo()):
        1, the player is driven by internal tempo (miditempo). This is the default.
        0, the player is driven by external tempo (exttempo)


### PR DESCRIPTION
While working with a larger set of MIDI files with the changes in #1159, I discovered that for some of the files, `fluid_synth_get_active_voice_count(player->synth)` never goes to zero (at least, not after as long as I was willing to wait for it, maybe 15-30 seconds). This causes the player to appear to terminate automatically on some songs bug hang indefinitely on others.

In an attempt to prevent that situation, this PR changes the post-MIDI-events player logic in #1159 from "wait until `fluid_synth_get_active_voice_count(player->synth)` is zero, then wait until `FLUID_PLAYER_STOP_GRACE_MS` have elapsed" to instead "wait until _either_ `fluid_synth_get_active_voice_count(player->synth)` _or_ `FLUID_PLAYER_STOP_GRACE_MS` have elapsed".