### PR TITLE
Add an integration test for consuming fluidsynth via pkg-config

### DIFF
--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -26,10 +26,10 @@ jobs:
     matrix:
       UnixLibs11:
         imageName: 'macos-11'
-        CMakeFlags: '-Denable-framework=0'
+        CMakeFlags: '-Denable-framework=0 -Denable-readline=0'
       UnixLibs11_static:
         imageName: 'macos-11'
-        CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
+        CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0 -Denable-readline=0'
       #UnixLibs12:
         #imageName: 'macos-12'
         #CMakeFlags: '-Denable-framework=0'
@@ -59,6 +59,7 @@ jobs:
         mkdir build && cd build
         export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/opt/homebrew/opt/readline/lib/pkgconfig"
         cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
+        cat CMakeFiles/CMakeError.log
         make -j3
       displayName: 'Compile fluidsynth'
     - script: |

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -58,10 +58,8 @@ jobs:
         set -ex
         mkdir build && cd build
         export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig"
-        ls -la /usr/local/opt/libomp/ || true
-        ls -la /usr/local/opt/libomp/lib/pkgconfig || true
-        cmake --version
-        cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
+        # assist cmake in finding openmp installed via homebrew
+        cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -DCMAKE_PREFIX_PATH=/usr/local/opt/libomp ..
         ls -la .
         ls -la CMakeFiles/
         cat CMakeFiles/CMakeError.log CMakeFiles/CMakeOutput.log CMakeFiles/CMakeConfigureLog.yaml || true

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -57,11 +57,11 @@ jobs:
     - script: |
         set -ex
         mkdir build && cd build
-        export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/opt/homebrew/opt/readline/lib/pkgconfig"
-        ls -la /opt/homebrew/opt/ || true
-        ls -la /opt/homebrew/opt/readline/lib/pkgconfig || true
-        ls -la /opt/homebrew/opt/omp/ || true
-        ls -la /opt/homebrew/opt/omp/lib/pkgconfig || true
+        export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig"
+        ls -la /usr/local/opt/ || true
+        ls -la /usr/local/opt/readline/lib/pkgconfig || true
+        ls -la /usr/local/opt/omp/ || true
+        ls -la /usr/local/opt/omp/lib/pkgconfig || true
         cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
         ls -la .
         ls -la CMakeFiles/
@@ -96,7 +96,7 @@ jobs:
         #include <fluidsynth.h>
         int main() { fluid_free(0); return 0; }
         EOF
-        export PKG_CONFIG_PATH=$(Build.ArtifactStagingDirectory)/lib/pkgconfig:/opt/homebrew/opt/readline/lib/pkgconfig
+        export PKG_CONFIG_PATH=$(Build.ArtifactStagingDirectory)/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig
         set -x
         cc -fPIE -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ./static-link-test

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -58,8 +58,14 @@ jobs:
         set -ex
         mkdir build && cd build
         export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/opt/homebrew/opt/readline/lib/pkgconfig"
+        ls -la /opt/homebrew/opt/ || true
+        ls -la /opt/homebrew/opt/readline/lib/pkgconfig || true
+        ls -la /opt/homebrew/opt/omp/ || true
+        ls -la /opt/homebrew/opt/omp/lib/pkgconfig || true
         cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
-        cat CMakeFiles/CMakeError.log
+        ls -la .
+        ls -la CMakeFiles/
+        cat CMakeFiles/CMakeError.log CMakeFiles/CMakeOutput.log || true
         make -j3
       displayName: 'Compile fluidsynth'
     - script: |

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -60,10 +60,10 @@ jobs:
         export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig"
         ls -la /usr/local/opt/ || true
         ls -la /usr/local/opt/readline/lib/pkgconfig || true
-        ls -la /usr/local/opt/omp/ || true
-        ls -la /usr/local/opt/omp/lib/pkgconfig || true
+        ls -la /usr/local/opt/libomp/ || true
+        ls -la /usr/local/opt/libomp/lib/pkgconfig || true
         cmake --version
