### PR TITLE
Fix SonarQube task

### DIFF
--- a/cmake_admin/CodeCoverage.cmake
+++ b/cmake_admin/CodeCoverage.cmake
@@ -467,7 +467,7 @@ function(setup_target_for_coverage_gcovr_html)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND "#;"
+        COMMAND "echo"
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
 

--- a/cmake_admin/CodeCoverage.cmake
+++ b/cmake_admin/CodeCoverage.cmake
@@ -467,7 +467,7 @@ function(setup_target_for_coverage_gcovr_html)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND "echo Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+        COMMAND "#;"
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
 

--- a/cmake_admin/CodeCoverage.cmake
+++ b/cmake_admin/CodeCoverage.cmake
@@ -467,7 +467,7 @@ function(setup_target_for_coverage_gcovr_html)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND "echo Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
 


### PR DESCRIPTION
Fix cmake error:

```
CMake Error (dev) at cmake_admin/CodeCoverage.cmake:469 (add_custom_command):
  At least one COMMAND must be given.
```