### PR TITLE
Silence "Referenced but unset environment variable" warning

### DIFF
--- a/fluidsynth.service.in
+++ b/fluidsynth.service.in
@@ -19,6 +19,7 @@ ProtectControlGroups=true
 PrivateUsers=yes
 Type=notify
 NotifyAccess=main
+Environment=OTHER_OPTS= SOUND_FONT=
 EnvironmentFile=@FLUID_DAEMON_ENV_FILE@
 EnvironmentFile=-%h/.config/fluidsynth
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/fluidsynth -is $OTHER_OPTS $SOUND_FONT


### PR DESCRIPTION
Systemd v254+ warns about unset environment variables, so we need to provide an explicit default value.

Based on https://github.com/analogdevicesinc/libiio/pull/1144