-        cmake -Werror=dev --log-level=DEBUG $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
+        cmake -Werror=dev --trace $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
         ls -la .
         ls -la CMakeFiles/
         cat CMakeFiles/CMakeError.log CMakeFiles/CMakeOutput.log || true

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -74,6 +74,18 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) ..
         make install
       displayName: 'Install fluidsynth to artifact dir'
+    - script: |
+        set -e
+        cat << EOF > static-link-test.c
+        #include <fluidsynth.h>
+        int main() { fluid_free(0); return 0; }
+        EOF
+        export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
+        set -x
+        cc -fPIE -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
+        ./static-link-test
+        echo $?
+      displayName: 'Consume from pkg-config'
 
 
 - job: macOS_ports

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -101,6 +101,7 @@ jobs:
         ./static-link-test
         echo $?
       displayName: 'Consume from pkg-config'
+      condition: and(succeeded(), contains(variables.CMakeFlags, 'Denable-framework=0'))
 
 
 - job: macOS_ports

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -24,13 +24,22 @@ jobs:
 - job: macOS_brew
   strategy:
     matrix:
-      UnixLibs:
+      UnixLibs11:
         imageName: 'macos-11'
         CMakeFlags: '-Denable-framework=0'
-      11_0:
+      UnixLibs11_static:
+        imageName: 'macos-11'
+        CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
+      UnixLibs12:
+        imageName: 'macos-12'
+        CMakeFlags: '-Denable-framework=0'
+      UnixLibs12_static:
+        imageName: 'macos-12'
+        CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
+      FrameWork11:
         imageName: 'macos-11'
         CMakeFlags: ''
-      12_0:
+      FrameWork12:
         imageName: 'macos-12'
         CMakeFlags: ''
 

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -48,7 +48,7 @@ jobs:
     - script: |
         set -ex
         mkdir build && cd build
-        export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
+        export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/opt/homebrew/opt/readline/lib/pkgconfig"
         cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
         make -j3
       displayName: 'Compile fluidsynth'
@@ -80,7 +80,7 @@ jobs:
         #include <fluidsynth.h>
         int main() { fluid_free(0); return 0; }
         EOF
-        export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
+        export PKG_CONFIG_PATH=$(Build.ArtifactStagingDirectory)/lib/pkgconfig:/opt/homebrew/opt/readline/lib/pkgconfig
         set -x
         cc -fPIE -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ./static-link-test

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -26,22 +26,22 @@ jobs:
     matrix:
       UnixLibs11:
         imageName: 'macos-11'
-        CMakeFlags: '-Denable-framework=0 -Denable-readline=0'
+        CMakeFlags: '-Denable-framework=0'
       UnixLibs11_static:
         imageName: 'macos-11'
-        CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0 -Denable-readline=0'
-      #UnixLibs12:
-        #imageName: 'macos-12'
-        #CMakeFlags: '-Denable-framework=0'
-      #UnixLibs12_static:
-        #imageName: 'macos-12'
-        #CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
-      #FrameWork11:
-        #imageName: 'macos-11'
-        #CMakeFlags: ''
-      #FrameWork12:
-        #imageName: 'macos-12'
-        #CMakeFlags: ''
+        CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
+      UnixLibs12:
+        imageName: 'macos-12'
+        CMakeFlags: '-Denable-framework=0'
+      UnixLibs12_static:
+        imageName: 'macos-12'
+        CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
+      FrameWork11:
+        imageName: 'macos-11'
+        CMakeFlags: ''
+      FrameWork12:
+        imageName: 'macos-12'
+        CMakeFlags: ''
 
   pool:
     vmImage: $(imageName)
@@ -58,12 +58,10 @@ jobs:
         set -ex
         mkdir build && cd build
         export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig"
-        ls -la /usr/local/opt/ || true
-        ls -la /usr/local/opt/readline/lib/pkgconfig || true
         ls -la /usr/local/opt/libomp/ || true
         ls -la /usr/local/opt/libomp/lib/pkgconfig || true
         cmake --version
-        cmake -Werror=dev --trace $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
+        cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
         ls -la .
         ls -la CMakeFiles/
         cat CMakeFiles/CMakeError.log CMakeFiles/CMakeOutput.log || true

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -62,7 +62,8 @@ jobs:
         ls -la /usr/local/opt/readline/lib/pkgconfig || true
         ls -la /usr/local/opt/omp/ || true
         ls -la /usr/local/opt/omp/lib/pkgconfig || true
