### PR TITLE
Fix player termination after stopping and restarting

### DIFF
--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2291,6 +2291,7 @@ fluid_player_play(fluid_player_t *player)
     if(!player->use_system_timer)
     {
         fluid_sample_timer_reset(player->synth, player->sample_timer);
+        player->cur_msec = 0;
     }
 
     /* If we're at the end of the playlist and there are no loops left, loop once */


### PR DESCRIPTION
If using the sample timer, reset cur_msec=0 in fluid_player_play() since the sample timer is also reset. This way fluid_player_callback() will not misinterpret the player's cur_msec < msec as being due to a fluid_synth_get_ticks overflow.