### PR TITLE
Port DSP code to C++ to address performance penalty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,23 +439,23 @@ if ( enable-profiling )
     set ( WITH_PROFILING 1 )
     if ( CMAKE_C_COMPILER_ID STREQUAL "Clang" )
       set ( OPT_FLAGS "-Rpass=loop-vectorize" ) # -Rpass-analysis=loop-vectorize" )
-    elseif ( CMAKE_C_COMPILER_ID STREQUAL "Intel" )
-      set ( OPT_FLAGS "-qopt-report=3" )
-    elseif ( CMAKE_C_COMPILER_ID STREQUAL "GNU" )
-      set ( OPT_FLAGS "" )
-    endif ( )
+      find_program( CLANG_TIDY
+                    NAMES "clang-tidy"
+                    DOC "Path to clang-tidy executable" )
 
-    set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OPT_FLAGS}" )
-
-    find_program( CLANG_TIDY
-                NAMES "clang-tidy"
-                DOC "Path to clang-tidy executable" )
-
-    if ( CLANG_TIDY )
+      if ( CLANG_TIDY )
         message ( STATUS "Found clang-tidy at ${CLANG_TIDY}" )
         execute_process ( COMMAND ${CLANG_TIDY} "--version" )
         set ( CMAKE_C_CLANG_TIDY ${CLANG_TIDY} )
-    endif ( CLANG_TIDY )
+      endif ( CLANG_TIDY )
+    elseif ( CMAKE_C_COMPILER_ID STREQUAL "Intel" )
+      set ( OPT_FLAGS "-qopt-report=3" )
+    elseif ( CMAKE_C_COMPILER_ID STREQUAL "GNU" )
+      set ( OPT_FLAGS "-fopt-info -fopt-info-vec-missed" )
+    endif ( )
+
+    set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OPT_FLAGS}" )
+    set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPT_FLAGS}" )
 
 endif ( enable-profiling )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,7 +139,7 @@ set ( libfluidsynth_SOURCES
     rvoice/fluid_lfo.h
     rvoice/fluid_rvoice.h
     rvoice/fluid_rvoice.c
-    rvoice/fluid_rvoice_dsp.c
+    rvoice/fluid_rvoice_dsp.cpp
     rvoice/fluid_rvoice_event.h
     rvoice/fluid_rvoice_event.c
     rvoice/fluid_rvoice_mixer.h
@@ -311,8 +311,6 @@ elseif ( WIN32 )
   set_target_properties ( libfluidsynth
     PROPERTIES
       PUBLIC_HEADER "${public_HEADERS}"
-      ARCHIVE_OUTPUT_NAME "fluidsynth"
-      PREFIX "lib"
       OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
       VERSION ${LIB_VERSION_INFO}
       SOVERSION ${LIB_VERSION_CURRENT}

--- a/src/gentables/make_tables.c
+++ b/src/gentables/make_tables.c
@@ -61,7 +61,22 @@ static void open_table(FILE**fp, const char* dir, const char* file)
     }
     
     /* Emit warning header */
-    fprintf(*fp, "/* THIS FILE HAS BEEN AUTOMATICALLY GENERATED. DO NOT EDIT. */\n\n");
+    fprintf(*fp,
+	"/* THIS FILE HAS BEEN AUTOMATICALLY GENERATED. DO NOT EDIT. */\n\n"
+    "#ifdef __cplusplus\n"
+	"extern \"C\" {\n"
+	"#endif\n\n"
+	);
+}
+
+static void close_table(FILE**fp)
+{
+    fprintf(*fp,
+	"#ifdef __cplusplus\n"
+	"}\n"
+	"#endif\n"
+	);
+    fclose(*fp);
 }
 
 int main (int argc, char *argv[])
@@ -74,11 +89,11 @@ int main (int argc, char *argv[])
     
     open_table(&fp, argv[1], "fluid_conv_tables.inc.h");
     gen_conv_table(fp);
-    fclose(fp);
+    close_table(&fp);
 
     open_table(&fp, argv[1], "fluid_rvoice_dsp_tables.inc.h");
     gen_rvoice_table_dsp(fp);
-    fclose(fp);
+    close_table(&fp);
 
     return 0;
 }

--- a/src/rvoice/fluid_adsr_env.h
+++ b/src/rvoice/fluid_adsr_env.h
@@ -24,6 +24,9 @@
 #include "fluidsynth_priv.h"
 #include "fluid_sys.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /*
  * envelope data
  */