-        cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
+        cmake --version
+        cmake -Werror=dev --log-level=DEBUG $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
         ls -la .
         ls -la CMakeFiles/
         cat CMakeFiles/CMakeError.log CMakeFiles/CMakeOutput.log || true

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -30,18 +30,18 @@ jobs:
       UnixLibs11_static:
         imageName: 'macos-11'
         CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
-      UnixLibs12:
-        imageName: 'macos-12'
-        CMakeFlags: '-Denable-framework=0'
-      UnixLibs12_static:
-        imageName: 'macos-12'
-        CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
-      FrameWork11:
-        imageName: 'macos-11'
-        CMakeFlags: ''
-      FrameWork12:
-        imageName: 'macos-12'
-        CMakeFlags: ''
+      #UnixLibs12:
+        #imageName: 'macos-12'
+        #CMakeFlags: '-Denable-framework=0'
+      #UnixLibs12_static:
+        #imageName: 'macos-12'
+        #CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
+      #FrameWork11:
+        #imageName: 'macos-11'
+        #CMakeFlags: ''
+      #FrameWork12:
+        #imageName: 'macos-12'
+        #CMakeFlags: ''
 
   pool:
     vmImage: $(imageName)
@@ -51,7 +51,7 @@ jobs:
   steps:
     - script: |
         set -ex
-        PACKAGES="glib gobject-introspection libsndfile pkg-config jack dbus-glib pulseaudio portaudio sdl2 libomp"
+        PACKAGES="glib gobject-introspection libsndfile pkg-config jack dbus-glib pulseaudio portaudio sdl2 libomp readline"
         brew install $PACKAGES
       displayName: 'Prerequisites'
     - script: |

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -64,7 +64,7 @@ jobs:
         cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 ..
         ls -la .
         ls -la CMakeFiles/
-        cat CMakeFiles/CMakeError.log CMakeFiles/CMakeOutput.log || true
+        cat CMakeFiles/CMakeError.log CMakeFiles/CMakeOutput.log CMakeFiles/CMakeConfigureLog.yaml || true
         make -j3
       displayName: 'Compile fluidsynth'
     - script: |

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -57,9 +57,9 @@ jobs:
     - script: |
         set -ex
         mkdir build && cd build
-        export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig:$(brew --prefix readline)/lib/pkgconfig"
         # assist cmake in finding openmp installed via homebrew
-        cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -DCMAKE_PREFIX_PATH=/usr/local/opt/libomp ..
+        cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -DCMAKE_PREFIX_PATH=$(brew --prefix libomp) ..
         make -j3
       displayName: 'Compile fluidsynth'
     - script: |
@@ -90,7 +90,7 @@ jobs:
         #include <fluidsynth.h>
         int main() { fluid_synth_process(0,0,0,0,0,0); return 0; }
         EOF
-        export PKG_CONFIG_PATH=$(Build.ArtifactStagingDirectory)/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig
+        export PKG_CONFIG_PATH=$(Build.ArtifactStagingDirectory)/lib/pkgconfig:$(brew --prefix readline)/lib/pkgconfig
         set -x
         cc -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ./static-link-test

--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -60,9 +60,6 @@ jobs:
         export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig"
         # assist cmake in finding openmp installed via homebrew
         cmake -Werror=dev $(CMakeFlags) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -DCMAKE_PREFIX_PATH=/usr/local/opt/libomp ..
-        ls -la .
-        ls -la CMakeFiles/
-        cat CMakeFiles/CMakeError.log CMakeFiles/CMakeOutput.log CMakeFiles/CMakeConfigureLog.yaml || true
         make -j3
       displayName: 'Compile fluidsynth'
     - script: |
@@ -91,11 +88,11 @@ jobs:
         set -e
         cat << EOF > static-link-test.c
         #include <fluidsynth.h>
-        int main() { fluid_free(0); return 0; }
+        int main() { fluid_synth_process(0,0,0,0,0,0); return 0; }
         EOF
         export PKG_CONFIG_PATH=$(Build.ArtifactStagingDirectory)/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig
         set -x
