### PR TITLE
Fix Mac CI

### DIFF
--- a/.azure/azure-pipelines-mac.yml
+++ b/.azure/azure-pipelines-mac.yml
@@ -38,24 +38,24 @@ jobs:
         imageName: 'macOS-13'
         CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
         ReadlinePkgConf: '$(brew --prefix readline)/lib/pkgconfig'
-      UnixLibs12:
-        imageName: 'macos-12'
+      UnixLibs14:
+        imageName: 'macos-14'
         CMakeFlags: '-Denable-framework=0'
         ReadlinePkgConf: ''
-      UnixLibs12_static:
-        imageName: 'macos-12'
+      UnixLibs14_static:
+        imageName: 'macos-14'
         CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
         ReadlinePkgConf: ''
-      UnixLibs12_static_pkgconf_readline:
-        imageName: 'macos-12'
+      UnixLibs14_static_pkgconf_readline:
+        imageName: 'macos-14'
         CMakeFlags: '-Denable-framework=0 -DBUILD_SHARED_LIBS=0'
         ReadlinePkgConf: '$(brew --prefix readline)/lib/pkgconfig'
       FrameWork13:
         imageName: 'macOS-13'
         CMakeFlags: ''
         ReadlinePkgConf: ''
-      FrameWork12:
-        imageName: 'macos-12'
+      FrameWork14:
+        imageName: 'macos-14'
         CMakeFlags: ''
         ReadlinePkgConf: ''
 
@@ -136,9 +136,9 @@ jobs:
       #  macPortsUrl: 'https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2-11-BigSur.pkg'
       #  imageName: 'macos-11'
       #  CMakeFlags: '-Denable-sdl2=0 -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -Denable-framework=0
-      12_0_universal_unixlibs:
-        macPortsUrl: 'https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-12-Monterey.pkg'
-        imageName: 'macos-12'
+      14_0_universal_unixlibs:
+        macPortsUrl: 'https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg'
+        imageName: 'macos-14'
         CMakeFlags: '-Denable-sdl2=0 -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -Denable-framework=0'
       13_0_universal_unixlibs:
         macPortsUrl: 'https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-13-Ventura.pkg'


### PR DESCRIPTION
MacOS 12 is deprecated in Azure Pipelines