### PR TITLE
drivers/fluid_alsa: don't try to close invalid ctls

### DIFF
--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -645,7 +645,7 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
     while((err == 0) && (card >= 0))
     {
         int device = -1;
-        snd_ctl_t *ctl;
+        snd_ctl_t *ctl = NULL;
         char card_name[32];
 
         FLUID_SNPRINTF(card_name, sizeof(card_name), "hw:%d", card);
@@ -707,7 +707,12 @@ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t *settings)
             }
         }
 
-        snd_ctl_close(ctl);
+        if(ctl)
+        {
+            snd_ctl_close(ctl);
+            ctl = NULL;
+        }
+
         err = snd_card_next(&card);
     }
 }


### PR DESCRIPTION
snd_ctl_close is called unconditionally after snd_ctl_open in fluid_alsa_rawmidi_driver_settings, resulting in a segfault if snd_ctl_open failed to open the card. This commit has the function call snd_ctl_close only when the ctl was successfully opened.