-        cc -fPIE -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
+        cc -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ./static-link-test
         echo $?
       displayName: 'Consume from pkg-config'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -123,7 +123,7 @@ jobs:
         set -e
         cat << EOF > static-link-test.c
         #include <fluidsynth.h>
-        int main() { fluid_free(0); return 0; }
+        int main() { fluid_synth_process(0,0,0,0,0,0); return 0; }
         EOF
         export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
         set -x

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,8 +46,8 @@ jobs:
           - CC: "clang-12"
             CXX: "clang++-12"
             CMAKE_FLAGS: ""
-          - CC: "clang-12"
-            CXX: "clang++-12"
+          - CC: "clang-10"
+            CXX: "clang++-10"
             CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
 # clang9 is covered by openSUSE Leap 15.2
 # clang11 is covered by openSUSE Leap 15.3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -97,6 +97,7 @@ jobs:
           -G Ninja \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_VERBOSE_MAKEFILE=1 \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=1 \
           -Werror=dev \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_LOCATION \
           -Denable-portaudio=1 \
@@ -126,7 +127,7 @@ jobs:
         EOF
         export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
         set -x
-        gcc -fno-pie -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
+        gcc -fPIE -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ./static-link-test
         echo $?
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,9 +49,6 @@ jobs:
           - CC: "clang-12"
             CXX: "clang++-12"
             CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
-          - CC: "clang-13"
-            CXX: "clang++-13"
-            CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
 # clang9 is covered by openSUSE Leap 15.2
 # clang11 is covered by openSUSE Leap 15.3
 
@@ -71,7 +68,6 @@ jobs:
           clang-8 \
           clang-10 \
           clang-12 \
-          clang-13 \
           clang-tidy \
           cmake \
           cmake-data \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,6 +46,9 @@ jobs:
           - CC: "clang-12"
             CXX: "clang++-12"
             CMAKE_FLAGS: ""
+          - CC: "clang-12"
+            CXX: "clang++-12"
+            CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
 # clang9 is covered by openSUSE Leap 15.2
 # clang11 is covered by openSUSE Leap 15.3
 
@@ -113,20 +116,22 @@ jobs:
       run: cmake --install build && ls -la $INSTALL_LOCATION
 
     - name: Consume from pkg-config
-      if: ${{ contains(matrix.CMAKE_FLAGS, '-DBUILD_SHARED_LIBS=0') }}
+      if: ${{ contains(matrix.CMAKE_FLAGS, 'BUILD_SHARED_LIBS=0') }}
       run: |
+        set -e
         cat << EOF > static-link-test.c
         #include <fluidsynth.h>
         int main() { fluid_free(0); return 0; }
         EOF
         export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
-        set +x
+        set -x
         gcc -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ./static-link-test
         echo $?
 
     - name: Consume from build
       run: |
+        set -e
         export CC=${{ matrix.CC }}
         export CXX=${{ matrix.CXX }}
         cmake -S test/cmake \
@@ -138,6 +143,7 @@ jobs:
 
     - name: Consume from install
       run: |
+        set -e
         export CC=${{ matrix.CC }}
         export CXX=${{ matrix.CXX }}
         cmake -S test/cmake -B consume-install \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,7 +126,7 @@ jobs:
         EOF
         export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
         set -x
-        gcc -fPIE -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
+        gcc -fno-pie -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ./static-link-test
         echo $?
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,9 +118,9 @@ jobs:
         #include <fluidsynth.h>
         int main() { fluid_free(0); return 0; }
         EOF
-        export PKG_CONFIG_PATH=$INSTALL_LOCATION
+        export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
         pkg-config --libs --static fluidsynth
-        ${{ matrix.CC }} -o static-link-test static-link-test.c src/libfluidsynth.a $(pkg-config --libs --static fluidsynth)
+        ${{ matrix.CC }} -o static-link-test static-link-test.c $(pkg-config --libs --static fluidsynth)
         ls -la
         ./static-link-test
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,6 +49,9 @@ jobs:
           - CC: "clang-12"
             CXX: "clang++-12"
             CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
+          - CC: "clang-13"
+            CXX: "clang++-13"
+            CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
 # clang9 is covered by openSUSE Leap 15.2
 # clang11 is covered by openSUSE Leap 15.3
 
