### PR TITLE
Make MSGS-style note-cut configurable

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -195,6 +195,20 @@ Developers:
                 Sets the minimum note duration in milliseconds. This ensures that really short duration note events, such as percussion notes, have a better chance of sounding as intended. Set to 0 to disable this feature.</desc>
         </setting>
         <setting>
+            <name>msgs-note-cut</name>
+            <type>int</type>
+            <def>0</def>
+            <min>0</min>
+            <max>2</max>
+            <desc>
+                Early synthesizers like the Roland SC-55 and Microsoft Wavetable GS MIDI synthesizer (MSGS) are terminating notes abruptly that have already received a noteOff after receiving a noteOn for the same key. This behavior was presumably implemented to save polyphony in these systems. This setting was introduced in fluidsynth 2.4.3 can be enabled to mimic this behavior, to esp. playback old tunes like Doom E1M1 accurately. Please note that using a SoundFont which makes proper use of exclusive class for e.g. percussion instruments will yield a similar result. This approach is generally preferable since it's portable among SF2 compliant synths and can be applied more fine-grained among instruments.
+                <ul>
+                    <li>0: No note-cut is applied, which is the default SF2 compliant behavior.</li>
+                    <li>1: Note-cut is only applied on drum MIDI channels (i.e. CHANNEL_TYPE_DRUM). Fluidsynth 2.4.0, 2.4.1, and 2.4.2</li>
+                    <li>2: Note-cut is applied to both, drum and melodic MIDI channels.</li>
+                </ul></desc>
+        </setting>
+        <setting>
             <name>overflow.age</name>
             <type>num</type>
             <def>1000.0</def>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -201,9 +201,9 @@ Developers:
             <min>0</min>
             <max>2</max>
             <desc>
-                This setting specifies the behavior for releasing voices, if the same note is hit twice on the same channel. Early synthesizers like the Roland SC-55 and Microsoft Wavetable GS MIDI synthesizer (MSGS) are terminating notes abruptly that have already received a noteOff after receiving a noteOn for the same key. This behavior was presumably implemented to save polyphony in these systems. This setting was introduced in fluidsynth 2.4.3 can be enabled to mimic this behavior, to esp. playback old tunes like Doom E1M1 accurately. Please note that using a SoundFont which makes proper use of exclusive class for e.g. percussion instruments will yield a similar result. This approach is generally preferable since it's portable among SF2 compliant synths and can be applied more fine-grained among instruments.
+                This setting specifies the behavior for releasing voices, if the same note is hit twice on the same channel. Early synthesizers like the Roland SC-55 and Microsoft Wavetable GS MIDI synthesizer (MSGS) are terminating notes abruptly that have already received a noteOff after receiving a noteOn for the same key. This behavior was presumably implemented to save polyphony in these systems. This setting was introduced in fluidsynth 2.4.3 and can be enabled to mimic this behavior, to esp. play back old tunes like Doom E1M1 more accurately. Please note that using a SoundFont which makes proper use of exclusive classes for e.g. percussion instruments will yield a similar result. Also, this approach is generally preferable since it's portable among SF2 compliant synths and can be applied more fine-grained among instruments.
                 <ul>
-                    <li>0: A regular noteOff is applied, which is the default SF2 compliant behavior.</li>
+                    <li>0: A regular noteOff is applied to the previous note, which is the default SF2 compliant behavior.</li>
                     <li>1: Note-cut is only applied on drum MIDI channels (i.e. CHANNEL_TYPE_DRUM). Fluidsynth 2.4.0, 2.4.1, and 2.4.2 unconditionally used this mode.</li>
                     <li>2: Note-cut is applied to both, drum and melodic MIDI channels.</li>
                 </ul></desc>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -195,7 +195,7 @@ Developers:
                 Sets the minimum note duration in milliseconds. This ensures that really short duration note events, such as percussion notes, have a better chance of sounding as intended. Set to 0 to disable this feature.</desc>
         </setting>
         <setting>
-            <name>msgs-note-cut</name>
+            <name>note-cut</name>
             <type>int</type>
             <def>0</def>
             <min>0</min>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -201,10 +201,10 @@ Developers:
             <min>0</min>
             <max>2</max>
             <desc>
