### PR TITLE
systemd: restore sandboxing options and add PrivateUsers=yes to make them work as user units

### DIFF
--- a/fluidsynth.service.in
+++ b/fluidsynth.service.in
@@ -14,6 +14,8 @@ ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true
 # end of automatic additions
+# required in order for the above sandboxing options to work on a user unit
+PrivateUsers=yes
 Type=notify
 NotifyAccess=main
 EnvironmentFile=@FLUID_DAEMON_ENV_FILE@

--- a/fluidsynth.service.in
+++ b/fluidsynth.service.in
@@ -4,7 +4,16 @@ Documentation=man:fluidsynth(1)
 After=sound.target
 
 [Service]
+# added automatically, for details please see
+# https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort
 ProtectSystem=full
+ProtectHome=read-only
+ProtectHostname=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+# end of automatic additions
 Type=notify
 NotifyAccess=main
 EnvironmentFile=@FLUID_DAEMON_ENV_FILE@


### PR DESCRIPTION
The alternative is to also remove ProtectSystem, which also requires PrivateUsers. At some point we'll make it implicit, and only a handful of user units use it, so we want to make sure it is intentional to have this and not accidental.