### PR TITLE
Fix filter processing order in DSP chain

### DIFF
--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -436,11 +436,14 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
                      && fluid_adsr_env_get_section(&voice->envlfo.volenv) < FLUID_VOICE_ENVRELEASE);
 
     /*************** resonant filter ******************/
+    // Only "prepare" the filter here, the filter itself will be applied in the dsp_interpolation routines below.
+    // This is to satisfy SF2 Section 9.1.8, particularly, the filtered output must be gain-adjusted by the volEnv.
+    // Applying the filter after applying the gain from the volEnv might cause audible clicks for when turning off
+    // voices that are filtered by a high Q, see https://github.com/FluidSynth/fluidsynth/issues/1427
 
     fluid_iir_filter_calc(&voice->resonant_filter, voice->dsp.output_rate,
                           fluid_lfo_get_val(&voice->envlfo.modlfo) * voice->envlfo.modlfo_to_fc +
                           modenv_val * voice->envlfo.modenv_to_fc);
-
 
     /* additional custom filter - only uses the fixed modulator, no lfos... */
     fluid_iir_filter_calc(&voice->resonant_custom_filter, voice->dsp.output_rate, 0);
@@ -459,8 +462,6 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
         //
         // Currently, this does access the sample buffers, which is redundant and could be optimized away.
         // On the other hand, entering this if-clause is not supposed to happen often.
-        //
-        // Also note, that we're returning directly without running the IIR filter below.
         return fluid_rvoice_dsp_interpolate_none(voice, dsp_buf, is_looping);
     }
 

--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -91,7 +91,6 @@ fluid_rvoice_calc_amp(fluid_rvoice_t *voice)
          * can safely turn off the voice. Duh. */
         if(amp_max < amplitude_that_reaches_noise_floor)
         {
-            FLUID_LOG(FLUID_DBG, "amp_max %f < amplitude_that_reaches_noise_floor %f | env_get_val: %f", amp_max, amplitude_that_reaches_noise_floor, fluid_adsr_env_get_val(&voice->envlfo.volenv));
             return 0;
         }
     }
@@ -104,7 +103,6 @@ fluid_rvoice_calc_amp(fluid_rvoice_t *voice)
     /* no volume and not changing? - No need to process */
     if((voice->dsp.amp == 0.0f) && (voice->dsp.amp_incr == 0.0f))
     {
-        FLUID_LOG(FLUID_DBG, "no volume and not changing? - No need to process");
         return -1;
     }
 
@@ -338,18 +336,6 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
 
     if(fluid_adsr_env_get_section(&voice->envlfo.volenv) == FLUID_VOICE_ENVFINISHED)
     {
-        FLUID_LOG(FLUID_DBG, "voice finished, voice->dsp.amp=%f", voice->dsp.amp);
-        
-        FLUID_MEMSET(dsp_buf, 0, sizeof(*dsp_buf) * FLUID_BUFSIZE);
-        
-        fluid_iir_filter_apply(&voice->resonant_filter, dsp_buf, FLUID_BUFSIZE, voice->dsp.output_rate);
-        
-        // voice->envlfo.volenv.section++;
-        return FLUID_BUFSIZE;
-    }
-    
-    if(fluid_adsr_env_get_section(&voice->envlfo.volenv) == FLUID_VOICE_ENVLAST)
-    {
         return 0;
     }
 
@@ -370,7 +356,6 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
     count = fluid_rvoice_calc_amp(voice);
     if(count == 0)
     {
-        FLUID_LOG(FLUID_DBG, "fluid_rvoice_calc_amp returned zero");
         // Voice has finished, remove from dsp loop
         return 0;
     }
@@ -493,7 +478,6 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
 
     if(count == 0)
     {
-        FLUID_LOG(FLUID_DBG,"sample count zero, voice finished");
         // voice has finished
         return count;
     }
@@ -503,7 +487,7 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
     fluid_iir_filter_calc(&voice->resonant_filter, voice->dsp.output_rate,
                           fluid_lfo_get_val(&voice->envlfo.modlfo) * voice->envlfo.modlfo_to_fc +
                           modenv_val * voice->envlfo.modenv_to_fc);
-    
+
     fluid_iir_filter_apply(&voice->resonant_filter, dsp_buf, count, voice->dsp.output_rate);
 
     /* additional custom filter - only uses the fixed modulator, no lfos... */

--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -440,6 +440,9 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
     // This is to satisfy SF2 Section 9.1.8, particularly, the filtered output must be gain-adjusted by the volEnv.
     // Applying the filter after applying the gain from the volEnv might cause audible clicks for when turning off
     // voices that are filtered by a high Q, see https://github.com/FluidSynth/fluidsynth/issues/1427
