### PR TITLE
Support Windows Driver on CYGWIN.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,21 @@ unset ( WASAPI_SUPPORT CACHE )
 unset ( WAVEOUT_SUPPORT CACHE )
 unset ( WINMIDI_SUPPORT CACHE )
 unset ( MINGW32 CACHE )
-if ( WIN32 )
+
+if ( CYGWIN )
+  find_library(W32API_UUID_LIBRARY uuid
+    NO_DEFAULT_PATH
+    PATHS /lib/w32api
+  )
+  if ( NOT W32API_UUID_LIBRARY )
+    set ( enable-wasapi off )
+  else ()
+    message(STATUS "Found W32API uuid library for CYGWIN: " ${W32API_UUID_LIBRARY})
+    set ( WINDOWS_LIBS "${WINDOWS_LIBS};${W32API_UUID_LIBRARY}" )
+  endif ()
+endif ( CYGWIN )
+
+if ( WIN32 OR CYGWIN )
   include ( CheckIncludeFiles )
 
   # We have to set _WIN32_WINNT to make sure CMake gets correct results when probing for functions.
@@ -283,14 +297,10 @@ if ( WIN32 )
   # Check presence of MS include files
   check_include_file ( windows.h HAVE_WINDOWS_H )
   check_include_file ( io.h HAVE_IO_H )
-  check_include_file ( dsound.h HAVE_DSOUND_H )
+  check_include_files ( "windows.h;dsound.h" HAVE_DSOUND_H )
   check_include_files ( "windows.h;mmsystem.h" HAVE_MMSYSTEM_H )
   check_include_files ( "mmdeviceapi.h;audioclient.h" HAVE_WASAPI_HEADERS )
   check_include_file ( objbase.h HAVE_OBJBASE_H )
-
-  if ( enable-network )
-    set ( WINDOWS_LIBS "${WINDOWS_LIBS};ws2_32" )
-  endif ( enable-network )
 
   if ( enable-dsound AND HAVE_DSOUND_H )
     set ( WINDOWS_LIBS "${WINDOWS_LIBS};dsound;ksuser" )
@@ -311,6 +321,12 @@ if ( WIN32 )
     set ( WINDOWS_LIBS "${WINDOWS_LIBS};ole32" )
     set ( WASAPI_SUPPORT 1 )
   endif ()
+endif ( WIN32 OR CYGWIN )
+
+if ( WIN32 )
+  if ( enable-network )
+    set ( WINDOWS_LIBS "${WINDOWS_LIBS};ws2_32" )
+  endif ( enable-network )
 
   set ( LIBFLUID_CPPFLAGS "-DFLUIDSYNTH_DLL_EXPORTS" )
   set ( FLUID_CPPFLAGS "-DFLUIDSYNTH_NOT_A_DLL" )

--- a/doc/examples/example.c
+++ b/doc/examples/example.c
@@ -16,7 +16,7 @@
 
 #include <fluidsynth.h>
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #define sleep(_t) Sleep(_t * 1000)
 #include <process.h>

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -620,7 +620,7 @@ fluid_source(fluid_cmd_handler_t *handler, const char *filename)
     fluid_shell_t shell;
     int result;
 
-#ifdef WIN32
+#ifdef _WIN32
     file = _open(filename, _O_RDONLY);
 #else
     file = open(filename, O_RDONLY);
@@ -634,7 +634,7 @@ fluid_source(fluid_cmd_handler_t *handler, const char *filename)
     fluid_shell_init(&shell, NULL, handler, file, fluid_get_stdout());
     result = (fluid_shell_run(&shell) == FLUID_THREAD_RETURN_VALUE) ? 0 : -1;
 
-#ifdef WIN32
+#ifdef _WIN32
     _close(file);
 #else
     close(file);
