### PR TITLE
Update documentation about reverb width

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -348,7 +348,7 @@ Developers:
             <max>100.0</max>
             <realtime/>
             <desc>
-                Sets the stereo spread of the reverb signal. A value of 0 indicates no stereo-separation causing the reverb to sound like a monophonic signal. A value of 1 indicates maximum separation between the the left and right channels (i.e. reverb is still a monophonic effect). This subrange [0;1] is recommended for general usage. Values bigger 1 increase (or exaggerate) the perception of the uncorrelated left and right signals. Otherwise, this setting should be considered as dimensionless quantity, with its maximum value existing due to historical reasons. Please note that under some circumstances, values bigger than 1 may induce a feedback into the signal which can be perceived as unpleasant.</desc>
+                Sets the stereo spread of the reverb signal. A value of 0 indicates no stereo-separation causing the reverb to sound like a monophonic signal. A value of 1 indicates maximum separation between the uncorrelated left and right channels (note that reverb is still a monophonic effect). This subrange [0;1] is recommended for general usage. Values bigger 1 increase (or exaggerate) the perception of the uncorrelated left and right signals. Otherwise, this setting should be considered as dimensionless quantity, with its maximum value existing for historical reasons. Please note that under some circumstances, values bigger than 1 may induce a feedback into the signal which can be perceived as unpleasant.</desc>
         </setting>
         <setting>
             <name>sample-rate</name>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -348,7 +348,7 @@ Developers:
             <max>100.0</max>
             <realtime/>
             <desc>
-                Sets the stereo spread of the reverb signal.</desc>
+                Sets the stereo spread of the reverb signal. A value of 0 indicates no stereo-separation causing the reverb to sound like a monophonic signal. A value of 100 indicates maximum separation between left and right channels. Otherwise, this setting should be considered as dimensionless quantity. Please note that under some circumstances, values bigger than 1 may induce a feedback into the signal which can be perceived as unpleasant.</desc>
         </setting>
         <setting>
             <name>sample-rate</name>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -348,7 +348,7 @@ Developers:
             <max>100.0</max>
             <realtime/>
             <desc>
-                Sets the stereo spread of the reverb signal. A value of 0 indicates no stereo-separation causing the reverb to sound like a monophonic signal. A value of 100 indicates maximum separation between left and right channels. Otherwise, this setting should be considered as dimensionless quantity. Please note that under some circumstances, values bigger than 1 may induce a feedback into the signal which can be perceived as unpleasant.</desc>
+                Sets the stereo spread of the reverb signal. A value of 0 indicates no stereo-separation causing the reverb to sound like a monophonic signal. A value of 1 indicates maximum separation between the the left and right channels (i.e. reverb is still a monophonic effect). This subrange [0;1] is recommended for general usage. Values bigger 1 increase (or exaggerate) the perception of the uncorrelated left and right signals. Otherwise, this setting should be considered as dimensionless quantity, with its maximum value existing due to historical reasons. Please note that under some circumstances, values bigger than 1 may induce a feedback into the signal which can be perceived as unpleasant.</desc>
         </setting>
         <setting>
             <name>sample-rate</name>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -348,7 +348,7 @@ Developers:
             <max>100.0</max>
             <realtime/>
             <desc>
-                Sets the stereo spread of the reverb signal. A value of 0 indicates no stereo-separation causing the reverb to sound like a monophonic signal. A value of 1 indicates maximum separation between the uncorrelated left and right channels (note that reverb is still a monophonic effect). This subrange [0;1] is recommended for general usage. Values bigger 1 increase (or exaggerate) the perception of the uncorrelated left and right signals. Otherwise, this setting should be considered as dimensionless quantity, with its maximum value existing for historical reasons. Please note that under some circumstances, values bigger than 1 may induce a feedback into the signal which can be perceived as unpleasant.</desc>
+                Sets the stereo spread of the reverb signal. A value of 0 indicates no stereo-separation causing the reverb to sound like a monophonic signal. A value of 1 indicates maximum separation between the uncorrelated left and right channels (note that reverb is still a monophonic effect). This subrange [0;1] is recommended for general usage. Values bigger than 1 increase (or exaggerate) the perception of the uncorrelated left and right signals. Otherwise, this setting should be considered as dimensionless quantity, with its maximum value existing for historical reasons. Please note that under some circumstances, values bigger than 1 may induce a feedback into the signal which can be perceived as unpleasant.</desc>
         </setting>
         <setting>
             <name>sample-rate</name>

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -66,7 +66,8 @@
  *  - width (0 to 100): controls the left/right output separation.
  *    When 0, there are no separation and the signal on left and right.
  *    output is the same. This sounds like a monophonic signal.