@@ -39,7 +42,7 @@ struct _fluid_env_data_t
 /* Indices for envelope tables */
 enum fluid_voice_envelope_index
 {
-    FLUID_VOICE_ENVDELAY,
+    FLUID_VOICE_ENVDELAY=0,
     FLUID_VOICE_ENVATTACK,
     FLUID_VOICE_ENVHOLD,
     FLUID_VOICE_ENVDECAY,
@@ -56,9 +59,9 @@ typedef struct _fluid_adsr_env_t fluid_adsr_env_t;
 struct _fluid_adsr_env_t
 {
     fluid_env_data_t data[FLUID_VOICE_ENVLAST];
+    unsigned int section; // type fluid_adsr_env_section_t, but declare it unsigned to make C++ happy
     unsigned int count;
     fluid_real_t val;         /* the current value of the envelope */
-    fluid_adsr_env_section_t section;
 };
 
 /* For performance, all functions are inlined */
@@ -136,14 +139,14 @@ fluid_adsr_env_set_val(fluid_adsr_env_t *env, fluid_real_t val)
 static FLUID_INLINE fluid_adsr_env_section_t
 fluid_adsr_env_get_section(fluid_adsr_env_t *env)
 {
-    return env->section;
+    return (fluid_adsr_env_section_t)env->section;
 }
 
 static FLUID_INLINE void
 fluid_adsr_env_set_section(fluid_adsr_env_t *env,
                            fluid_adsr_env_section_t section)
 {
-    env->section = section;
+    env->section = (unsigned int)section;
     env->count = 0;
 }
 
@@ -163,5 +166,8 @@ fluid_adsr_env_get_max_val(fluid_adsr_env_t *env)
     }
 }
 
+#ifdef __cplusplus
+}
+#endif
 #endif
 

--- a/src/rvoice/fluid_iir_filter.c
+++ b/src/rvoice/fluid_iir_filter.c
@@ -23,121 +23,6 @@
 #include "fluid_conv.h"
 
 
-static FLUID_INLINE void
-fluid_iir_filter_calculate_coefficients(fluid_iir_filter_t *iir_filter, fluid_real_t output_rate,
-                                        fluid_real_t *a1_out, fluid_real_t *a2_out,
-                                        fluid_real_t *b02_out, fluid_real_t *b1_out);
-
-
-/**
- * Applies a low- or high-pass filter with variable cutoff frequency and quality factor
- * for a given biquad transfer function:
- *          b0 + b1*z^-1 + b2*z^-2
- *  H(z) = ------------------------
- *          a0 + a1*z^-1 + a2*z^-2
- *
- * Also modifies filter state accordingly.
- * @param iir_filter Filter parameter
- * @param dsp_buf Pointer to the synthesized audio data
- * @param count Count of samples in dsp_buf
- */
-/*
- * Variable description:
- * - dsp_a1, dsp_a2: Filter coefficients for the the previously filtered output signal
- * - dsp_b0, dsp_b1, dsp_b2: Filter coefficients for input signal
- * - coefficients normalized to a0
- *
- * A couple of variables are used internally, their results are discarded:
- * - dsp_i: Index through the output buffer
- * - dsp_centernode: delay line for the IIR filter
- * - dsp_hist1: same
- * - dsp_hist2: same
- */
-void
-fluid_iir_filter_apply(fluid_iir_filter_t *iir_filter,
-                       fluid_real_t *dsp_buf, int count, fluid_real_t output_rate)
-{
-    if(iir_filter->type == FLUID_IIR_DISABLED || FLUID_FABS(iir_filter->last_q) <= 0.001)
-    {
-        return;
-    }
-    else
-    {
-        /* IIR filter sample history */
-        fluid_real_t dsp_hist1 = iir_filter->hist1;
-        fluid_real_t dsp_hist2 = iir_filter->hist2;
-
-        /* IIR filter coefficients */
-        fluid_real_t dsp_a1 = iir_filter->a1;
-        fluid_real_t dsp_a2 = iir_filter->a2;
-        fluid_real_t dsp_b02 = iir_filter->b02;
-        fluid_real_t dsp_b1 = iir_filter->b1;
-        
-        int fres_incr_count = iir_filter->fres_incr_count;
-        int q_incr_count = iir_filter->q_incr_count;
-
-        fluid_real_t dsp_centernode;
-        int dsp_i;
-
-        /* filter (implement the voice filter according to SoundFont standard) */
-
-        /* Check for denormal number (too close to zero). */
-        if(FLUID_FABS(dsp_hist1) < 1e-20f)
-        {
-            dsp_hist1 = 0.0f;    /* FIXME JMG - Is this even needed? */
-        }
-
-        /* Two versions of the filter loop. One, while the filter is
-        * changing towards its new setting. The other, if the filter
-        * doesn't change.
-        */
-
-        for(dsp_i = 0; dsp_i < count; dsp_i++)
-        {
-            /* The filter is implemented in Direct-II form. */
-            dsp_centernode = dsp_buf[dsp_i] - dsp_a1 * dsp_hist1 - dsp_a2 * dsp_hist2;
-            dsp_buf[dsp_i] = dsp_b02 * (dsp_centernode + dsp_hist2) + dsp_b1 * dsp_hist1;
-            dsp_hist2 = dsp_hist1;
-            dsp_hist1 = dsp_centernode;
-            /* Alternatively, it could be implemented in Transposed Direct Form II */
-            // fluid_real_t dsp_input = dsp_buf[dsp_i];
-            // dsp_buf[dsp_i] = dsp_b02 * dsp_input + dsp_hist1;
-            // dsp_hist1 = dsp_b1 * dsp_input - dsp_a1 * dsp_buf[dsp_i] + dsp_hist2;
-            // dsp_hist2 = dsp_b02 * dsp_input - dsp_a2 * dsp_buf[dsp_i];
-            
-            if(fres_incr_count > 0 || q_incr_count > 0)
-            {
-                if(fres_incr_count > 0)
-                {
-                    --fres_incr_count;
-                    iir_filter->last_fres += iir_filter->fres_incr;
-                }
-                if(q_incr_count > 0)
-                {
-                    --q_incr_count;
-                    iir_filter->last_q += iir_filter->q_incr;
-                }
-                
-                LOG_FILTER("last_fres: %.2f Hz  |  target_fres: %.2f Hz  |---|  last_q: %.4f  |  target_q: %.4f", iir_filter->last_fres, iir_filter->target_fres, iir_filter->last_q, iir_filter->target_q);
-                
-                fluid_iir_filter_calculate_coefficients(iir_filter, output_rate, &dsp_a1, &dsp_a2, &dsp_b02, &dsp_b1);
-            }
-        }
-
-        iir_filter->hist1 = dsp_hist1;
-        iir_filter->hist2 = dsp_hist2;
-        iir_filter->a1 = dsp_a1;
-        iir_filter->a2 = dsp_a2;
-        iir_filter->b02 = dsp_b02;
-        iir_filter->b1 = dsp_b1;
-        
-        iir_filter->fres_incr_count = fres_incr_count;
-        iir_filter->q_incr_count = q_incr_count;
-
-        fluid_check_fpe("voice_filter");
-    }
-}
-
 DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_init)
 {
     fluid_iir_filter_t *iir_filter = obj;
@@ -234,6 +119,11 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_q)
     else
     {
         static const fluid_real_t q_incr_count = FLUID_BUFSIZE;
+        // Q must be at least Q_MIN, otherwise fluid_iir_filter_apply would never be entered
+        if(q >= Q_MIN && iir_filter->last_q < Q_MIN)
+        {
+            iir_filter->last_q = Q_MIN;
+        }
         iir_filter->q_incr = (q - iir_filter->last_q) / (q_incr_count);
         iir_filter->q_incr_count = q_incr_count;
     }