+    //
+    // Note that at this point we are using voice->dsp.output_rate which is set to the synth's output rate, because
+    // the filter will receive the interpolated waveform.
 
     fluid_iir_filter_calc(&voice->resonant_filter, voice->dsp.output_rate,
                           fluid_lfo_get_val(&voice->envlfo.modlfo) * voice->envlfo.modlfo_to_fc +

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -200,10 +200,10 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_sample);
 
 /* defined in fluid_rvoice_dsp.c */
 void fluid_rvoice_dsp_config(void);
-int fluid_rvoice_dsp_interpolate_none(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
-int fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
-int fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
-int fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
+int fluid_rvoice_dsp_interpolate_none(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
+int fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
+int fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
+int fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
 
 
 /*

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -35,8 +35,6 @@ typedef struct _fluid_rvoice_buffers_t fluid_rvoice_buffers_t;
 typedef struct _fluid_rvoice_t fluid_rvoice_t;
 
 /* Smallest amplitude that can be perceived (full scale is +/- 0.5)
- * gain = 10^(dB/20)
- * attenuation = 1 / gain
  * 16 bits => 96+4=100 dB dynamic range => 0.00001
  * 24 bits => 144-4 = 140 dB dynamic range => 1.e-7
  * 1.e-7 * 2 == 2.e-7 :)

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -35,6 +35,8 @@ typedef struct _fluid_rvoice_buffers_t fluid_rvoice_buffers_t;
 typedef struct _fluid_rvoice_t fluid_rvoice_t;
 
 /* Smallest amplitude that can be perceived (full scale is +/- 0.5)
+ * gain = 10^(dB/20)
+ * attenuation = 1 / gain
  * 16 bits => 96+4=100 dB dynamic range => 0.00001
  * 24 bits => 144-4 = 140 dB dynamic range => 1.e-7
  * 1.e-7 * 2 == 2.e-7 :)

--- a/src/rvoice/fluid_rvoice_dsp.c
+++ b/src/rvoice/fluid_rvoice_dsp.c
@@ -58,8 +58,9 @@ fluid_rvoice_get_float_sample(const short int *dsp_msb, const char *dsp_lsb, uns
   * the playback pointer.  Questionable quality, but very
   * efficient. */
 int
-fluid_rvoice_dsp_interpolate_none(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
+fluid_rvoice_dsp_interpolate_none(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
 {
+    fluid_rvoice_dsp_t *voice = &rvoice->dsp;
     fluid_phase_t dsp_phase = voice->phase;
     fluid_phase_t dsp_phase_incr;
     short int *dsp_data = voice->sample->data;
@@ -82,7 +83,12 @@ fluid_rvoice_dsp_interpolate_none(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID
         /* interpolate sequence of sample points */
         for(; dsp_i < FLUID_BUFSIZE && dsp_phase_index <= end_index; dsp_i++)
         {
-            dsp_buf[dsp_i] = dsp_amp * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index);
+            fluid_real_t sample = fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index);
+            
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+            
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -121,8 +127,9 @@ fluid_rvoice_dsp_interpolate_none(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID
  * smaller if end of sample occurs).
  */
 int
-fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
+fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
 {
+    fluid_rvoice_dsp_t *voice = &rvoice->dsp;
     fluid_phase_t dsp_phase = voice->phase;
     fluid_phase_t dsp_phase_incr;
     short int *dsp_data = voice->sample->data;
@@ -158,9 +165,16 @@ fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_dsp_t *voice, fluid_real_t *FLU
         /* interpolate the sequence of sample points */
         for(; dsp_i < FLUID_BUFSIZE && dsp_phase_index <= end_index; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = interp_coeff_linear[fluid_phase_fract_to_tablerow(dsp_phase)];
-            dsp_buf[dsp_i] = dsp_amp * (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                        + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1));
+            
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1));
+            
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+            
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -179,9 +193,16 @@ fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_dsp_t *voice, fluid_real_t *FLU
         /* interpolate within last point */
         for(; dsp_phase_index <= end_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = interp_coeff_linear[fluid_phase_fract_to_tablerow(dsp_phase)];
-            dsp_buf[dsp_i] = dsp_amp * (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                        + coeffs[1] * point);
+            
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[1] * point);
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -221,8 +242,9 @@ fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_dsp_t *voice, fluid_real_t *FLU
  * smaller if end of sample occurs).
  */
 int
-fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
+fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
 {
+    fluid_rvoice_dsp_t *voice = &rvoice->dsp;
     fluid_phase_t dsp_phase = voice->phase;
     fluid_phase_t dsp_phase_incr;
     short int *dsp_data = voice->sample->data;
@@ -271,12 +293,18 @@ fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate first sample point (start or loop start) if needed */
         for(; dsp_phase_index == start_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = interp_coeff[fluid_phase_fract_to_tablerow(dsp_phase)];
-            dsp_buf[dsp_i] = dsp_amp *
-                             (coeffs[0] * start_point
-                              + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                              + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                              + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2));
+
+            sample =  (coeffs[0] * start_point
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2));
+            
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+            
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -287,12 +315,18 @@ fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate the sequence of sample points */
         for(; dsp_i < FLUID_BUFSIZE && dsp_phase_index <= end_index; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = interp_coeff[fluid_phase_fract_to_tablerow(dsp_phase)];
-            dsp_buf[dsp_i] = dsp_amp *
-                             (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                              + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                              + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                              + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2));
+
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2));
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -311,12 +345,18 @@ fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate within 2nd to last point */
         for(; dsp_phase_index <= end_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = interp_coeff[fluid_phase_fract_to_tablerow(dsp_phase)];
-            dsp_buf[dsp_i] = dsp_amp *
-                             (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                              + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                              + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                              + coeffs[3] * end_point1);
+
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[3] * end_point1);
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -329,12 +369,19 @@ fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate within the last point */
         for(; dsp_phase_index <= end_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = interp_coeff[fluid_phase_fract_to_tablerow(dsp_phase)];
-            dsp_buf[dsp_i] = dsp_amp *
-                             (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                              + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                              + coeffs[2] * end_point1
-                              + coeffs[3] * end_point2);
+
+            
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[2] * end_point1
+                     + coeffs[3] * end_point2);
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -380,8 +427,9 @@ fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
  * smaller if end of sample occurs).
  */
 int
-fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
+fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
 {
+    fluid_rvoice_dsp_t *voice = &rvoice->dsp;
     fluid_phase_t dsp_phase = voice->phase;
     fluid_phase_t dsp_phase_incr;
     short int *dsp_data = voice->sample->data;
@@ -440,16 +488,21 @@ fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate first sample point (start or loop start) if needed */
         for(; dsp_phase_index == start_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = sinc_table7[fluid_phase_fract_to_tablerow(dsp_phase)];
 
-            dsp_buf[dsp_i] = dsp_amp
-                             * (coeffs[0] * start_points[2]
-                                + coeffs[1] * start_points[1]
-                                + coeffs[2] * start_points[0]
-                                + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                                + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
-                                + coeffs[6] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 3));
+            sample =  (coeffs[0] * start_points[2]
+                     + coeffs[1] * start_points[1]
+                     + coeffs[2] * start_points[0]
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
+                     + coeffs[6] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 3));
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -462,16 +515,21 @@ fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate 2nd to first sample point (start or loop start) if needed */
         for(; dsp_phase_index == start_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = sinc_table7[fluid_phase_fract_to_tablerow(dsp_phase)];
 
-            dsp_buf[dsp_i] = dsp_amp
-                             * (coeffs[0] * start_points[1]
-                                + coeffs[1] * start_points[0]
-                                + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                                + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                                + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
-                                + coeffs[6] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 3));
+            sample =  (coeffs[0] * start_points[1]
+                     + coeffs[1] * start_points[0]
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
+                     + coeffs[6] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 3));
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -484,16 +542,21 @@ fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate 3rd to first sample point (start or loop start) if needed */
         for(; dsp_phase_index == start_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = sinc_table7[fluid_phase_fract_to_tablerow(dsp_phase)];
 
-            dsp_buf[dsp_i] = dsp_amp
-                             * (coeffs[0] * start_points[0]
-                                + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
-                                + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                                + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                                + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
-                                + coeffs[6] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 3));
+            sample =  (coeffs[0] * start_points[0]
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
+                     + coeffs[6] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 3));
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -507,16 +570,21 @@ fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate the sequence of sample points */
         for(; dsp_i < FLUID_BUFSIZE && dsp_phase_index <= end_index; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = sinc_table7[fluid_phase_fract_to_tablerow(dsp_phase)];
 
-            dsp_buf[dsp_i] = dsp_amp
-                             * (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 3)
-                                + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
-                                + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                                + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                                + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
-                                + coeffs[6] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 3));
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 3)
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
+                     + coeffs[6] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 3));
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -535,16 +603,21 @@ fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate within 3rd to last point */
         for(; dsp_phase_index <= end_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = sinc_table7[fluid_phase_fract_to_tablerow(dsp_phase)];
 
-            dsp_buf[dsp_i] = dsp_amp
-                             * (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 3)
-                                + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
-                                + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                                + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                                + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
-                                + coeffs[6] * end_points[0]);
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 3)
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[5] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 2)
+                     + coeffs[6] * end_points[0]);
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -557,16 +630,21 @@ fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate within 2nd to last point */
         for(; dsp_phase_index <= end_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = sinc_table7[fluid_phase_fract_to_tablerow(dsp_phase)];
 
-            dsp_buf[dsp_i] = dsp_amp
-                             * (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 3)
-                                + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
-                                + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                                + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
-                                + coeffs[5] * end_points[0]
-                                + coeffs[6] * end_points[1]);
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 3)
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[4] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index + 1)
+                     + coeffs[5] * end_points[0]
+                     + coeffs[6] * end_points[1]);
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
@@ -579,16 +657,21 @@ fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_dsp_t *voice, fluid_real_t *
         /* interpolate within last point */
         for(; dsp_phase_index <= end_index && dsp_i < FLUID_BUFSIZE; dsp_i++)
         {
+            fluid_real_t sample;
             coeffs = sinc_table7[fluid_phase_fract_to_tablerow(dsp_phase)];
 
-            dsp_buf[dsp_i] = dsp_amp
-                             * (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 3)
-                                + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
-                                + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
-                                + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
-                                + coeffs[4] * end_points[0]
-                                + coeffs[5] * end_points[1]
-                                + coeffs[6] * end_points[2]);
+            sample =  (coeffs[0] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 3)
+                     + coeffs[1] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 2)
+                     + coeffs[2] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index - 1)
+                     + coeffs[3] * fluid_rvoice_get_float_sample(dsp_data, dsp_data24, dsp_phase_index)
+                     + coeffs[4] * end_points[0]
+                     + coeffs[5] * end_points[1]
+                     + coeffs[6] * end_points[2]);
+
+            fluid_iir_filter_apply(&rvoice->resonant_filter, &sample, 1, voice->output_rate);
+            fluid_iir_filter_apply(&rvoice->resonant_custom_filter, &sample, 1, voice->output_rate);
+
+            dsp_buf[dsp_i] = dsp_amp * sample;
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,7 +93,7 @@ else()
     )
 
     add_custom_target(render1427
-        COMMAND fluidsynth -R 0 -C 0 -g 5 -v -F ${IIR_FILTER_RENDER_DIR}/1427_high-Q-note-cutoff.${FEXT} high_Q_note_cutoff_test.mid high_Q_note_cutoff_test.sf2
+        COMMAND fluidsynth -R 0 -C 0 -g 5 -F ${IIR_FILTER_RENDER_DIR}/1427_high-Q-note-cutoff.${FEXT} high_Q_note_cutoff_test.mid high_Q_note_cutoff_test.sf2
         COMMENT "Rendering testfile of issue 1427"
         DEPENDS fluidsynth create_iir_dir
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/manual/iir_filter/1427_high-Q-note-cutoff/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,7 +93,7 @@ else()
     )
 
     add_custom_target(render1427
-        COMMAND fluidsynth -R 0 -C 0 -g 5 -F ${IIR_FILTER_RENDER_DIR}/1427_high-Q-note-cutoff.${FEXT} high_Q_note_cutoff_test.mid high_Q_note_cutoff_test.sf2
+        COMMAND fluidsynth -R 0 -C 0 -g 5 -v -F ${IIR_FILTER_RENDER_DIR}/1427_high-Q-note-cutoff.${FEXT} high_Q_note_cutoff_test.mid high_Q_note_cutoff_test.sf2
         COMMENT "Rendering testfile of issue 1427"
         DEPENDS fluidsynth create_iir_dir
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/manual/iir_filter/1427_high-Q-note-cutoff/


### PR DESCRIPTION
Previously, the IIR filter was applied after the gain of the volume envelope was applied to the signal. This could have caused audible clicks when a voice is turned off while its filter was using a high Q value, see #1427.

This PR fixes that by applying the filter on the interpolated signal but before the volEnv gain is applied. This also matches the processing order of the DSP chain closer to the diagram of section 9.1.8 in the sf2 specification.

`fluid_iir_filter_apply()` which is actually meant to process an array of samples is now used to process only a single sample. One might consider to define this function in header file to allow the compiler to inline it...

Fixes #1427