### PR TITLE
CMake: Fixes for vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,11 @@ set ( PULSEAUDIO_MINIMUM_VERSION 2.0 )
 
 include ( PkgConfigHelpers ) # Needed for Find modules using pkg-config
 
+# Make searching for packages easier on VCPKG
+if ( CMAKE_VERSION VERSION_GREATER_EQUAL 3.15 AND VCPKG_TOOLCHAIN )
+  set ( CMAKE_FIND_PACKAGE_PREFER_CONFIG ON )
+endif ()
+
 # Mandatory libraries: glib and gthread
 find_package ( GLib2 ${GLIB2_MINUMUM_VERSION} REQUIRED )
 list( APPEND PC_REQUIRES_PRIV "glib-2.0" "gthread-2.0")

--- a/FluidSynthConfig.cmake.in
+++ b/FluidSynthConfig.cmake.in
@@ -49,6 +49,11 @@ if(NOT FLUIDSYNTH_IS_SHARED)
   # Allows CMake to use the additional modules
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
+  # Make searching for packages easier on VCPKG
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15 AND VCPKG_TOOLCHAIN)
+    set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+  endif()
+
   # Load the pkg-config helpers
   include(PkgConfigHelpers)
 

--- a/cmake_admin/FindGLib2.cmake
+++ b/cmake_admin/FindGLib2.cmake
@@ -112,11 +112,7 @@ if(GLib2_glib-2_LIBRARY AND NOT TARGET GLib2::glib-2)
     find_package(Intl QUIET)
     find_package(Iconv QUIET)
     list(APPEND _glib2_link_libraries "Intl::Intl" "Iconv::Iconv")
-    if(APPLE)
-      list(APPEND _glib2_link_libraries "-Wl,-framework,Foundation"
-           "-Wl,-framework,CoreFoundation" "-Wl,-framework,AppKit"
-           "-Wl,-framework,Carbon")
-    elseif(WIN32)
+    if(WIN32)
       list(APPEND _glib2_link_libraries "ws2_32" "winmm")
     else()
       list(APPEND _glib2_link_libraries "Threads::Threads")
@@ -151,6 +147,14 @@ if(GLib2_glib-2_LIBRARY AND NOT TARGET GLib2::glib-2)
     else()
       list(APPEND _glib2_link_libraries "pcre")
     endif()
+  endif()
+
+  # pkg_check_modules consider these as LDFLAGS_OTHER rather instead of
+  # libraries
+  if(APPLE)
+    list(APPEND _glib2_link_libraries "-Wl,-framework,Foundation"
+         "-Wl,-framework,CoreFoundation" "-Wl,-framework,AppKit"
+         "-Wl,-framework,Carbon")
   endif()
 
   add_library(GLib2::glib-2 UNKNOWN IMPORTED)


### PR DESCRIPTION
This PR is a follow-up to #1211.

For sanity check, I tried making a fully static build of fluidsynth using the vcpkg portfile. (`vcpkg install --head fluidsynth`, after removing the `add-usage-requirements.patch` patch). Unfortunately, this build failed on macOS due to an issue in `FindGLib2.cmake`.

On macOS, GLib2 depends on a handful of Apple Frameworks, but when using pkg-config, the frameworks were not added to `GLib2::glib-2.0`'s `INTERFACE_LINK_LIBRARIES` resulting in undefined references.

It seems that the error was due to `pkg_check_modules` misinterpreting frameworks as "other LDFLAGS" instead of libraries:
```
PC_GLIB2_STATIC_LDFLAGS_OTHER:INTERNAL=-framework;Foundation;-framework;CoreFoundation;-framework;AppKit;-framework;Carbon
PC_GLIB2_STATIC_LIBRARIES:INTERNAL=glib-2.0;intl;iconv;intl;m;pcre2-8
```

Since these frameworks are always a requirement for GLib2 on macOS, I unconditionally add them to the `INTERFACE_LINK_LIBRARIES`, even when pkg-config is used.

---

Additionally, to further ease building and using fluidsynth in vcpkg, I set `CMAKE_FIND_PACKAGE_PREFER_CONFIG` to `ON` when vcpkg is used.

Since vcpkg primarily builds its packages with CMake, they commonly offer the upstream config. Prioritising the config over the find modules seems like a good default for that environment since it ensures we get the correct library for the current configuration (release/debug), and helps getting accurate usage requirements.

---

Testing was done using vcpkg and a modified fluidsynth portfile that incorporates this PR:
```cmake
vcpkg_from_github(
    OUT_SOURCE_PATH SOURCE_PATH
    REPO FtZPetruska/fluidsynth
    REF "0dd812cbc128ec97cc6bfe181b0cf76812e5d62a"
    SHA512 cfb6337d987bb575b5521f0f9a14f5140e09c596db536a300da34d71656486b4857ce04d10a7807e58ea0bdf48684606e1d7901eeb641f82d9425e147c6ee9ad
    HEAD_REF master
    PATCHES
        gentables.patch
)
```

The following triplets were tested successfully:
- x64-windows
- x64-windows-static
- arm64-osx
- x64-linux

The following features were included:
- `buildtools` (gentables)
- `sndfile` (libsndfile support)