@@ -241,102 +131,6 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_q)
     iir_filter->target_q = q;
 #endif
 }
-
-static FLUID_INLINE void
-fluid_iir_filter_calculate_coefficients(fluid_iir_filter_t *iir_filter,
-                                        fluid_real_t output_rate,
-                                        fluid_real_t *a1_out, fluid_real_t *a2_out,
-                                        fluid_real_t *b02_out, fluid_real_t *b1_out)
-{
-    // FLUID_IIR_Q_LINEAR may switch the filter off by setting Q==0
-    // Due to the linear smoothing, last_q may not exactly become zero.
-    if(FLUID_FABS(iir_filter->last_q) <= 0.001)
-    {
-        return;
-    }
-    else
-    {
-        int flags = iir_filter->flags;
-        fluid_real_t filter_gain = 1.0f;
-
-        /*
-         * Those equations from Robert Bristow-Johnson's `Cookbook
-         * formulae for audio EQ biquad filter coefficients', obtained
-         * from Harmony-central.com / Computer / Programming. They are
-         * the result of the bilinear transform on an analogue filter
-         * prototype. To quote, `BLT frequency warping has been taken
-         * into account for both significant frequency relocation and for
-         * bandwidth readjustment'. */
-
-        fluid_real_t omega = (fluid_real_t)(2.0 * M_PI) *
-                                            (iir_filter->last_fres / output_rate);
-        fluid_real_t sin_coeff = FLUID_SIN(omega);
-        fluid_real_t cos_coeff = FLUID_COS(omega);
-        fluid_real_t alpha_coeff = sin_coeff / (2.0f * iir_filter->last_q);
-        fluid_real_t a0_inv = 1.0f / (1.0f + alpha_coeff);
-
-        /* Calculate the filter coefficients. All coefficients are
-         * normalized by a0. Think of `a1' as `a1/a0'.
-         *
-         * Here a couple of multiplications are saved by reusing common expressions.
-         * The original equations should be:
-         *  iir_filter->b0=(1.-cos_coeff)*a0_inv*0.5*filter_gain;
-         *  iir_filter->b1=(1.-cos_coeff)*a0_inv*filter_gain;
-         *  iir_filter->b2=(1.-cos_coeff)*a0_inv*0.5*filter_gain; */
-
-        /* "a" coeffs are same for all 3 available filter types */
-        fluid_real_t a1_temp = -2.0f * cos_coeff * a0_inv;
-        fluid_real_t a2_temp = (1.0f - alpha_coeff) * a0_inv;
-        fluid_real_t b02_temp, b1_temp;
-
-        if(!(flags & FLUID_IIR_NO_GAIN_AMP))
-        {
-            /* SF 2.01 page 59:
-            *
-            *  The SoundFont specs ask for a gain reduction equal to half the
-            *  height of the resonance peak (Q).  For example, for a 10 dB
-            *  resonance peak, the gain is reduced by 5 dB.  This is done by
-            *  multiplying the total gain with sqrt(1/Q).  `Sqrt' divides dB
-            *  by 2 (100 lin = 40 dB, 10 lin = 20 dB, 3.16 lin = 10 dB etc)
-            *  The gain is later factored into the 'b' coefficients
-            *  (numerator of the filter equation).  This gain factor depends
-            *  only on Q, so this is the right place to calculate it.
-            */
-            filter_gain /= FLUID_SQRT(iir_filter->last_q);
-        }
-
-        switch(iir_filter->type)
-        {
-        case FLUID_IIR_HIGHPASS:
-            b1_temp = (1.0f + cos_coeff) * a0_inv * filter_gain;
-
-            /* both b0 -and- b2 */
-            b02_temp = b1_temp * 0.5f;
-
-            b1_temp *= -1.0f;
-            break;
-
-        case FLUID_IIR_LOWPASS:
-            b1_temp = (1.0f - cos_coeff) * a0_inv * filter_gain;
-
-            /* both b0 -and- b2 */
-            b02_temp = b1_temp * 0.5f;
-            break;
-
-        default:
-            /* filter disabled, should never get here */
-            return;
-        }
-
-        *a1_out = a1_temp;
-        *a2_out = a2_temp;
-        *b02_out = b02_temp;
-        *b1_out = b1_temp;
-
-        fluid_check_fpe("voice_write filter calculation");
-    }
-}
-
 
 void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
                            fluid_real_t output_rate,
