### PR TITLE
Set synth.device-id to 16 by default

### DIFF
--- a/doc/recent_changes.txt
+++ b/doc/recent_changes.txt
@@ -1,6 +1,11 @@
 /*!
 
 \page RecentChanges Recent Changes
+\section NewIn2_4_0 What's new in 2.4.0?
+- synth.device-id now has a default value of 16
+- synth.gain now has a default value of 0.6
+- Default values of reverb and chorus settings have been tuned
+
 \section NewIn2_3_2 What's new in 2.3.2?
 
 - fluid_player_get_division() has been added

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -229,7 +229,7 @@ void fluid_synth_settings(fluid_settings_t *settings)
     fluid_settings_register_int(settings, "synth.effects-channels", 2, 2, 2, 0);
     fluid_settings_register_int(settings, "synth.effects-groups", 1, 1, 128, 0);
     fluid_settings_register_num(settings, "synth.sample-rate", 44100.0, 8000.0, 96000.0, 0);
-    fluid_settings_register_int(settings, "synth.device-id", 0, 0, 127, 0);
+    fluid_settings_register_int(settings, "synth.device-id", 16, 0, 127, 0);
 #ifdef ENABLE_MIXER_THREADS
     fluid_settings_register_int(settings, "synth.cpu-cores", 1, 1, 256, 0);
 #else


### PR DESCRIPTION
This allows fluidsynth to process most SysEX events by default.

Resolves #1382.