### PR TITLE
Fix IIR filter Q becoming negative

### DIFF
--- a/src/rvoice/fluid_iir_filter.c
+++ b/src/rvoice/fluid_iir_filter.c
@@ -115,6 +115,7 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_q)
     if(iir_filter->filter_startup)
     {
         iir_filter->last_q = q;
+        iir_filter->q_incr_count = 0;
     }
     else
     {
@@ -126,6 +127,7 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_iir_filter_set_q)
         }
         iir_filter->q_incr = (q - iir_filter->last_q) / (q_incr_count);
         iir_filter->q_incr_count = q_incr_count;
+        LOG_FILTER("%f - %f / %f = %f", q , iir_filter->last_q, q_incr_count, iir_filter->q_incr);
     }
 #ifdef DBG_FILTER
     iir_filter->target_q = q;

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -211,7 +211,7 @@ fluid_real_t
 fluid_sec2tc(fluid_real_t sec)
 {
     fluid_real_t res;
-    if(sec < 0)
+    if(sec <= 0)
     {
         // would require a complex solution of fluid_tc2sec(), but this is real-only
         return -32768.f;


### PR DESCRIPTION
Previously, the IIR filter wasn't clearing its previous Q interpolation, causing it to inherit the step factor from an older filter state (after calling e.g. `fluid_iir_filter_reset()`). This may have caused messing around with the Q, potentially becoming negative, and therefore causing a bunch of `inf` and `nan`s to be generated whenever Q was passed to `log()` or `sqrt()`. This in turn would lead to very high audio gain output. It is not quite clear to me though, why this affected only some audio drivers, when either reverb or chorus was active, and why most notably the file renderer was completely unimpressed by this issue.

This PR properly clears the Q interpolation upon filter startup. Additionally, it was found that calling `fluid_sec2tc` with zero would have also raised a SIGFPE. This has been fixed as well.

Fixes #1464 