@@ -383,7 +177,7 @@ void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
         
         iir_filter->fres_incr_count = 0;
         iir_filter->last_fres = fres;
-        iir_filter->filter_startup = 0;
+        iir_filter->filter_startup = (FLUID_FABS(iir_filter->last_q) < Q_MIN); // filter coefficients will not be initialized when Q is small
     }
     else if(FLUID_FABS(fres_diff) > 0.01f)
     {
@@ -409,7 +203,7 @@ void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
         // will be taken care of in fluid_iir_filter_apply().
     }
 
-    if(calc_coeff_flag)
+    if (calc_coeff_flag && !iir_filter->filter_startup)
     {
         fluid_iir_filter_calculate_coefficients(iir_filter, output_rate, &iir_filter->a1, &iir_filter->a2, &iir_filter->b02, &iir_filter->b1);
     }

--- a/src/rvoice/fluid_iir_filter.h
+++ b/src/rvoice/fluid_iir_filter.h
@@ -22,6 +22,7 @@
 #define _FLUID_IIR_FILTER_H
 
 #include "fluidsynth_priv.h"
+#include "fluid_sys.h"
 
 // Uncomment to get debug logging for filter parameters
 // #define DBG_FILTER
@@ -31,20 +32,9 @@
 #define LOG_FILTER(...) 
 #endif
 
-typedef struct _fluid_iir_filter_t fluid_iir_filter_t;
-
-DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_init);
-DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_fres);
-DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_q);
-
-void fluid_iir_filter_apply(fluid_iir_filter_t *iir_filter,
-                            fluid_real_t *dsp_buf, int dsp_buf_count, fluid_real_t output_rate);
-
-void fluid_iir_filter_reset(fluid_iir_filter_t *iir_filter);
-
-void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
-                           fluid_real_t output_rate,
-                           fluid_real_t fres_mod);
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* We can't do information hiding here, as fluid_voice_t includes the struct
    without a pointer. */
@@ -78,5 +68,218 @@ struct _fluid_iir_filter_t
 #endif
 };
 
