### PR TITLE
Fix zone range initialization

### DIFF
--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -1447,8 +1447,8 @@ fluid_zone_gen_import_sfont(fluid_gen_t *gen, fluid_zone_range_t *range, fluid_z
 
     if(global_range != NULL)
     {
-        // Local zones are initialized with the default range of 0-127. However, they should be inited
-        // with the range of their global zone in case the local zone lacks a GEN_KEYRANGE or GEN_VELRANGE
+        // All zones are initialized with the default range of 0-127. However, local zones should be superseded by
+        // the range of their global zone in case that local zone lacks a GEN_KEYRANGE or GEN_VELRANGE
         // (see issue #1250).
         range->keylo = global_range->keylo;
         range->keyhi = global_range->keyhi;

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -182,7 +182,7 @@ fluid_preset_zone_t *new_fluid_preset_zone(char *name);
 void delete_fluid_list_mod(fluid_mod_t *mod);
 void delete_fluid_preset_zone(fluid_preset_zone_t *zone);
 fluid_preset_zone_t *fluid_preset_zone_next(fluid_preset_zone_t *zone);
-int fluid_preset_zone_import_sfont(fluid_preset_zone_t *zone, SFZone *sfzone, fluid_defsfont_t *defssfont, SFData *sfdata);
+int fluid_preset_zone_import_sfont(fluid_preset_zone_t *zone, fluid_preset_zone_t *global_zone, SFZone *sfzone, fluid_defsfont_t *defssfont, SFData *sfdata);
 fluid_inst_t *fluid_preset_zone_get_inst(fluid_preset_zone_t *zone);
 
 /*
@@ -221,7 +221,7 @@ struct _fluid_inst_zone_t
 fluid_inst_zone_t *new_fluid_inst_zone(char *name);
 void delete_fluid_inst_zone(fluid_inst_zone_t *zone);
 fluid_inst_zone_t *fluid_inst_zone_next(fluid_inst_zone_t *zone);
-int fluid_inst_zone_import_sfont(fluid_inst_zone_t *inst_zone, SFZone *sfzone, fluid_defsfont_t *defsfont, SFData *sfdata);
+int fluid_inst_zone_import_sfont(fluid_inst_zone_t *inst_zone, fluid_inst_zone_t *global_inst_zone, SFZone *sfzone, fluid_defsfont_t *defsfont, SFData *sfdata);
 fluid_sample_t *fluid_inst_zone_get_sample(fluid_inst_zone_t *zone);
 
 


### PR DESCRIPTION
Previously, zone ranges were always initialized to their default `0-127` not respecting the global zone ranges. This PR fixes this behavior for both, instrument and preset zones as well as for key and velocity ranges. Resolves #1250.

This also fixes a few memory leaks in `fluid_inst_import_sfont()`.