-                Early synthesizers like the Roland SC-55 and Microsoft Wavetable GS MIDI synthesizer (MSGS) are terminating notes abruptly that have already received a noteOff after receiving a noteOn for the same key. This behavior was presumably implemented to save polyphony in these systems. This setting was introduced in fluidsynth 2.4.3 can be enabled to mimic this behavior, to esp. playback old tunes like Doom E1M1 accurately. Please note that using a SoundFont which makes proper use of exclusive class for e.g. percussion instruments will yield a similar result. This approach is generally preferable since it's portable among SF2 compliant synths and can be applied more fine-grained among instruments.
+                This setting specifies the behavior for releasing voices, if the same note is hit twice on the same channel. Early synthesizers like the Roland SC-55 and Microsoft Wavetable GS MIDI synthesizer (MSGS) are terminating notes abruptly that have already received a noteOff after receiving a noteOn for the same key. This behavior was presumably implemented to save polyphony in these systems. This setting was introduced in fluidsynth 2.4.3 can be enabled to mimic this behavior, to esp. playback old tunes like Doom E1M1 accurately. Please note that using a SoundFont which makes proper use of exclusive class for e.g. percussion instruments will yield a similar result. This approach is generally preferable since it's portable among SF2 compliant synths and can be applied more fine-grained among instruments.
                 <ul>
-                    <li>0: No note-cut is applied, which is the default SF2 compliant behavior.</li>
-                    <li>1: Note-cut is only applied on drum MIDI channels (i.e. CHANNEL_TYPE_DRUM). Fluidsynth 2.4.0, 2.4.1, and 2.4.2</li>
+                    <li>0: A regular noteOff is applied, which is the default SF2 compliant behavior.</li>
+                    <li>1: Note-cut is only applied on drum MIDI channels (i.e. CHANNEL_TYPE_DRUM). Fluidsynth 2.4.0, 2.4.1, and 2.4.2 unconditionally used this mode.</li>
                     <li>2: Note-cut is applied to both, drum and melodic MIDI channels.</li>
                 </ul></desc>
         </setting>

--- a/doc/recent_changes.txt
+++ b/doc/recent_changes.txt
@@ -1,6 +1,9 @@
 /*!
 
 \page RecentChanges Recent Changes
+\section NewIn2_4_3 What's new in 2.4.3?
+- synth.note-cut has been introduced
+
 \section NewIn2_4_0 What's new in 2.4.0?
 - synth.device-id now has a default value of 16
 - Default values of reverb and chorus settings have been tuned

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -256,7 +256,7 @@ void fluid_synth_settings(fluid_settings_t *settings)
     fluid_settings_add_option(settings, "synth.midi-bank-select", "mma");
 
     fluid_settings_register_int(settings, "synth.dynamic-sample-loading", 0, 0, 1, FLUID_HINT_TOGGLED);
-    fluid_settings_register_int(settings, "synth.msgs-note-cut", 0, 0, 2, 0);
+    fluid_settings_register_int(settings, "synth.note-cut", 0, 0, 2, 0);
 }
 
 /**
@@ -689,7 +689,7 @@ new_fluid_synth(fluid_settings_t *settings)
     fluid_settings_getnum_float(settings, "synth.overflow.age", &synth->overflow.age);
     fluid_settings_getnum_float(settings, "synth.overflow.important", &synth->overflow.important);
     
-    fluid_settings_getnum_int(settings, "synth.msgs-note-cut", &i);
+    fluid_settings_getnum_int(settings, "synth.note-cut", &i);
     synth->msgs_note_cut_mode = i;
 
     /* register the callbacks */

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -689,7 +689,7 @@ new_fluid_synth(fluid_settings_t *settings)
     fluid_settings_getnum_float(settings, "synth.overflow.age", &synth->overflow.age);
     fluid_settings_getnum_float(settings, "synth.overflow.important", &synth->overflow.important);
     