+typedef struct _fluid_iir_filter_t fluid_iir_filter_t;
+
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_init);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_fres);
+DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_q);
+
+#define Q_MIN ((fluid_real_t)0.001)
+
+static FLUID_INLINE void
+fluid_iir_filter_calculate_coefficients(fluid_iir_filter_t *iir_filter, fluid_real_t output_rate,
+                                        fluid_real_t *a1_out, fluid_real_t *a2_out,
+                                        fluid_real_t *b02_out, fluid_real_t *b1_out)
+{
+    int flags = iir_filter->flags;
+    fluid_real_t filter_gain = 1.0f;
+
+    /*
+     * Those equations from Robert Bristow-Johnson's `Cookbook
+     * formulae for audio EQ biquad filter coefficients', obtained
+     * from Harmony-central.com / Computer / Programming. They are
+     * the result of the bilinear transform on an analogue filter
+     * prototype. To quote, `BLT frequency warping has been taken
+     * into account for both significant frequency relocation and for
+     * bandwidth readjustment'. */
+
+    fluid_real_t omega = (fluid_real_t)(2.0 * M_PI) *
+                                       (iir_filter->last_fres / output_rate);
+    fluid_real_t sin_coeff = FLUID_SIN(omega);
+    fluid_real_t cos_coeff = FLUID_COS(omega);
+    fluid_real_t alpha_coeff = sin_coeff / (2.0f * iir_filter->last_q);
+    fluid_real_t a0_inv = 1.0f / (1.0f + alpha_coeff);
+
+    /* Calculate the filter coefficients. All coefficients are
+     * normalized by a0. Think of `a1' as `a1/a0'.
+     *
+     * Here a couple of multiplications are saved by reusing common expressions.
+     * The original equations should be:
+     *  iir_filter->b0=(1.-cos_coeff)*a0_inv*0.5*filter_gain;
+     *  iir_filter->b1=(1.-cos_coeff)*a0_inv*filter_gain;
+     *  iir_filter->b2=(1.-cos_coeff)*a0_inv*0.5*filter_gain; */
+
+    /* "a" coeffs are same for all 3 available filter types */
+    fluid_real_t a1_temp = -2.0f * cos_coeff * a0_inv;
+    fluid_real_t a2_temp = (1.0f - alpha_coeff) * a0_inv;
+    fluid_real_t b02_temp, b1_temp;
+
+    if(!(flags & FLUID_IIR_NO_GAIN_AMP))
+    {
+        /* SF 2.01 page 59:
+         *
+         *  The SoundFont specs ask for a gain reduction equal to half the
+         *  height of the resonance peak (Q).  For example, for a 10 dB
+         *  resonance peak, the gain is reduced by 5 dB.  This is done by
+         *  multiplying the total gain with sqrt(1/Q).  `Sqrt' divides dB
+         *  by 2 (100 lin = 40 dB, 10 lin = 20 dB, 3.16 lin = 10 dB etc)
+         *  The gain is later factored into the 'b' coefficients
+         *  (numerator of the filter equation).  This gain factor depends
+         *  only on Q, so this is the right place to calculate it.
+         */
+        filter_gain /= FLUID_SQRT(iir_filter->last_q);
+    }
+
+    switch(iir_filter->type)
+    {
+    case FLUID_IIR_HIGHPASS:
+        b1_temp = (1.0f + cos_coeff) * a0_inv * filter_gain;
+
+        /* both b0 -and- b2 */
+        b02_temp = b1_temp * 0.5f;
+
+        b1_temp *= -1.0f;
+        break;
+
+    case FLUID_IIR_LOWPASS:
+        b1_temp = (1.0f - cos_coeff) * a0_inv * filter_gain;
+
+        /* both b0 -and- b2 */
+        b02_temp = b1_temp * 0.5f;
+        break;
+
+    default:
+        /* filter disabled, should never get here */
+        return;
+    }
+
+    *a1_out = a1_temp;
+    *a2_out = a2_temp;
+    *b02_out = b02_temp;
+    *b1_out = b1_temp;
+
+    fluid_check_fpe("voice_write filter calculation");
+}
+
+/**
+ * Applies a low- or high-pass filter with variable cutoff frequency and quality factor
+ * for a given biquad transfer function:
+ *          b0 + b1*z^-1 + b2*z^-2
+ *  H(z) = ------------------------
+ *          a0 + a1*z^-1 + a2*z^-2
+ *
+ * Also modifies filter state accordingly.
+ * @param iir_filter Filter parameter
+ * @param dsp_buf Pointer to the synthesized audio data
+ * @param count Count of samples in dsp_buf
+ */
+/*
+ * Variable description:
+ * - dsp_a1, dsp_a2: Filter coefficients for the the previously filtered output signal
+ * - dsp_b0, dsp_b1, dsp_b2: Filter coefficients for input signal
+ * - coefficients normalized to a0
+ *
+ * A couple of variables are used internally, their results are discarded:
+ * - dsp_i: Index through the output buffer
+ * - dsp_centernode: delay line for the IIR filter
+ * - dsp_hist1: same
+ * - dsp_hist2: same
+ */
+static FLUID_INLINE void
+fluid_iir_filter_apply(fluid_iir_filter_t *iir_filter,
+                       fluid_real_t *dsp_buf, int count, fluid_real_t output_rate)
+{
+    // FLUID_IIR_Q_LINEAR may switch the filter off by setting Q==0
+    // Due to the linear smoothing, last_q may not exactly become zero.
+    if (iir_filter->type == FLUID_IIR_DISABLED || FLUID_FABS(iir_filter->last_q) < Q_MIN)
+    {
+        return;
+    }
+    else
+    {
+        /* IIR filter sample history */
+        fluid_real_t dsp_hist1 = iir_filter->hist1;
+        fluid_real_t dsp_hist2 = iir_filter->hist2;
+
+        /* IIR filter coefficients */
+        fluid_real_t dsp_a1 = iir_filter->a1;
+        fluid_real_t dsp_a2 = iir_filter->a2;
+        fluid_real_t dsp_b02 = iir_filter->b02;
+        fluid_real_t dsp_b1 = iir_filter->b1;
+        
+        int fres_incr_count = iir_filter->fres_incr_count;
+        int q_incr_count = iir_filter->q_incr_count;
+
+        fluid_real_t dsp_centernode;
+        int dsp_i;
+
+        /* filter (implement the voice filter according to SoundFont standard) */
+
+        /* Check for denormal number (too close to zero). */
+        if(FLUID_FABS(dsp_hist1) < 1e-20f)
+        {
+            dsp_hist1 = 0.0f;    /* FIXME JMG - Is this even needed? */
+        }
+
+        /* Two versions of the filter loop. One, while the filter is
+        * changing towards its new setting. The other, if the filter
+        * doesn't change.
+        */
+
+        for(dsp_i = 0; dsp_i < count; dsp_i++)
+        {
+            /* The filter is implemented in Direct-II form. */
+            dsp_centernode = dsp_buf[dsp_i] - dsp_a1 * dsp_hist1 - dsp_a2 * dsp_hist2;
+            dsp_buf[dsp_i] = dsp_b02 * (dsp_centernode + dsp_hist2) + dsp_b1 * dsp_hist1;
+            dsp_hist2 = dsp_hist1;
+            dsp_hist1 = dsp_centernode;
+            /* Alternatively, it could be implemented in Transposed Direct Form II */
+            // fluid_real_t dsp_input = dsp_buf[dsp_i];
+            // dsp_buf[dsp_i] = dsp_b02 * dsp_input + dsp_hist1;
+            // dsp_hist1 = dsp_b1 * dsp_input - dsp_a1 * dsp_buf[dsp_i] + dsp_hist2;
+            // dsp_hist2 = dsp_b02 * dsp_input - dsp_a2 * dsp_buf[dsp_i];
+            
+            if(fres_incr_count > 0 || q_incr_count > 0)
+            {
+                if(fres_incr_count > 0)
+                {
+                    --fres_incr_count;
+                    iir_filter->last_fres += iir_filter->fres_incr;
+                }
+                if(q_incr_count > 0)
+                {
+                    --q_incr_count;
+                    iir_filter->last_q += iir_filter->q_incr;
+                }
+                
+                LOG_FILTER("last_fres: %.2f Hz  |  target_fres: %.2f Hz  |---|  last_q: %.4f  |  target_q: %.4f", iir_filter->last_fres, iir_filter->target_fres, iir_filter->last_q, iir_filter->target_q);
+                
+                fluid_iir_filter_calculate_coefficients(iir_filter, output_rate, &dsp_a1, &dsp_a2, &dsp_b02, &dsp_b1);
+            }
+        }
+
+        iir_filter->hist1 = dsp_hist1;
+        iir_filter->hist2 = dsp_hist2;
+        iir_filter->a1 = dsp_a1;
+        iir_filter->a2 = dsp_a2;
+        iir_filter->b02 = dsp_b02;
+        iir_filter->b1 = dsp_b1;
+        
+        iir_filter->fres_incr_count = fres_incr_count;
+        iir_filter->q_incr_count = q_incr_count;
+
+        fluid_check_fpe("voice_filter");
+    }
+}
+
+void fluid_iir_filter_reset(fluid_iir_filter_t *iir_filter);
+
+void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
+                           fluid_real_t output_rate,
+                           fluid_real_t fres_mod);
+
+#ifdef __cplusplus
+}
+#endif
 #endif
 