@@ -658,7 +658,7 @@ fluid_get_userconf(char *buf, int len)
 {
     const char *home = NULL;
     const char *config_file;
-#if defined(WIN32)
+#if defined(_WIN32)
     home = getenv("USERPROFILE");
     config_file = "\\fluidsynth.cfg";
 
@@ -693,7 +693,7 @@ fluid_get_userconf(char *buf, int len)
 char *
 fluid_get_sysconf(char *buf, int len)
 {
-#if defined(WIN32)
+#if defined(_WIN32)
     const char* program_data = getenv("ProgramData");
     if(program_data == NULL || program_data[0] == '\0')
     {
@@ -4502,7 +4502,7 @@ fluid_is_number(char *a)
 char *
 fluid_expand_path(char *path, char *new_path, int len)
 {
-#if defined(WIN32) || defined(MACOS9)
+#if defined(_WIN32) || defined(MACOS9)
     FLUID_SNPRINTF(new_path, len - 1, "%s", path);
 #else
 

--- a/src/drivers/fluid_adriver.c
+++ b/src/drivers/fluid_adriver.c
@@ -220,7 +220,7 @@ void fluid_audio_driver_settings(fluid_settings_t *settings)
     fluid_settings_add_option(settings, "audio.sample-format", "16bits");
     fluid_settings_add_option(settings, "audio.sample-format", "float");
 
-#if defined(WIN32)
+#if defined(_WIN32)
     fluid_settings_register_int(settings, "audio.period-size", 512, 64, 8192, 0);
     fluid_settings_register_int(settings, "audio.periods", 8, 2, 64, 0);
 #elif defined(MACOS9)

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -20,7 +20,7 @@
 
 #include "fluid_sys.h"
 
-#if !defined(WIN32) && !defined(MACINTOSH)
+#if !defined(_WIN32) && !defined(MACINTOSH)
 #define _GNU_SOURCE
 #endif
 
@@ -160,7 +160,7 @@ print_pretty_int(int i)
     }
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 /* Function using win32 api to convert ANSI encoding string to UTF8 encoding string */
 static char*
 win32_ansi_to_utf8(const char* ansi_null_terminated_string)
@@ -734,7 +734,7 @@ int main(int argc, char **argv)
         case 'q':
             quiet = 1;
 
-#if defined(WIN32)
+#if defined(_WIN32)
             /* Windows logs to stdout by default, so make sure anything
              * lower than PANIC is not printed either */
             fluid_set_log_function(FLUID_ERR, NULL, NULL);
@@ -852,7 +852,7 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     SetPriorityClass(GetCurrentProcess(), REALTIME_PRIORITY_CLASS);
 #endif
 
@@ -945,7 +945,7 @@ int main(int argc, char **argv)
     for(i = arg1; i < argc; i++)
     {
         const char *u8_path = argv[i];
-#if defined(WIN32)
+#if defined(_WIN32)
         /* try to convert ANSI encoding path to UTF8 encoding path */
         char *u8_buf = win32_ansi_to_utf8(argv[i]);
         if (u8_buf == NULL)
@@ -971,7 +971,7 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Parameter '%s' not a SoundFont or MIDI file or error occurred identifying it.\n", argv[i]);
         }
-#if defined(WIN32)
+#if defined(_WIN32)
         free(u8_buf);
 #endif
     }

--- a/src/sfloader/fluid_sfont.c
+++ b/src/sfloader/fluid_sfont.c
@@ -45,7 +45,7 @@ fluid_long_long_t default_ftell(void *handle)
     return FLUID_FTELL((FILE *)handle);
 }
 
-#ifdef WIN32
+#ifdef _WIN32
     #define PRIi64 "%I64d"
 #else
     #define PRIi64 "%lld"

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -1777,7 +1777,7 @@ fluid_long_long_t fluid_file_tell(FILE* f)
 #endif
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 // not thread-safe!
 char* fluid_get_windows_error(void)
 {

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -30,7 +30,7 @@
 #include "fluid_rtkit.h"
 #endif
 
-#if HAVE_PTHREAD_H && !defined(WIN32)
+#if HAVE_PTHREAD_H && !defined(_WIN32)
 // Do not include pthread on windows. It includes winsock.h, which collides with ws2tcpip.h from fluid_sys.h
 // It isn't need on Windows anyway.
 #include <pthread.h>
@@ -132,7 +132,7 @@ fluid_default_log_function(int level, const char *message, void *data)
 {
     FILE *out;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     out = stdout;
 #else
     out = stderr;
@@ -228,7 +228,7 @@ void* fluid_alloc(size_t len)
  */
 FILE *fluid_fopen(const char *filename, const char *mode)
 {
-#if defined(WIN32)
+#if defined(_WIN32)
     wchar_t *wpath = NULL, *wmode = NULL;
     FILE *file = NULL;
     int length;
@@ -420,7 +420,7 @@ fluid_utime(void)
      * used instead.
      * see: https://bugzilla.gnome.org/show_bug.cgi?id=783340
      */
-#if defined(WITH_PROFILING) &&  defined(WIN32) &&\
+#if defined(WITH_PROFILING) &&  defined(_WIN32) &&\
 	/* glib < 2.53.3 */\
 	(GLIB_MINOR_VERSION <= 53 && (GLIB_MINOR_VERSION < 53 || GLIB_MICRO_VERSION < 3))
     /* use high precision performance counter. */
@@ -449,7 +449,7 @@ fluid_utime(void)
 
 
 
-#if defined(WIN32)      /* Windoze specific stuff */
+#if defined(_WIN32)      /* Windoze specific stuff */
 
 void
 fluid_thread_self_set_prio(int prio_level)
@@ -864,7 +864,7 @@ int fluid_profile_is_cancel_req(void)
 {
 #ifdef FLUID_PROFILE_CANCEL
 
-#if defined(WIN32)      /* Windows specific stuff */
+#if defined(_WIN32)      /* Windows specific stuff */
     /* Profile cancellation is supported for Windows */
     /* returns TRUE if key <ENTER> is depressed */
     return(GetAsyncKeyState(VK_RETURN) & 0x1);
@@ -1357,7 +1357,7 @@ fluid_istream_gets(fluid_istream_t in, char *buf, int len)
 
     while(--len > 0)
     {
-#ifndef WIN32
+#ifndef _WIN32
         n = read(in, &c, 1);
 
         if(n == -1)
@@ -1447,7 +1447,7 @@ fluid_ostream_printf(fluid_ostream_t out, const char *format, ...)
 
     buf[4095] = 0;
 
-#ifndef WIN32
+#ifndef _WIN32
     return write(out, buf, FLUID_STRLEN(buf));
 #else
     {
@@ -1757,7 +1757,7 @@ FILE* fluid_file_open(const char* path, const char** errMsg)
 
 fluid_long_long_t fluid_file_tell(FILE* f)
 {
-#ifdef WIN32
+#ifdef _WIN32
     // On Windows, long is only a 32 bit integer. Thus ftell() does not support to handle files >2GiB.
     // We should use _ftelli64() in this case, however its availability depends on MS CRT and might not be
     // available on WindowsXP, Win98, etc.
@@ -1777,7 +1777,7 @@ fluid_long_long_t fluid_file_tell(FILE* f)
 #endif
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 // not thread-safe!
 char* fluid_get_windows_error(void)
 {

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -129,6 +129,17 @@ typedef gintptr  intptr_t;
 
 #endif
 
+/*
+ * CYGWIN has its own version of <windows.h>, which can be
+ * safely included together with POSIX includes.
+ * Thanks to this, CYGWIN can also run audio output and MIDI
+ * input drivers from traditional interfaces of Windows.
+ */
+#if defined(__CYGWIN__) && HAVE_WINDOWS_H
+#include <windows.h>
+#include <wchar.h>
+#endif
+
 #if defined(_WIN32) && HAVE_WINDOWS_H
 #include <winsock2.h>
 #include <ws2tcpip.h>	/* Provides also socklen_t */
@@ -167,7 +178,7 @@ typedef gintptr  intptr_t;
  */
 #define fluid_gerror_message(err)  ((err) ? err->message : "No error details")
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 char* fluid_get_windows_error(void);
 #endif
 

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -129,7 +129,7 @@ typedef gintptr  intptr_t;
 
 #endif
 
-#if defined(WIN32) &&  HAVE_WINDOWS_H
+#if defined(_WIN32) && HAVE_WINDOWS_H
 #include <winsock2.h>
 #include <ws2tcpip.h>	/* Provides also socklen_t */
 
@@ -167,7 +167,7 @@ typedef gintptr  intptr_t;
  */
 #define fluid_gerror_message(err)  ((err) ? err->message : "No error details")
 
-#ifdef WIN32
+#ifdef _WIN32
 char* fluid_get_windows_error(void);
 #endif
 
@@ -474,7 +474,7 @@ typedef GModule fluid_module_t;
 int fluid_istream_readline(fluid_istream_t in, fluid_ostream_t out, char *prompt, char *buf, int len);
 int fluid_ostream_printf(fluid_ostream_t out, const char *format, ...);
 
-#if defined(WIN32)
+#if defined(_WIN32)
 typedef SOCKET fluid_socket_t;
 #else
 typedef int fluid_socket_t;
@@ -498,7 +498,7 @@ fluid_ostream_t fluid_socket_get_ostream(fluid_socket_t sock);
     /* GStatBuf has not been introduced yet, manually typedef to what they had at that time:
      * https://github.com/GNOME/glib/blob/e7763678b56e3be073cc55d707a6e92fc2055ee0/glib/gstdio.h#L98-L115
      */
-    #if defined(WIN32) || HAVE_WINDOWS_H // somehow reliably mock G_OS_WIN32??
+    #if defined(_WIN32) || HAVE_WINDOWS_H // somehow reliably mock G_OS_WIN32??
         // Any effort from our side to reliably mock GStatBuf on Windows is in vain. E.g. glib-2.16 is broken as it uses struct stat rather than struct _stat32 on Win x86.
         // Disable it (the user has been warned by cmake).
         #undef fluid_stat
@@ -575,7 +575,7 @@ int fluid_profile_is_cancel_req(void);
  1) Adds #define FLUID_PROFILE_CANCEL
  2) Adds the necessary code inside fluid_profile_is_cancel() see fluid_sys.c
 */
-#if defined(WIN32)      /* Profile cancellation is supported for Windows */
+#if defined(_WIN32)      /* Profile cancellation is supported for Windows */
 #define FLUID_PROFILE_CANCEL
 
 #elif defined(__OS2__)  /* OS/2 specific stuff */

--- a/src/utils/fluidsynth_priv.h
+++ b/src/utils/fluidsynth_priv.h
@@ -200,7 +200,7 @@ void* fluid_alloc(size_t len);
 
 FILE *fluid_fopen(const char *filename, const char *mode);
 
-#ifdef WIN32
+#ifdef _WIN32
 #define FLUID_FSEEK(_f,_n,_set)      _fseeki64(_f,_n,_set)
 #else
 #define FLUID_FSEEK(_f,_n,_set)      fseek(_f,_n,_set)
@@ -236,7 +236,7 @@ do { strncpy(_dst,_src,_n-1); \
 #define FLUID_SPRINTF                sprintf
 #define FLUID_FPRINTF                fprintf
 
-#if (defined(WIN32) && _MSC_VER < 1900) || defined(MINGW32)
+#if (defined(_WIN32) && _MSC_VER < 1900) || defined(MINGW32)
 /* need to make sure we use a C99 compliant implementation of (v)snprintf(),
  * i.e. not microsofts non compliant extension _snprintf() as it doesn't
  * reliably null-terminate the buffer
@@ -246,19 +246,19 @@ do { strncpy(_dst,_src,_n-1); \
 #define FLUID_SNPRINTF           snprintf
 #endif
 
-#if (defined(WIN32) && _MSC_VER < 1500) || defined(MINGW32)
+#if (defined(_WIN32) && _MSC_VER < 1500) || defined(MINGW32)
 #define FLUID_VSNPRINTF          g_vsnprintf
 #else
 #define FLUID_VSNPRINTF          vsnprintf
 #endif
 
-#if defined(WIN32) && !defined(MINGW32)
+#if defined(_WIN32) && !defined(MINGW32)
 #define FLUID_STRCASECMP         _stricmp
 #else
 #define FLUID_STRCASECMP         strcasecmp
 #endif
 
-#if defined(WIN32) && !defined(MINGW32)
+#if defined(_WIN32) && !defined(MINGW32)
 #define FLUID_STRNCASECMP         _strnicmp
 #else
 #define FLUID_STRNCASECMP         strncasecmp

--- a/test/test.h
+++ b/test/test.h
@@ -17,7 +17,7 @@
  */
 #if defined(NO_GUI) && defined(MINGW32)
 #define TEST_ABORT exit(EXIT_FAILURE);
-#elif defined(NO_GUI) && defined(WIN32)
+#elif defined(NO_GUI) && defined(_WIN32)
 #define TEST_ABORT _set_abort_behavior(0, _WRITE_ABORT_MSG); abort()
 #else
 #define TEST_ABORT abort()


### PR DESCRIPTION
`_WIN32` is an intrinsic compiler macro that is always provided by the compiler. Instead, `WIN32` is defined by the project template or after you included Windows.h (for example). I suggest to use `_WIN32` instead of `WIN32` macro.
Nothing will change at compile time, but this is the first step to take for supporting Windows drivers also on CYGWIN, see issue #1212. Next, a second commit adds support for Windows drivers under CYGWIN, as explained into issue #1212.
Tested without problems with MSVC 2019/2022 for x86/x64 and i686/x86_64 under MinGW-w64.
Tested second commit on the latest CYGWIN 64-bits.