-    fluid_settings_getnum_int(settings, "synth.note-cut", &i);
+    fluid_settings_getint(settings, "synth.note-cut", &i);
     synth->msgs_note_cut_mode = i;
 
     /* register the callbacks */

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -6882,6 +6882,7 @@ fluid_synth_release_voice_on_same_note_LOCAL(fluid_synth_t *synth, int chan,
                 && (fluid_voice_get_id(voice) != synth->noteid))
         {
             enum fluid_midi_channel_type type = synth->channel[chan]->channel_type;
+            enum fluid_msgs_note_cut note_cut_mode = synth->msgs_note_cut_mode;
 
             /* Id of voices that was sustained by sostenuto */
             if(fluid_voice_is_sostenuto(voice))
@@ -6889,21 +6890,17 @@ fluid_synth_release_voice_on_same_note_LOCAL(fluid_synth_t *synth, int chan,
                 synth->storeid = fluid_voice_get_id(voice);
             }
 
-            switch(type)
+            if(note_cut_mode == FLUID_MSGS_DISABLED || (note_cut_mode == FLUID_MSGS_DRUM_CUT && type == CHANNEL_TYPE_MELODIC))
             {
-                case CHANNEL_TYPE_DRUM:
-                    /* release the voice, this should make riding hi-hats or snares sound more
-                     * realistic (Discussion #1196) */
-                    fluid_voice_off(voice);
-                    break;
-                case CHANNEL_TYPE_MELODIC:
-                    /* Force the voice into release stage except if pedaling (sostenuto or sustain) is active.
-                     * This gives a more realistic sound to pianos and possibly other instruments (see PR #905). */
-                    fluid_voice_noteoff(voice);
-                    break;
-                default:
-                    FLUID_LOG(FLUID_ERR, "This should never happen: unknown channel type %d", (int)type);
-                    break;
+                /* Force the voice into release stage except if pedaling (sostenuto or sustain) is active.
+                 * This gives a more realistic sound to pianos and possibly other instruments (see PR #905). */
+                fluid_voice_noteoff(voice);
+            }
+            else // i.e. if((note_cut_mode == FLUID_MSGS_ALL_CUT) || (note_cut_mode == FLUID_MSGS_DRUM_CUT && type == CHANNEL_TYPE_DRUM))
+            {
+                /* release the voice, this should make riding hi-hats or snares sound more realistic (Discussion #1196)
+                 * Note however, that this is not a SF2 compliant behavior, see #1466 */
+                fluid_voice_off(voice);
             }
         }
     }

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -256,6 +256,7 @@ void fluid_synth_settings(fluid_settings_t *settings)
     fluid_settings_add_option(settings, "synth.midi-bank-select", "mma");
 
     fluid_settings_register_int(settings, "synth.dynamic-sample-loading", 0, 0, 1, FLUID_HINT_TOGGLED);
+    fluid_settings_register_int(settings, "synth.msgs-note-cut", 0, 0, 2, 0);
 }
 
 /**
@@ -687,6 +688,9 @@ new_fluid_synth(fluid_settings_t *settings)
     fluid_settings_getnum_float(settings, "synth.overflow.volume", &synth->overflow.volume);
     fluid_settings_getnum_float(settings, "synth.overflow.age", &synth->overflow.age);
     fluid_settings_getnum_float(settings, "synth.overflow.important", &synth->overflow.important);
+    
+    fluid_settings_getnum_int(settings, "synth.msgs-note-cut", &i);
+    synth->msgs_note_cut_mode = i;
 
     /* register the callbacks */
     fluid_settings_callback_num(settings, "synth.gain",

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -81,6 +81,13 @@ enum fluid_synth_status
     FLUID_SYNTH_STOPPED
 };
 
+enum fluid_msgs_note_cut
+{
+    FLUID_MSGS_DISABLED = 0,
+    FLUID_MSGS_DRUM_CUT = 1,
+    FLUID_MSGS_ALL_CUT  = 2
+};
+
 #define SYNTH_REVERB_CHANNEL 0
 #define SYNTH_CHORUS_CHANNEL 1
 
@@ -115,8 +122,7 @@ struct _fluid_synth_t
     int midi_channels;                 /**< the number of MIDI channels (>= 16) */
     int bank_select;                   /**< the style of Bank Select MIDI messages */
     int audio_channels;                /**< the number of audio channels (1 channel=left+right) */
-    int audio_groups;                  /**< the number of (stereo) 'sub'groups from the synth.
-					  Typically equal to audio_channels. */
+    int audio_groups;                  /**< the number of (stereo) 'sub'groups from the synth. Typically equal to audio_channels. */
     int effects_channels;              /**< the number of effects channels (>= 2) */
     int effects_groups;                /**< the number of effects units (>= 1) */
     int state;                         /**< the synthesizer state */
@@ -164,6 +170,7 @@ struct _fluid_synth_t
     fluid_ladspa_fx_t *ladspa_fx;      /**< Effects unit for LADSPA support */
     enum fluid_iir_filter_type custom_filter_type; /**< filter type of the user-defined filter currently used for all voices */
     enum fluid_iir_filter_flags custom_filter_flags; /**< filter type of the user-defined filter currently used for all voices */
