### PR TITLE
Fix choppy sound when selecting pipewire output

### DIFF
--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -196,10 +196,15 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
         goto driver_cleanup;
     }
 
+    struct pw_properties *props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, NULL);
+
+    pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", period_size, (int) sample_rate);
+    pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
+
     drv->pw_stream = pw_stream_new_simple(
                          pw_thread_loop_get_loop(drv->pw_loop),
                          "FluidSynth",
-                         pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, NULL),
+                         props,
                          drv->events,
                          drv);
 


### PR DESCRIPTION
Because forgot to set the period size in pipewire.