--- a/src/rvoice/fluid_lfo.h
+++ b/src/rvoice/fluid_lfo.h
@@ -23,6 +23,9 @@
 
 #include "fluid_sys.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 typedef struct _fluid_lfo_t fluid_lfo_t;
 
 struct _fluid_lfo_t
@@ -71,5 +74,8 @@ fluid_lfo_calc(fluid_lfo_t *lfo, unsigned int cur_delay)
 
 }
 
+#ifdef __cplusplus
+}
+#endif
 #endif
 

--- a/src/rvoice/fluid_phase.h
+++ b/src/rvoice/fluid_phase.h
@@ -22,6 +22,9 @@
 #ifndef _FLUID_PHASE_H
 #define _FLUID_PHASE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /*
  *  phase
  */
@@ -110,4 +113,7 @@ typedef uint64_t fluid_phase_t;
  * Creates the expression a.index++. */
 #define fluid_phase_index_plusplus(a)  (((a) += 0x100000000LL)
 
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _FLUID_PHASE_H */

--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -465,7 +465,7 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
         //
         // Currently, this does access the sample buffers, which is redundant and could be optimized away.
         // On the other hand, entering this if-clause is not supposed to happen often.
-        return fluid_rvoice_dsp_interpolate_none(voice, dsp_buf, is_looping);
+        return fluid_rvoice_dsp_silence(voice, dsp_buf, is_looping);
     }
 
     switch(voice->dsp.interp_method)

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -29,6 +29,9 @@
 #include "fluid_phase.h"
 #include "fluid_sfont.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 typedef struct _fluid_rvoice_envlfo_t fluid_rvoice_envlfo_t;
 typedef struct _fluid_rvoice_dsp_t fluid_rvoice_dsp_t;
 typedef struct _fluid_rvoice_buffers_t fluid_rvoice_buffers_t;
