### PR TITLE
Fix regression that broke LFOFREQs for negative values

### DIFF
--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -48,7 +48,7 @@ fluid_ct2hz_real(fluid_real_t cents)
 {
     if(FLUID_UNLIKELY(cents < 0))
     {
-        return (fluid_real_t) 1.0;
+        return fluid_act2hz(cents);
     }
     else
     {

--- a/test/test_ct2hz.c
+++ b/test/test_ct2hz.c
@@ -35,7 +35,8 @@ int main(void)
     TEST_ASSERT(float_eq(fluid_ct2hz_real(1), 8.1805228064648688650522010380302841769481091116));
     TEST_ASSERT(float_eq(fluid_ct2hz_real(0), 8.1757989156437073336828122976032719176391831357)); // often referred to as Absolute zero in the SF2 spec
 
-    for(i = 0; i < 13500; i++)
+    // Test the entire possible range: from lowest permitted value of MODLFOFREQ up to filter fc limit
+    for(i = -16000; i < 13500; i++)
     {
         TEST_ASSERT(float_eq(fluid_ct2hz_real(i), fluid_act2hz(i)));
     }


### PR DESCRIPTION
Fallback to expensive `pow()` calculation when passing negative values to `fluid_ct2hz_real()`. Should be backward compatible with existing code where this function is used.

Resolves #1182 