### PR TITLE
Fix a regression introduced by #1314

### DIFF
--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -354,6 +354,12 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
     /******************* amplitude **********************/
 
     count = fluid_rvoice_calc_amp(voice);
+    if(count == 0)
+    {
+        // Voice has finished, remove from dsp loop
+        return 0;
+    }
+    // else if count is negative, still process the voice
 
 
     /******************* phase **********************/
@@ -427,7 +433,7 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
      * Depending on the position in the loop and the loop size, this
      * may require several runs. */
 
-    if(count <= 0)
+    if(count < 0)
     {
         // The voice is quite, i.e. either in delay phase or zero volume.
         // We need to update the rvoice's dsp phase, as the delay phase shall not "postpone" the sound, rather


### PR DESCRIPTION
This fixes a regression introduced in #1314, most notable in test case 1 of [Christian's new test suite](https://github.com/mrbumpy409/SoundFont-Spec-Test), but also present in others.

Broken behavior introduced by #1314: The short saw wave voice finished processing, but this was not properly attributed and therefore remained in the dsp loop, causing audible sound until the noteoff was received.

![Screenshot_20240917_121558](https://github.com/user-attachments/assets/145e42d3-fd52-44c4-82a4-92de96f6e0da)


Correct behavior before #1314 and with this fix: The saw wave voice is now removed from the dsp loop once it has finished. Voices which are in delay phase (#1312) are still processed to have their dsp phase updated correctly.

![Screenshot_20240917_121606](https://github.com/user-attachments/assets/3e6cf044-d88b-4d7a-a113-fd2943dab40b)

