### PR TITLE
Enable ALSA support by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option ( enable-trap-on-fpe "enable SIGFPE trap on Floating Point Exceptions" of
 option ( enable-ubsan "compile and link against UBSan (for debugging fluidsynth internals)" off )
 
 # Options enabled by default
+option ( enable-alsa "compile ALSA support (if it is available)" on )
 option ( enable-aufile "compile support for sound file output" on )
 option ( BUILD_SHARED_LIBS "Build a shared object or DLL" on )
 option ( enable-dbus "compile DBUS support (if it is available)" on )
@@ -101,10 +102,6 @@ option ( enable-threads "enable multi-threading support (such as parallel voice 
 option ( enable-openmp "enable OpenMP support (parallelization of soundfont decoding, vectorization of voice mixing, etc.)" on )
 
 # Platform specific options
-if ( CMAKE_SYSTEM MATCHES "Linux|FreeBSD|DragonFly" )
-    option ( enable-alsa "compile ALSA support (if it is available)" on )
-endif ( CMAKE_SYSTEM MATCHES "Linux|FreeBSD|DragonFly" )
-
 if ( CMAKE_SYSTEM MATCHES "Linux" )
     option ( enable-systemd "compile systemd support (if it is available)" on )
 endif ( CMAKE_SYSTEM MATCHES "Linux" )

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -42,6 +42,14 @@
 
 #define BUFFER_LENGTH 512
 
+#ifndef ESTRPIPE
+#define ESTRPIPE EPIPE
+#endif
+
+#ifndef EBADFD
+#define EBADFD EBADF
+#endif
+
 /** fluid_alsa_audio_driver_t
  *
  * This structure should not be accessed directly. Use audio port


### PR DESCRIPTION
pkgsrc, a portable packaging system, supports ALSA on quite a number of platforms (including e.g. NetBSD, Solaris, Illumos). I think it's easier to just allow the option by default than to try collecting the allowed platforms.

Add two compatibility defines for error codes that do not exist on all those platforms.