@@ -211,21 +214,40 @@ int fluid_rvoice_dsp_interpolate_7th_order(fluid_rvoice_t *voice, fluid_real_t *
  * least sig. 8 bit part in order to create a 24 bit sample.
  */
 static FLUID_INLINE int32_t
-fluid_rvoice_get_sample(const short int *dsp_msb, const char *dsp_lsb, unsigned int idx)
+fluid_rvoice_get_sample24(const short int *FLUID_RESTRICT dsp_msb, const char *FLUID_RESTRICT dsp_lsb, unsigned int idx)
 {
     /* cast sample to unsigned type, so we can safely shift and bitwise or
      * without relying on undefined behaviour (should never happen anyway ofc...) */
     uint32_t msb = (uint32_t)dsp_msb[idx];
-    uint8_t lsb = 0U;
-
-    /* most soundfonts have 16 bit samples, assume that it's unlikely we
-     * experience 24 bit samples here */
-    if(FLUID_UNLIKELY(dsp_lsb != NULL))
-    {
-        lsb = (uint8_t)dsp_lsb[idx];
-    }
+    uint8_t lsb = (uint8_t)dsp_lsb[idx];
 
     return (int32_t)((msb << 8) | lsb);
 }
 
+static FLUID_INLINE int32_t
+fluid_rvoice_get_sample16(const short int *FLUID_RESTRICT dsp_msb, unsigned int idx)
+{
+    /* cast sample to unsigned type, so we can safely shift and bitwise or
+     * without relying on undefined behaviour (should never happen anyway ofc...) */
+    uint32_t msb = (uint32_t)dsp_msb[idx];
+
+    return (int32_t)((msb << 8) | 0);
+}
+
+static FLUID_INLINE int32_t
+fluid_rvoice_get_sample(const short int *FLUID_RESTRICT dsp_msb, const char *FLUID_RESTRICT dsp_lsb, unsigned int idx)
+{
+    if (dsp_lsb != NULL)
+    {
+        return fluid_rvoice_get_sample24(dsp_msb, dsp_lsb, idx);
+    }
+    else
+    {
+        return fluid_rvoice_get_sample16(dsp_msb, idx);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -203,6 +203,7 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_sample);
 
 /* defined in fluid_rvoice_dsp.c */
 void fluid_rvoice_dsp_config(void);
+int fluid_rvoice_dsp_silence(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping);
 int fluid_rvoice_dsp_interpolate_none(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
 int fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
 int fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);

--- a/src/rvoice/fluid_rvoice_dsp.cpp
+++ b/src/rvoice/fluid_rvoice_dsp.cpp
@@ -64,6 +64,64 @@ fluid_rvoice_get_float_sample(const short int *FLUID_RESTRICT dsp_msb, const cha
     return (fluid_real_t)sample;
 }
 
+/* Special case of interpolate_none for rendering silent voices, i.e. in delay phase or zero volume */
+template<bool LOOPING>
+static int fluid_rvoice_dsp_silence_local(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf)
+{
+    fluid_rvoice_dsp_t *voice = &rvoice->dsp;
+    fluid_phase_t dsp_phase = voice->phase;
+    fluid_phase_t dsp_phase_incr;
+    unsigned short dsp_i = 0;
+    unsigned int dsp_phase_index;
+    unsigned int end_index;
+
+    /* Convert playback "speed" floating point value to phase index/fract */
+    fluid_phase_set_float(dsp_phase_incr, voice->phase_incr);
+
+    end_index = LOOPING ? voice->loopend - 1 : voice->end;
+
+    while (1)
+    {
+        dsp_phase_index = fluid_phase_index_round(dsp_phase); /* round to nearest point */
+
+        /* interpolate sequence of sample points */
+        for (; dsp_i < FLUID_BUFSIZE && dsp_phase_index <= end_index; dsp_i++)
+        {
+            fluid_real_t sample = 0;
+            dsp_buf[dsp_i] = sample;
+
+            /* increment phase and amplitude */
+            fluid_phase_incr(dsp_phase, dsp_phase_incr);
+        }
+
+        /* break out if not looping (buffer may not be full) */
+        if (!LOOPING)
+        {
+            break;
+        }
+
+        dsp_phase_index = fluid_phase_index_round(dsp_phase); /* round to nearest point */
+        /* go back to loop start */
+        if (dsp_phase_index > end_index)
+        {
+            fluid_phase_sub_int(dsp_phase, voice->loopend - voice->loopstart);
+            voice->has_looped = 1;
+        }
+
+        /* break out if filled buffer */
+        if (dsp_i >= FLUID_BUFSIZE)
+        {
+            break;
+        }
+    }
+
+    voice->phase = dsp_phase;
+    // Note, there is no need to update the amplitude here. When the voice becomes audible again, the amp will be updated anyway in fluid_rvoice_calc_amp().
+    // voice->amp = dsp_amp;
+
+    return (dsp_i);
+}
+
 /* No interpolation. Just take the sample, which is closest to
   * the playback pointer.  Questionable quality, but very
   * efficient. */
@@ -767,6 +825,15 @@ fluid_rvoice_dsp_interpolate_7th_order_local(fluid_rvoice_t *rvoice, fluid_real_
     return (dsp_i);
 }
 
+struct ProcessSilence
+{
+    template<bool ENABLE_CUSTOM_FILTER, bool IS_24BIT, bool LOOPING>
+    int operator()(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf) const
+    {
+        return fluid_rvoice_dsp_silence_local<LOOPING>(rvoice, dsp_buf);
+    }
+};
+
 struct InterpolateNone
 {
     template<bool ENABLE_CUSTOM_FILTER, bool IS_24BIT, bool LOOPING>
@@ -860,6 +927,12 @@ int dsp_invoker(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf, in
             }
         }
     }
+}
+
+extern "C" int
+fluid_rvoice_dsp_silence(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping)
+{
+    return dsp_invoker<ProcessSilence>(rvoice, dsp_buf, looping);
 }
 
 extern "C" int

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -24,6 +24,9 @@
 
 #include "fluidsynth.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int fluid_sample_validate(fluid_sample_t *sample, unsigned int max_end);
 int fluid_sample_sanitize_loop(fluid_sample_t *sample, unsigned int max_end);
 
