### PR TITLE
Update FreeBSD CI: Drop 12.4 and add 14.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@ task:
     name: FreeBSD
     freebsd_instance:
         matrix:
+            image_family: freebsd-14-0
             image_family: freebsd-13-2
-            image_family: freebsd-12-4
 
     install_script: pwd && ls -la && pkg update --force && pkg install -y cmake glib alsa-lib ladspa portaudio pulseaudio pkgconf sdl2
     


### PR DESCRIPTION
FreeBSD 12.4 is EOL at the end of 2023, and 14.0 was released recently.