- *    When 100, the separation between left and right is maximum.
+ *    When 1, the separation between left and right is maximum.
+ *    When 100 the perception of this separation is further "exaggerated".
  *
  *  - level (0 to 1), controls the output level reverberation.
  *

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ else()
     set(AWE32_NRPN_RENDER_DIR "${CMAKE_CURRENT_BINARY_DIR}/manual/awe32_nrpn")
     set(SFSPEC_RENDER_DIR "${CMAKE_CURRENT_BINARY_DIR}/manual/SoundFont-Spec-Test")
     set(PORTAMENTO_RENDER_DIR "${CMAKE_CURRENT_BINARY_DIR}/manual/portamento")
+    set(REVERB_RENDER_DIR "${CMAKE_CURRENT_BINARY_DIR}/manual/reverb")
 
     if(LIBSNDFILE_SUPPORT)
       set(FEXT "wav")
@@ -66,7 +67,7 @@ else()
     add_custom_target(check_manual)
 
     add_custom_target(create_iir_dir
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${IIR_FILTER_RENDER_DIR} ${AWE32_NRPN_RENDER_DIR} ${SFSPEC_RENDER_DIR} ${PORTAMENTO_RENDER_DIR}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${IIR_FILTER_RENDER_DIR} ${AWE32_NRPN_RENDER_DIR} ${SFSPEC_RENDER_DIR} ${PORTAMENTO_RENDER_DIR} ${REVERB_RENDER_DIR}
         VERBATIM)
 
     add_custom_target(render1415
@@ -153,6 +154,35 @@ else()
         VERBATIM
     )
 
+    add_custom_target(render1455
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=0.0 -F ${REVERB_RENDER_DIR}/mrbumpys_rev_width_test_000.0.${FEXT} mrbumpys_rev_width_test.mid ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=0.5 -F ${REVERB_RENDER_DIR}/mrbumpys_rev_width_test_000.5.${FEXT} mrbumpys_rev_width_test.mid ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=1.0 -F ${REVERB_RENDER_DIR}/mrbumpys_rev_width_test_001.0.${FEXT} mrbumpys_rev_width_test.mid ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=5.0 -F ${REVERB_RENDER_DIR}/mrbumpys_rev_width_test_005.0.${FEXT} mrbumpys_rev_width_test.mid ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=10  -F ${REVERB_RENDER_DIR}/mrbumpys_rev_width_test_010.0.${FEXT} mrbumpys_rev_width_test.mid ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=50  -F ${REVERB_RENDER_DIR}/mrbumpys_rev_width_test_050.0.${FEXT} mrbumpys_rev_width_test.mid ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=100 -F ${REVERB_RENDER_DIR}/mrbumpys_rev_width_test_100.0.${FEXT} mrbumpys_rev_width_test.mid ${GENERAL_USER_GS2}
+        COMMENT "Rendering Christian Collins' reverb test issue 1455"
+        DEPENDS fluidsynth create_iir_dir
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/manual/reverb/
+        VERBATIM
+    )
+
+    set(DK64SF2 "../sf2/ANMP-data/soundfonts/N64/DK64.sf2")
+    add_custom_target(renderDK64JJU
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=0.0 -F ${REVERB_RENDER_DIR}/DK64_sparse04_000.0.${FEXT} DK64_sparse04.mid ${DK64SF2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=0.5 -F ${REVERB_RENDER_DIR}/DK64_sparse04_000.5.${FEXT} DK64_sparse04.mid ${DK64SF2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=1.0 -F ${REVERB_RENDER_DIR}/DK64_sparse04_001.0.${FEXT} DK64_sparse04.mid ${DK64SF2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=5.0 -F ${REVERB_RENDER_DIR}/DK64_sparse04_005.0.${FEXT} DK64_sparse04.mid ${DK64SF2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=10  -F ${REVERB_RENDER_DIR}/DK64_sparse04_010.0.${FEXT} DK64_sparse04.mid ${DK64SF2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=50  -F ${REVERB_RENDER_DIR}/DK64_sparse04_050.0.${FEXT} DK64_sparse04.mid ${DK64SF2}
+        COMMAND fluidsynth -R 1 -C 0 -g 0.5 -o synth.reverb.width=100 -F ${REVERB_RENDER_DIR}/DK64_sparse04_100.0.${FEXT} DK64_sparse04.mid ${DK64SF2}
+        COMMENT "Praise Grant Kirkhope!"
+        DEPENDS fluidsynth create_iir_dir
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/manual/reverb/
+        VERBATIM
+    )
+
     # Add a dependency so that rendering targets depends on check_manual
     add_dependencies(check_manual render1415)
     add_dependencies(check_manual render1417)
@@ -164,5 +194,7 @@ else()
     add_dependencies(check_manual render1TOWOW)
     add_dependencies(check_manual renderDescent8)
     add_dependencies(check_manual renderSfSpecTest)
+    add_dependencies(check_manual render1455)
+    add_dependencies(check_manual renderDK64JJU)
 
 endif()


### PR DESCRIPTION
This PR adds two test files for reverb and updates the docs about reverb width as suggested in #1455.

Fixes #1455 