### PR TITLE
Fix Default Pan Modulator Amount

### DIFF
--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -422,6 +422,12 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
         voice->dsp.phase_incr = 1;
     }
 
+    /* loop mode release? if not in release, the voice is silent */
+    if( voice->dsp.samplemode == FLUID_START_ON_RELEASE && fluid_adsr_env_get_section(&voice->envlfo.volenv) < FLUID_VOICE_ENVRELEASE)
+    {
+        return -1;
+    }
+
     /* voice is currently looping? */
     is_looping = voice->dsp.samplemode == FLUID_LOOP_DURING_RELEASE
                  || (voice->dsp.samplemode == FLUID_LOOP_UNTIL_RELEASE

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -45,7 +45,7 @@ enum fluid_loop
 {
     FLUID_UNLOOPED = 0,
     FLUID_LOOP_DURING_RELEASE = 1,
-    FLUID_NOTUSED = 2,
+    FLUID_START_ON_RELEASE = 2, /* this is a looping mode introduced by Polyphone, see #1398 for more info */
     FLUID_LOOP_UNTIL_RELEASE = 3
 };
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -402,10 +402,7 @@ fluid_synth_init(void)
                          );
     fluid_mod_set_source2(&default_pan_mod, 0, 0);                 /* No second source */
     fluid_mod_set_dest(&default_pan_mod, GEN_PAN);                 /* Target: pan */
-    /* Amount: 500. The SF specs $8.4.6, p. 55 says: "Amount = 1000
-       tenths of a percent". The center value (64) corresponds to 50%,
-       so it follows that amount = 50% x 1000/% = 500. */
-    fluid_mod_set_amount(&default_pan_mod, 500.0);
+    fluid_mod_set_amount(&default_pan_mod, 1000.0);                /* Amount: 1000 tenths of a percent */
 
 
     /* SF2.01 page 55 section 8.4.7: MIDI continuous controller 11 to initial attenuation*/


### PR DESCRIPTION
This PR fixes the incorrect amount in the default modulator for pan in fluidsynth.

Resolves #1395 