### PR TITLE
Fix another regression introduced by #1314

### DIFF
--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -465,7 +465,7 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
         //
         // Currently, this does access the sample buffers, which is redundant and could be optimized away.
         // On the other hand, entering this if-clause is not supposed to happen often.
-        return fluid_rvoice_dsp_interpolate_none(voice, dsp_buf, is_looping);
+        return fluid_rvoice_dsp_silence(voice, dsp_buf, is_looping);
     }
 
     switch(voice->dsp.interp_method)

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -203,6 +203,7 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_sample);
 
 /* defined in fluid_rvoice_dsp.c */
 void fluid_rvoice_dsp_config(void);
+int fluid_rvoice_dsp_silence(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRICT dsp_buf, int looping);
 int fluid_rvoice_dsp_interpolate_none(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
 int fluid_rvoice_dsp_interpolate_linear(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);
 int fluid_rvoice_dsp_interpolate_4th_order(fluid_rvoice_t *voice, fluid_real_t *FLUID_RESTRICT dsp_buf, int is_looping);

--- a/src/rvoice/fluid_rvoice_dsp.cpp
+++ b/src/rvoice/fluid_rvoice_dsp.cpp
@@ -71,8 +71,6 @@ static int fluid_rvoice_dsp_silence_local(fluid_rvoice_t *rvoice, fluid_real_t *
     fluid_rvoice_dsp_t *voice = &rvoice->dsp;
     fluid_phase_t dsp_phase = voice->phase;
     fluid_phase_t dsp_phase_incr;
-    fluid_real_t dsp_amp = voice->amp;
-    fluid_real_t dsp_amp_incr = voice->amp_incr;
     unsigned short dsp_i = 0;
     unsigned int dsp_phase_index;
     unsigned int end_index;
@@ -94,7 +92,6 @@ static int fluid_rvoice_dsp_silence_local(fluid_rvoice_t *rvoice, fluid_real_t *
 
             /* increment phase and amplitude */
             fluid_phase_incr(dsp_phase, dsp_phase_incr);
-            dsp_amp += dsp_amp_incr;
         }
 
         /* break out if not looping (buffer may not be full) */
@@ -119,7 +116,8 @@ static int fluid_rvoice_dsp_silence_local(fluid_rvoice_t *rvoice, fluid_real_t *
     }
 
     voice->phase = dsp_phase;
-    voice->amp = dsp_amp;
+    // Note, there is no need to update the amplitude here. When the voice becomes audible again, the amp will be updated anyway in fluid_rvoice_calc_amp().
+    // voice->amp = dsp_amp;
 
     return (dsp_i);
 }


### PR DESCRIPTION
When a voice is playing in delay phase, its amplitude and amplitude increment aren't updated or cleared, causing it to inherit them from a previous voice. Previously, if the increment was non-zero, nothing prevented the amplitude of the voice from rising infinitely while it was playing in delay phase.

To fix this one could either explicitly prune the amplitude to zero in this case. However, it would still attempt to read the sample buffer and multiply them with a zero amplitude, resulting in a zero sample, which is unnecessarily wasteful.

Because of that, this PR adds a new DSP routine, whose only purpose is to write silence to the dsp buffer and update the dsp phase of the voice accordingly.

Fixes #1451 