### PR TITLE
Fix an import library is treated as a static library on OS/2

### DIFF
--- a/cmake_admin/PkgConfigHelpers.cmake
+++ b/cmake_admin/PkgConfigHelpers.cmake
@@ -76,7 +76,8 @@ macro ( unset_pkg_config _prefix )
 endmacro ( unset_pkg_config )
 
 function ( get_target_properties_from_pkg_config _library _prefix _out_prefix )
-  if ( "${_library}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$" )
+  if ( NOT "${_library}" MATCHES "${CMAKE_IMPORT_LIBRARY_SUFFIX}$"
+       AND "${_library}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$" )
     set ( _cflags ${_prefix}_STATIC_CFLAGS_OTHER )
     set ( _link_libraries ${_prefix}_STATIC_LIBRARIES )
     set ( _library_dirs ${_prefix}_STATIC_LIBRARY_DIRS )


### PR DESCRIPTION
On OS/2, a suffix of an import library is '_dll.a', and a suffix of a static library is '.a'.

Because of this, an import library is treated as a static library in get_target_properties_from_pkg_config().