@@ -66,8 +69,9 @@ jobs:
         sudo apt-get -yq --no-install-suggests --no-install-recommends install \
           clang-7 \
           clang-8 \
-          clang-9 \
           clang-10 \
+          clang-12 \
+          clang-13 \
           clang-tidy \
           cmake \
           cmake-data \
@@ -85,6 +89,7 @@ jobs:
           libsndfile-dev \
           libsystemd-dev \
           ninja-build \
+          libomp-dev \
           portaudio19-dev
 
     - name: Configure CMake
@@ -125,7 +130,7 @@ jobs:
         EOF
         export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
         set -x
-        gcc -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
+        gcc -fPIE -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ./static-link-test
         echo $?
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
       run: cmake --install build && ls -la $INSTALL_LOCATION
 
     - name: Consume from pkg-config
-      if: ${{ contains(${{matrix.CMAKE_FLAGS}}, '-DBUILD_SHARED_LIBS=0') }}
+      if: ${{ contains(matrix.CMAKE_FLAGS, '-DBUILD_SHARED_LIBS=0') }}
       run: |
         cat << EOF > static-link-test.c
         #include <fluidsynth.h>

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -92,6 +92,7 @@ jobs:
           -B build \
           -G Ninja \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_VERBOSE_MAKEFILE=1 \
           -Werror=dev \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_LOCATION \
           -Denable-portaudio=1 \
@@ -119,10 +120,10 @@ jobs:
         int main() { fluid_free(0); return 0; }
         EOF
         export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
-        pkg-config --libs --static fluidsynth
+        set +x
         gcc -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
-        ls -la
         ./static-link-test
+        echo $?
 
     - name: Consume from build
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,7 +120,7 @@ jobs:
         EOF
         export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
         pkg-config --libs --static fluidsynth
-        ${{ matrix.CC }} -o static-link-test static-link-test.c $(pkg-config --libs --static fluidsynth)
+        gcc -o static-link-test static-link-test.c $(pkg-config --libs --static fluidsynth)
         ls -la
         ./static-link-test
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,7 +120,7 @@ jobs:
         EOF
         export PKG_CONFIG_PATH=$INSTALL_LOCATION/lib/pkgconfig
         pkg-config --libs --static fluidsynth
-        gcc -o static-link-test static-link-test.c $(pkg-config --libs --static fluidsynth)
+        gcc -o static-link-test static-link-test.c $(pkg-config --cflags --static fluidsynth) $(pkg-config --libs --static fluidsynth)
         ls -la
         ./static-link-test
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -109,7 +109,20 @@ jobs:
       run: cmake --build build --target demo
 
     - name: Install
-      run: cmake --install build
+      run: cmake --install build && ls -la $INSTALL_LOCATION
+
+    - name: Consume from pkg-config
+      if: ${{ contains(${{matrix.CMAKE_FLAGS}}, '-DBUILD_SHARED_LIBS=0') }}
+      run: |
+        cat << EOF > static-link-test.c
+        #include <fluidsynth.h>
+        int main() { fluid_free(0); return 0; }
+        EOF
+        export PKG_CONFIG_PATH=$INSTALL_LOCATION
+        pkg-config --libs --static fluidsynth
+        ${{ matrix.CC }} -o static-link-test static-link-test.c src/libfluidsynth.a $(pkg-config --libs --static fluidsynth)
+        ls -la
+        ./static-link-test
 
     - name: Consume from build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,7 +725,7 @@ if ( enable-threads )
 endif ( enable-threads )
 
 unset ( HAVE_OPENMP CACHE )
-find_package ( OpenMP QUIET COMPONENTS C )
+find_package ( OpenMP COMPONENTS C )
 if (enable-openmp AND ENABLE_UBSAN)
     message(WARNING "OpenMP is not supported when UBSan is enabled. Disabling OpenMP.")
 elseif (enable-openmp AND OpenMP_C_FOUND )


### PR DESCRIPTION
This adds an additional build step to MacOS and Linux CI to make sure a static libfluidsynth can be consumed via `pkg-config`.

It's intended as a regression test for #1224.