### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -344,7 +344,7 @@ valuable information.
 
 2006-02-20    Josh Green <jgreen@users.sourceforge.net>
 
-	* Fixed build error that occured when neither LASH or LADCCA are
+	* Fixed build error that occurred when neither LASH or LADCCA are
 	  present.
 	* Updated README-OSX from Ebrahim Mayat.
 
@@ -573,7 +573,7 @@ valuable information.
 	(main): User config and system config file are now loaded correctly
 
 	* src/fluid_cmd.c (fluid_shell_run): the shell doesn't get stuck
-	and loop on an emtpy string when the end of the stream is reached.
+	and loop on an empty string when the end of the stream is reached.
 
 	* src/fluid_io.c (fluid_istream_gets): fluid_istream_gets()
 	returns 0 if the end of the stream was reached and -1 on error.
@@ -804,7 +804,7 @@ valuable information.
 	
 1999-11-30  Antoine Schmitt  <as@gratin.org>
 
-	* src/fluid_defsfont.c: inst_zone lokey is now properly inialized to 0
+	* src/fluid_defsfont.c: inst_zone lokey is now properly initialized to 0
 	(it was not, leading to random lost noteons depending on memory
 	initialization)
 
@@ -1048,13 +1048,13 @@ valuable information.
 	(iiwu_synth_system_reset): This function now also resets the
 	default controller values on the MIDI channels, and clears the
 	reverb and chorus delay lines.
-	(iiwu_synth_count_midi_channels): New function to retreive the
+	(iiwu_synth_count_midi_channels): New function to retrieve the
 	number of available midi channels.
-	(iiwu_synth_count_audio_channels): New function to retreive the
+	(iiwu_synth_count_audio_channels): New function to retrieve the
 	number of available midi channels.
-	(iiwu_synth_count_effects_channels): New function to retreive the
+	(iiwu_synth_count_effects_channels): New function to retrieve the
 	number of available effects channels.
-	(iiwu_synth_get_cpu_load): New function to retreive an estimation
+	(iiwu_synth_get_cpu_load): New function to retrieve an estimation
 	of the CPU load.
 
 	* src/iiwusynth.h: Added fields to handle multi-channel audio and
@@ -1346,7 +1346,7 @@ valuable information.
 	references.
 
 	* src/iiwu_cmd.c (iiwu_handle_reverb): renamed 'rev_enable' to
-	'reverb' in correspondance with the long command line arguments
+	'reverb' in correspondence with the long command line arguments
 
 	* src/iiwusynth.c (main): checking if files on command line are valid
 
@@ -1623,9 +1623,9 @@ valuable information.
 
 	* src/iiwu_synth.c (iiwu_sp_write_lr): now using a 64-bits
 	fixed-point number to calculate the phase of the
-	wavetable. because of rounding erros, the float value I used
+	wavetable. because of rounding errors, the float value I used
 	before gave terrible tuning problems. I updated all the
-	intepolation macros.
+	interpolation macros.
 
 	* src/iiwusynth_priv.h: included the iiwu_phase_t data type. This
 	type represents a 64-bits fixed-point number. It's used to hold
@@ -1644,9 +1644,9 @@ valuable information.
 2001-06-07  Peter Hanappe  <peter@hanappe.com>
 
 	* src/iiwu_synth.c (iiwu_sp_write_lr): rewrote the dsp function to
-	accept a seperate left and right channel buffer.
+	accept a separate left and right channel buffer.
 	(iiwu_sp_write_lr): using cubic hermite interpolation by default.
-	(iiwu_synth_write_lr): added a dsp function to accept a seperate
+	(iiwu_synth_write_lr): added a dsp function to accept a separate
 	left and right channel buffer.
 
 2001-05-26  Peter Hanappe  <peter@hanappe.com>
@@ -1668,20 +1668,20 @@ valuable information.
 
 	* src/iiwusynth.c: added the stupidly simple interpreter
 
-	* src/iiwu_synth.c: removed all param strcutures. 
+	* src/iiwu_synth.c: removed all param structures. 
 
 	* src/iiwu_synth.c (iiwu_channel_get_banknum): new function
 
 2001-05-23  Peter Hanappe  <peter@hanappe.com>
 
