### PR TITLE
Fix libinstpatch and sndfile not being discovered on Windows

### DIFF
--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -71,7 +71,7 @@ jobs:
         SET "PATH=d:\deps\bin;%PATH%"
         pkg-config --list-all
         mkdir build && cd build || exit -1
-        cmake --trace -Werror=dev -A $(platform) -T $(toolset) -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-sdl2=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -Dwindows-version=0x0501 .. || exit -1
+        cmake -Werror=dev -A $(platform) -T $(toolset) -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-sdl2=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -Dwindows-version=0x0501 .. || exit -1
         cmake --build . --config Release --parallel 3 || exit -1
       displayName: 'Compile fluidsynth'
     - script: |
@@ -144,7 +144,7 @@ jobs:
         @ECHO ON
         SET "PATH=d:\deps\bin;%PATH%"
         mkdir build && cd build || exit -1
-        cmake --trace -Werror=dev -A x64 -T $(toolset) -DCMAKE_BUILD_TYPE=$(CMAKE_CONFIG) -DCMAKE_VERBOSE_MAKEFILE=1 $(CMAKE_FLAGS) -DNO_GUI=1 -Dwindows-version=0x0A00 -Denable-jack=0 -Denable-pulseaudio=0 -Denable-ladspa=0 -Denable-dbus=0 -Denable-readline=0 -Denable-sdl2=0 -Denable-libinstpatch=0 .. || exit -1
+        cmake -Werror=dev -A x64 -T $(toolset) -DCMAKE_BUILD_TYPE=$(CMAKE_CONFIG) -DCMAKE_VERBOSE_MAKEFILE=1 $(CMAKE_FLAGS) -DNO_GUI=1 -Dwindows-version=0x0A00 -Denable-jack=0 -Denable-pulseaudio=0 -Denable-ladspa=0 -Denable-dbus=0 -Denable-readline=0 -Denable-sdl2=0 -Denable-libinstpatch=0 .. || exit -1
         cmake --build . --config $(CMAKE_CONFIG) --parallel 3 || exit -1
       displayName: 'Compile fluidsynth'
     - script: |
@@ -215,7 +215,7 @@ jobs:
         set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
         pkg-config --list-all
         mkdir build && cd build || exit -1
-        cmake --trace -Werror=dev -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) $(CMAKE_FLAGS) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-pulseaudio=0 -Denable-ladspa=0 -Denable-dbus=0 -Denable-sdl2=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 .. || exit -1
+        cmake -Werror=dev -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) $(CMAKE_FLAGS) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-pulseaudio=0 -Denable-ladspa=0 -Denable-dbus=0 -Denable-sdl2=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 .. || exit -1
         mingw32-make.exe -j3 all || exit -1
       displayName: 'Compile fluidsynth'
     - script: |

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -71,7 +71,7 @@ jobs:
         SET "PATH=d:\deps\bin;%PATH%"
         pkg-config --list-all
         mkdir build && cd build || exit -1
-        cmake -Werror=dev -A $(platform) -T $(toolset) -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-sdl2=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -Dwindows-version=0x0501 .. || exit -1
+        cmake --trace -Werror=dev -A $(platform) -T $(toolset) -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-sdl2=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -Dwindows-version=0x0501 .. || exit -1
         cmake --build . --config Release --parallel 3 || exit -1
       displayName: 'Compile fluidsynth'
     - script: |
@@ -144,7 +144,7 @@ jobs:
         @ECHO ON
         SET "PATH=d:\deps\bin;%PATH%"
         mkdir build && cd build || exit -1
-        cmake -Werror=dev -A x64 -T $(toolset) -DCMAKE_BUILD_TYPE=$(CMAKE_CONFIG) -DCMAKE_VERBOSE_MAKEFILE=1 $(CMAKE_FLAGS) -DNO_GUI=1 -Dwindows-version=0x0A00 -Denable-jack=0 -Denable-pulseaudio=0 -Denable-ladspa=0 -Denable-dbus=0 -Denable-readline=0 -Denable-sdl2=0 -Denable-libinstpatch=0 .. || exit -1
+        cmake --trace -Werror=dev -A x64 -T $(toolset) -DCMAKE_BUILD_TYPE=$(CMAKE_CONFIG) -DCMAKE_VERBOSE_MAKEFILE=1 $(CMAKE_FLAGS) -DNO_GUI=1 -Dwindows-version=0x0A00 -Denable-jack=0 -Denable-pulseaudio=0 -Denable-ladspa=0 -Denable-dbus=0 -Denable-readline=0 -Denable-sdl2=0 -Denable-libinstpatch=0 .. || exit -1
         cmake --build . --config $(CMAKE_CONFIG) --parallel 3 || exit -1
       displayName: 'Compile fluidsynth'
     - script: |
