### PR TITLE
Support stereo fx send to LADSPA

### DIFF
--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -131,9 +131,23 @@ struct _fluid_rvoice_dsp_t
     fluid_real_t phase_incr;	/* the phase increment for the next FLUID_BUFSIZE samples */
 };
 
+#define STEREO_FX
+
+typedef enum  {
+DRY_L = 0,
+DRY_R,
+REV_L,
+CHO_L,
+#ifdef STEREO_FX
+REV_R,
+CHO_R,
+#endif
+RBUF_COUNT
+}  fluid_rvoice_bufidx_t;
+
 /* Currently left, right, reverb, chorus. To be changed if we
    ever add surround positioning, or stereo reverb/chorus */
-#define FLUID_RVOICE_MAX_BUFS (4)
+#define FLUID_RVOICE_MAX_BUFS (RBUF_COUNT)
 
 /*
  * rvoice mixer-related parameters


### PR DESCRIPTION
For details, see #1161

Open questions:

* Should this become fluidsynth's default way of handling fx?
* Or should we make this feature configurable?
  * at runtime via a setting?
  * or at compile-time via a `#define` / CMake option?