### PR TITLE
Add fluid_thread

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,6 +121,7 @@ set ( libfluidsynth_SOURCES
     utils/fluidsynth_priv.h
     utils/fluid_sys.c
     utils/fluid_sys.h
+    utils/fluid_thread.h
     sfloader/fluid_defsfont.c
     sfloader/fluid_defsfont.h
     sfloader/fluid_sfont.h

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -1002,7 +1002,7 @@ void fluid_profile_start_stop(unsigned int end_ticks, short clear_data)
 fluid_cond_t *
 new_fluid_cond(void)
 {
-    if(!g_thread_supported())
+    if(!fluid_thread_supported())
     {
         g_thread_init(NULL);
     }
@@ -1048,7 +1048,7 @@ new_fluid_thread(const char *name, fluid_thread_func_t func, void *data, int pri
     /* Make sure g_thread_init has been called.
      * Probably not a good idea in a shared library,
      * but what can we do *and* remain backwards compatible? */
-    if(!g_thread_supported())
+    if(!fluid_thread_supported())
     {
         g_thread_init(NULL);
     }

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -40,6 +40,7 @@
 #define _FLUID_SYS_H
 
 #include "fluidsynth_priv.h"
+#include "fluid_thread.h"
 
 #if HAVE_MATH_H
 #include <math.h>
@@ -348,7 +349,7 @@ typedef GStaticMutex fluid_mutex_t;
 #define fluid_mutex_unlock(_m)    g_static_mutex_unlock(&(_m))
 
 #define fluid_mutex_init(_m)      do { \
-  if (!g_thread_supported ()) g_thread_init (NULL); \
+  if (!fluid_thread_supported()) g_thread_init (NULL); \
   g_static_mutex_init (&(_m)); \
 } while(0)
 
@@ -359,7 +360,7 @@ typedef GStaticRecMutex fluid_rec_mutex_t;
 #define fluid_rec_mutex_unlock(_m)    g_static_rec_mutex_unlock(&(_m))
 
 #define fluid_rec_mutex_init(_m)      do { \
-  if (!g_thread_supported ()) g_thread_init (NULL); \
+  if (!fluid_thread_supported()) g_thread_init (NULL); \
   g_static_rec_mutex_init (&(_m)); \
 } while(0)
 
@@ -372,7 +373,7 @@ typedef GMutex    fluid_cond_mutex_t;
 static FLUID_INLINE fluid_cond_mutex_t *
 new_fluid_cond_mutex(void)
 {
-    if(!g_thread_supported())
+    if(!fluid_thread_supported())
     {
         g_thread_init(NULL);
     }
@@ -395,7 +396,7 @@ typedef GStaticPrivate fluid_private_t;
 #define fluid_private_free(_priv)                  g_static_private_free(&(_priv))
 
 #define fluid_private_init(_priv)                  do { \
-  if (!g_thread_supported ()) g_thread_init (NULL); \
+  if (!fluid_thread_supported()) g_thread_init (NULL); \
   g_static_private_init (&(_priv)); \
 } while(0)
 

--- a/src/utils/fluid_thread.h
+++ b/src/utils/fluid_thread.h
@@ -1,0 +1,6 @@
+#ifndef _FLUID_THREAD_H
+#define _FLUID_THREAD_H
+
+#define fluid_thread_supported g_thread_supported
+
+#endif


### PR DESCRIPTION
There have been a lot of discussions about wanting to get rid of glib (my personal reasons are to make FS work w/ WASM). As others have pointed out most of the use of glib is for threading. As a (very small) first step I think that some indirection needs to be added so that `fluid_sys` is not riddled with `g_*` calls. 

If creating `fluid_thread.h` seems like a good idea to others the various other `fluid_thread_*` functions can be moved over as well.