-	* src/iiwu_synth.c (iiwu_sp_write): Fixed devide by zero in filter
+	* src/iiwu_synth.c (iiwu_sp_write): Fixed divide by zero in filter
 
 	* src/smurf.c (gerr): applied Josh's patch: using va_list now (as
 	it should).
 
 2001-05-22  Peter Hanappe  <peter@hanappe.com>
 
-	* src/iiwu_midi.c: the midi handler is now devided in a dummy
+	* src/iiwu_midi.c: the midi handler is now divided in a dummy
 	iiwu_midi_handler_t and a "low level" driver. This allows for
 	multiple midi drivers to be compiled in.
 

--- a/src/drivers/fluid_dart.c
+++ b/src/drivers/fluid_dart.c
@@ -51,7 +51,7 @@ typedef struct
     USHORT usDeviceID;                          /* Amp Mixer device id     */
     MCI_MIX_BUFFER MixBuffers[NUM_MIX_BUFS];    /* Device buffers          */
     MCI_MIXSETUP_PARMS MixSetupParms;           /* Mixer parameters        */
-    MCI_BUFFER_PARMS BufferParms;               /* Device buffer parms     */
+    MCI_BUFFER_PARMS BufferParms;               /* Device buffer params    */
 } fluid_dart_audio_driver_t;
 
 static HMODULE m_hmodMDM = NULLHANDLE;

--- a/src/drivers/fluid_jack.c
+++ b/src/drivers/fluid_jack.c
@@ -160,7 +160,7 @@ new_fluid_jack_client(fluid_settings_t *settings, int isaudio, void *driver)
     fluid_mutex_lock(last_client_mutex);      /* ++ lock last_client */
 
     /* If the last client uses the same server and is not the same type (audio or MIDI),
-     * then re-use the client. */
+     * then reuse the client. */
     if(last_client &&
             (last_client->server != NULL && server != NULL && FLUID_STRCMP(last_client->server, server) == 0) &&
             ((!isaudio && last_client->midi_driver == NULL) || (isaudio && last_client->audio_driver == NULL)))

--- a/src/midi/fluid_midi_router.c
+++ b/src/midi/fluid_midi_router.c
@@ -369,7 +369,7 @@ fluid_midi_router_add_rule(fluid_midi_router_t *router, fluid_midi_router_rule_t
  *
  * @return Newly allocated router rule or NULL if out of memory.
  *
- * The new rule is a "unity" rule which will accept any values and wont modify
+ * The new rule is a "unity" rule which will accept any values and won't modify
  * them.
  *
  * @since 1.1.0

--- a/src/midi/fluid_seq_queue.cpp
+++ b/src/midi/fluid_seq_queue.cpp
@@ -74,7 +74,7 @@ static bool event_compare(const fluid_event_t& left, const fluid_event_t& right)
         //  * possible values of ltype in rows,
         //  * the boolean values to indicate whether leftIsBeforeRight,
         //  * X meaning any other event type, and
-        //  * the '*' means that it could be zero, but making it 1 simplyfies the boolean expression.
+        //  * the '*' means that it could be zero, but making it 1 simplifies the boolean expression.
         //
         // | ltype \ rtype | SYSR | UNREG | BANK | PROG | NOTEON | X  |
         // |      SYSR     |  1   |   1   |   1  |   1  |   1    | 1  |

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -66,7 +66,7 @@ struct _fluid_zone_range_t
 };
 
 /* Stored on a preset zone to keep track of the inst zones that could start a voice
- * and their combined preset zone/instument zone ranges */
+ * and their combined preset zone/instrument zone ranges */
 struct _fluid_voice_zone_t
 {
     fluid_inst_zone_t *inst_zone;


### PR DESCRIPTION
Fix typos discovered by codespell -- https://github.com/codespell-project/codespell
```
codespell --ignore-words-list=bloc,blocs,caf,capela,datas,egal,readd,rin,seh --skip="*.pdf" \
          --quiet-level=3 --write-changes
```