@@ -215,7 +215,7 @@ jobs:
         set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
         pkg-config --list-all
         mkdir build && cd build || exit -1
-        cmake -Werror=dev -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) $(CMAKE_FLAGS) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-pulseaudio=0 -Denable-ladspa=0 -Denable-dbus=0 -Denable-sdl2=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 .. || exit -1
+        cmake --trace -Werror=dev -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) $(CMAKE_FLAGS) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-pulseaudio=0 -Denable-ladspa=0 -Denable-dbus=0 -Denable-sdl2=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 .. || exit -1
         mingw32-make.exe -j3 all || exit -1
       displayName: 'Compile fluidsynth'
     - script: |

--- a/cmake_admin/FindInstPatch.cmake
+++ b/cmake_admin/FindInstPatch.cmake
@@ -68,10 +68,6 @@ else()
                                 "GLib2::glib-2" "SndFile::sndfile")
 endif()
 
-message(STATUS "PC_INSTPATCH_FOUND: ${PC_INSTPATCH_FOUND}")
-message(STATUS "_instpatch_link_libraries: ${_instpatch_link_libraries}")
-message(STATUS "SNDFILE_INCLUDE_DIR: ${SNDFILE_INCLUDE_DIR}")
-
 # Forward the result to CMake
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake_admin/FindInstPatch.cmake
+++ b/cmake_admin/FindInstPatch.cmake
@@ -68,6 +68,10 @@ else()
                                 "GLib2::glib-2" "SndFile::sndfile")
 endif()
 
