### PR TITLE
Added fluid_player_get_division

### DIFF
--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -283,6 +283,7 @@ FLUIDSYNTH_API int fluid_player_get_status(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_get_current_tick(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_get_total_ticks(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_get_bpm(fluid_player_t *player);
+FLUIDSYNTH_API int fluid_player_get_division(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_get_midi_tempo(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_seek(fluid_player_t *player, int ticks);
 /** @} */

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2607,6 +2607,19 @@ int fluid_player_get_bpm(fluid_player_t *player)
 }
 
 /**
+ * Get the division currently used by a MIDI player.
+ * The player can be controlled by internal tempo coming from MIDI file tempo
+ * change or controlled by external tempo see fluid_player_set_tempo().
+ * @param player MIDI player instance. Must be a valid pointer.
+ * @return MIDI player division or FLUID_FAILED if error.
+ * @since 2.3.2
+ */
+int fluid_player_get_division(fluid_player_t *player)
+{
+    return player->division;
+}
+
+/**
  * Get the tempo currently used by a MIDI player.
  * The player can be controlled by internal tempo coming from MIDI file tempo
  * change or controlled by external tempo see fluid_player_set_tempo().


### PR DESCRIPTION
Added getter for division which is helpful to calculate the MIDI track length.

See also [#1112](https://github.com/FluidSynth/fluidsynth/discussions/1112)