+    enum fluid_msgs_note_cut msgs_note_cut_mode;
 };
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -186,12 +186,25 @@ else()
 
     add_custom_target(renderExcl
         COMMAND fluidsynth -R 0 -C 0 -g 1.4 -F "${EXCL_RENDER_DIR}/exclusive class cutoff speed.${FEXT}" "exclusive class cutoff speed.mid" "exclusive class cutoff speed.sf2"
-        COMMAND fluidsynth -R 0 -C 0 -g 1.4 -F "${EXCL_RENDER_DIR}/MIDInotecut.${FEXT}" "MIDInotecut.mid" ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 0 -C 0 -g 1.4 -o synth.note-cut=0 -F "${EXCL_RENDER_DIR}/MIDInotecut0.${FEXT}" "MIDInotecut.mid" ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 0 -C 0 -g 1.4 -o synth.note-cut=1 -F "${EXCL_RENDER_DIR}/MIDInotecut1.${FEXT}" "MIDInotecut.mid" ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 0 -C 0 -g 1.4 -o synth.note-cut=2 -F "${EXCL_RENDER_DIR}/MIDInotecut2.${FEXT}" "MIDInotecut.mid" ${GENERAL_USER_GS2}
         COMMAND fluidsynth -R 0 -C 0 -g 1.4 -F "${EXCL_RENDER_DIR}/percussion note cutoff.${FEXT}" "percussion note cutoff.mid" ${GENERAL_USER_GS2}
         COMMAND fluidsynth -R 0 -C 0 -g 1.4 -F "${EXCL_RENDER_DIR}/percussion-test.${FEXT}" "percussion-test.mid" ${GENERAL_USER_GS2}
-        COMMAND fluidsynth -R 0 -C 0 -g 0.6 -F "${EXCL_RENDER_DIR}/e1m1_GeneralUser2.${FEXT}" "e1m1.mid" ${GENERAL_USER_GS2}
-        COMMAND fluidsynth -R 0 -C 0 -g 0.6 -F "${EXCL_RENDER_DIR}/e1m1_gzdoom.${FEXT}" "e1m1.mid" "../sf2/gzdoom.sf2"
         COMMENT "Rendering exclusive class cutoff tests"
+        DEPENDS fluidsynth create_iir_dir
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/manual/exclusive_class/
+        VERBATIM
+    )
+
+    add_custom_target(rendere1m1
+        COMMAND fluidsynth -R 0 -C 0 -g 0.6 -o synth.note-cut=0 -F "${EXCL_RENDER_DIR}/e1m1_GeneralUser2_notecut0.${FEXT}" "e1m1.mid" ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 0 -C 0 -g 0.6 -o synth.note-cut=0 -F "${EXCL_RENDER_DIR}/e1m1_gzdoom_notecut0.${FEXT}" "e1m1.mid" "../sf2/gzdoom.sf2"
+        COMMAND fluidsynth -R 0 -C 0 -g 0.6 -o synth.note-cut=1 -F "${EXCL_RENDER_DIR}/e1m1_GeneralUser2_notecut1.${FEXT}" "e1m1.mid" ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 0 -C 0 -g 0.6 -o synth.note-cut=1 -F "${EXCL_RENDER_DIR}/e1m1_gzdoom_notecut1.${FEXT}" "e1m1.mid" "../sf2/gzdoom.sf2"
+        COMMAND fluidsynth -R 0 -C 0 -g 0.6 -o synth.note-cut=2 -F "${EXCL_RENDER_DIR}/e1m1_GeneralUser2_notecut2.${FEXT}" "e1m1.mid" ${GENERAL_USER_GS2}
+        COMMAND fluidsynth -R 0 -C 0 -g 0.6 -o synth.note-cut=2 -F "${EXCL_RENDER_DIR}/e1m1_gzdoom_notecut2.${FEXT}" "e1m1.mid" "../sf2/gzdoom.sf2"
+        COMMENT "Rendering Doom E1M1 with note-cut 0,1,2"
         DEPENDS fluidsynth create_iir_dir
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/manual/exclusive_class/
         VERBATIM


### PR DESCRIPTION
This introduces a new setting, `synth.note-cut,` as discussed in #1466. It also restores the default behavior of releasing voices in the SF2 compliant way, as it was before Fluid Synth 2.4.0.

Fixes #1466