+message(STATUS "PC_INSTPATCH_FOUND: ${PC_INSTPATCH_FOUND}")
+message(STATUS "_instpatch_link_libraries: ${_instpatch_link_libraries}")
+message(STATUS "SNDFILE_INCLUDE_DIR: ${SNDFILE_INCLUDE_DIR}")
+
 # Forward the result to CMake
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake_admin/FindInstPatch.cmake
+++ b/cmake_admin/FindInstPatch.cmake
@@ -37,7 +37,7 @@ find_path(
 
 find_library(
   InstPatch_LIBRARY
-  NAMES "instpatch-1.0"
+  NAMES "instpatch-1.0" "instpatch-2"
   HINTS "${PC_INSTPATCH_LIBDIR}")
 
 # Get version from pkg-config or read the config header

--- a/cmake_admin/FindInstPatch.cmake
+++ b/cmake_admin/FindInstPatch.cmake
@@ -25,8 +25,8 @@ This will define the following variables:
 #]=======================================================================]
 
 # Use pkg-config if available
-find_package(PkgConfig)
-pkg_check_modules(PC_INSTPATCH libinstpatch-1.0)
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_INSTPATCH QUIET libinstpatch-1.0)
 
 # Find the headers and library
 find_path(
@@ -59,10 +59,10 @@ else()
   if(NOT TARGET GLib2::gobject-2
      OR NOT TARGET GLib2::gthread-2
      OR NOT TARGET GLib2::glib-2)
-    find_package(GLib2)
+    find_package(GLib2 QUIET)
   endif()
   if(NOT TARGET SndFile::sndfile)
-    find_package(SndFile)
+    find_package(SndFile QUIET)
   endif()
   set(_instpatch_link_libraries "GLib2::gobject-2" "GLib2::gthread-2"
                                 "GLib2::glib-2" "SndFile::sndfile")

--- a/cmake_admin/FindInstPatch.cmake
+++ b/cmake_admin/FindInstPatch.cmake
@@ -25,8 +25,8 @@ This will define the following variables:
 #]=======================================================================]
 
 # Use pkg-config if available
-find_package(PkgConfig QUIET)
-pkg_check_modules(PC_INSTPATCH QUIET libinstpatch-1.0)
+find_package(PkgConfig)
+pkg_check_modules(PC_INSTPATCH libinstpatch-1.0)
 
 # Find the headers and library
 find_path(
@@ -59,10 +59,10 @@ else()
   if(NOT TARGET GLib2::gobject-2
      OR NOT TARGET GLib2::gthread-2
      OR NOT TARGET GLib2::glib-2)
-    find_package(GLib2 QUIET)
+    find_package(GLib2)
   endif()
   if(NOT TARGET SndFile::sndfile)
-    find_package(SndFile QUIET)
+    find_package(SndFile)
   endif()
   set(_instpatch_link_libraries "GLib2::gobject-2" "GLib2::gthread-2"
                                 "GLib2::glib-2" "SndFile::sndfile")

--- a/cmake_admin/FindSndFile.cmake
+++ b/cmake_admin/FindSndFile.cmake
@@ -50,7 +50,7 @@ find_path(
 
 find_library(
   _sndfile_library
-  NAMES "sndfile"
+  NAMES "sndfile" "sndfile-1"
   HINTS "${PC_SNDFILE_LIBDIR}")
 
 # Get version from pkg-config or read the config header

--- a/cmake_admin/FindSndFile.cmake
+++ b/cmake_admin/FindSndFile.cmake
@@ -39,8 +39,8 @@ For compatibility with upstream, the following variables are also set:
 #]=======================================================================]
 
 # Use pkg-config if available
-find_package(PkgConfig)
-pkg_check_modules(PC_SNDFILE sndfile)
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_SNDFILE QUIET sndfile)
 
 # Find the headers and libraries
 find_path(
@@ -78,12 +78,12 @@ if(PC_SNDFILE_FOUND)
   endif()
 elseif(_sndfile_library)
   # sndfile may need any of these libraries
-  find_package(Ogg 1.3)
-  find_package(Vorbis)
-  find_package(FLAC)
-  find_package(Opus)
-  find_package(mp3lame)
-  find_package(mpg123)
+  find_package(Ogg 1.3 QUIET)
+  find_package(Vorbis QUIET)
+  find_package(FLAC QUIET)
+  find_package(Opus QUIET)
+  find_package(mp3lame QUIET)
+  find_package(mpg123 QUIET)
 
   if(NOT CMAKE_CROSSCOMPILING)
     include(CheckSourceRuns)

--- a/cmake_admin/FindSndFile.cmake
+++ b/cmake_admin/FindSndFile.cmake
@@ -39,8 +39,8 @@ For compatibility with upstream, the following variables are also set:
 #]=======================================================================]
 
 # Use pkg-config if available
-find_package(PkgConfig QUIET)
-pkg_check_modules(PC_SNDFILE QUIET sndfile)
+find_package(PkgConfig)
+pkg_check_modules(PC_SNDFILE sndfile)
 
 # Find the headers and libraries
 find_path(
@@ -78,12 +78,12 @@ if(PC_SNDFILE_FOUND)
   endif()
 elseif(_sndfile_library)
   # sndfile may need any of these libraries
-  find_package(Ogg 1.3 QUIET)
-  find_package(Vorbis QUIET)
-  find_package(FLAC QUIET)
-  find_package(Opus QUIET)
-  find_package(mp3lame QUIET)
-  find_package(mpg123 QUIET)
+  find_package(Ogg 1.3)
+  find_package(Vorbis)
+  find_package(FLAC)
+  find_package(Opus)
+  find_package(mp3lame)
+  find_package(mpg123)
 
   if(NOT CMAKE_CROSSCOMPILING)
     include(CheckSourceRuns)

--- a/cmake_admin/FindSndFile.cmake
+++ b/cmake_admin/FindSndFile.cmake
@@ -69,7 +69,8 @@ elseif(SndFile_INCLUDE_DIR)
 endif()
 
 # Check the features SndFile was built with
-if(PC_SNDFILE_FOUND)
+# 2024-01-02: Recent versions of libsndfile don't seem to provide a pkgconfig file and older version who did are lacking private libraries like OGG.
+if(FALSE) #PC_SNDFILE_FOUND
   if("vorbis" IN_LIST PC_SNDFILE_STATIC_LIBRARIES)
     set(SndFile_WITH_EXTERNAL_LIBS TRUE)
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -499,10 +499,6 @@ if ( TARGET PipeWire::PipeWire AND PIPEWIRE_SUPPORT ) # because pw_init() etc.
     target_link_libraries ( fluidsynth PRIVATE PipeWire::PipeWire )
 endif()
 
-if ( TARGET InstPatch::libinstpatch AND LIBINSTPATCH_SUPPORT )
-    target_link_libraries ( fluidsynth PRIVATE InstPatch::libinstpatch )
-endif()
-
 if ( TARGET LASH::LASH AND LASH_SUPPORT )
     target_link_libraries ( fluidsynth PRIVATE LASH::LASH )
 endif()

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -29,9 +29,6 @@
 #define GETOPT_SUPPORT 1
 #endif
 
-#ifdef LIBINSTPATCH_SUPPORT
-#include <libinstpatch/libinstpatch.h>
-#endif
 #include "fluid_lash.h"
 
 #ifdef SYSTEMD_SUPPORT


### PR DESCRIPTION
libinstpatch and sndfile are using different library filenames on Windows. Previously, the CMake scripts were only looking for their Unix names resulting in the libraries not being found. This PR fixes it, and therefore implicitly restores DLS support for the precompiled Windows binaries.

In addition, we're no longer relying on sndfile's pkgconfig file to report correct private libs to figure out whether it has OGG / Vorbis support. This change restores SF3 support for precompiled Windows binaries.

Fixes #1298 