@@ -186,4 +189,7 @@ struct _fluid_sample_t
 };
 
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _PRIV_FLUID_SFONT_H */

--- a/src/utils/fluid_conv.h
+++ b/src/utils/fluid_conv.h
@@ -24,6 +24,9 @@
 #include "fluidsynth_priv.h"
 #include "utils/fluid_conv_tables.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 fluid_real_t fluid_ct2hz_real(fluid_real_t cents);
 fluid_real_t fluid_ct2hz(fluid_real_t cents);
 fluid_real_t fluid_cb2amp(fluid_real_t cb);
@@ -39,4 +42,7 @@ fluid_real_t fluid_balance(fluid_real_t balance, int left);
 fluid_real_t fluid_concave(fluid_real_t val);
 fluid_real_t fluid_convex(fluid_real_t val);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _FLUID_CONV_H */

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -177,6 +177,10 @@ typedef gintptr  intptr_t;
 
 #include <glib/gstdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Macro used for safely accessing a message from a GError and using a default
  * message if it is NULL.
@@ -786,4 +790,7 @@ static FLUID_INLINE void *fluid_align_ptr(const void *ptr, unsigned int alignmen
 
 #define FLUID_DEFAULT_ALIGNMENT (64U)
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _FLUID_SYS_H */


### PR DESCRIPTION
I found that after merging  #1444 a small performance penalty was introduced. Looking at VTune's profiling report (see below) showed the outer if clause of `fluid_iir_filter_apply` being pretty busy. I assume this is because the calling code in `fluid_rvoice_dsp.c` invokes that function twice, once with the custom filter typically being disabled, and the regular low pass filter being enabled. Before merging #1444 this was done once per voice. Now it's done for every single sample, which apparently hurts branch prediction and possibly also instruction caching.

To address this, I ported the DSP code to C++98, which allows me to use templating to generate multiple versions of the DSP code. One of them e.g. never attempts to use the custom IIR filter in the DSP loop if it's unused for that voice. Also whether or not to construct a 24bit sample has been templatified.

In addition, most of the IIR filter code was moved to the header, allowing the compiler to inline it.

With these changes, our testsuite `make check_manual` now finishes up 7 seconds faster for me.

---

Profiling before this PR (at rev e57360d3ea4762189cdb6424f8a1339dc00f438e):

![Screenshot_20250112_121227](https://github.com/user-attachments/assets/d36cc9c8-8007-4787-93cc-8d6c2777a974)

![Screenshot_20250112_121412](https://github.com/user-attachments/assets/89ce4ea3-fe84-464a-b397-fdc411cd4b09)


Profiling after this PR, `fluid_iir_filter_apply` is no longer that busy.

![Screenshot_20250112_123611](https://github.com/user-attachments/assets/3012fdc4-06a3-457d-8fc1-569fa89c2661)
