### PR TITLE
Address findings from issue #1475

### DIFF
--- a/doc/fluidsynth.1
+++ b/doc/fluidsynth.1
@@ -13,7 +13,7 @@
 .\" along with this program; see the file LICENSE.  If not, write to
 .\" the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
 .\"
-.TH FluidSynth 1 "Jan 1, 2025"
+.TH FluidSynth 1 "Feb 2, 2025"
 .\" Please update the above date whenever this man page is modified.
 .\"
 .\" Some roff macros, for reference:
@@ -155,8 +155,10 @@ Quit the synthesizer
 .TP
 .B SOUNDFONTS
 .TP
-.B load filename
-Load a SoundFont
+.B load filename [reset] [bankofs]
+Load a SoundFont onto the SoundFont stack. If reset is 1 (which is the implicit default), all currently in-use SoundFont presets will be re-evaluated with the newly loaded SoundFont taken into account.
+Optionally, you can specify a non-zero bank offset for the new SoundFont. For example the command
+load soundfont.sf2 0 10 will load the soundfont.sf2 with a bank offset of 10 without re-evaluating the presets.
 .TP
 .B unload number
 Unload a SoundFont. The number is the index of the SoundFont on the stack.

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -120,7 +120,7 @@ static const fluid_cmd_t fluid_commands[] =
     },
     {
         "load", "general", fluid_handle_load,
-        "load file [reset] [bankofs] Loads SoundFont (reset=0|1, def 1; bankofs=n, def 0)"
+        "load file [reset] [bankofs] Loads SoundFont (reset=0|1, def=1; bankofs=n, n!=0)"
     },
     {
         "unload", "general", fluid_handle_unload,
@@ -985,11 +985,21 @@ fluid_handle_load(void *data, int ac, char **av, fluid_ostream_t out)
     if(ac == 2)
     {
         reset = atoi(av[1]);
+        if (reset != 0 && reset != 1)
+        {
+            fluid_ostream_printf(out, "load: invalid reset argument %d, only 1 or 0 are allowed\n", reset);
+            return FLUID_FAILED;
+        }
     }
 
     if(ac == 3)
     {
         offset = atoi(av[2]);
+        if (offset == 0)
+        {
+            fluid_ostream_printf(out, "load: only non-zero bank offsets are allowed, omit this parameter if zero was intended\n", offset);
+            return FLUID_FAILED;
+        }
     }
 
     /* Load the SoundFont without resetting the programs. The reset will
@@ -1003,7 +1013,7 @@ fluid_handle_load(void *data, int ac, char **av, fluid_ostream_t out)
     }
     else
     {
-        fluid_ostream_printf(out, "loaded SoundFont has ID %d\n", id);
+        fluid_ostream_printf(out, "loaded SoundFont has ID %d and bankofs=%d\n", id, offset);
     }
 
     if(offset)

--- a/src/synth/fluid_chan.c
+++ b/src/synth/fluid_chan.c
@@ -334,8 +334,7 @@ fluid_channel_set_bank_msb(fluid_channel_t *chan, int bankmsb)
         return;
     }
 
-    if(style == FLUID_BANK_STYLE_GM ||
-            chan->channel_type == CHANNEL_TYPE_DRUM)
+    if(style == FLUID_BANK_STYLE_GM )
     {
         return;    /* ignored */
     }
@@ -344,6 +343,10 @@ fluid_channel_set_bank_msb(fluid_channel_t *chan, int bankmsb)
 
     if(style == FLUID_BANK_STYLE_GS)
     {
+        if(chan->channel_type == CHANNEL_TYPE_DRUM)
+        {
+            bankmsb += DRUM_INST_BANK;
+        }
         newval = (oldval & ~BANK_MASKVAL) | (bankmsb << BANK_SHIFTVAL);
     }
     else /* style == FLUID_BANK_STYLE_MMA */

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3109,14 +3109,7 @@ fluid_synth_program_change(fluid_synth_t *synth, int chan, int prognum)
 
     channel = synth->channel[chan];
 
-    if(channel->channel_type == CHANNEL_TYPE_DRUM)
-    {
-        banknum = DRUM_INST_BANK;
-    }
-    else
-    {
-        fluid_channel_get_sfont_bank_prog(channel, NULL, &banknum, NULL);
-    }
+    fluid_channel_get_sfont_bank_prog(channel, NULL, &banknum, NULL);
 
     if(synth->verbose)
     {

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3135,9 +3135,13 @@ fluid_synth_program_change(fluid_synth_t *synth, int chan, int prognum)
             /* Percussion: Fallback to preset 0 in percussion bank */
             if(channel->channel_type == CHANNEL_TYPE_DRUM)
             {
-                subst_prog = 0;
                 subst_bank = DRUM_INST_BANK;
                 preset = fluid_synth_find_preset(synth, subst_bank, subst_prog);
+                if(!preset)
+                {
+                    subst_prog = 0;
+                    preset = fluid_synth_find_preset(synth, subst_bank, subst_prog);
+                }
             }
             /* Melodic instrument */
             else


### PR DESCRIPTION
This addresses the findings of issue #1475, in particular:

* Update the documentation about the `load` shell comand
* Revise error handling of the `load` shell command
* Allow drum channels to profit from Bank Offsets by no longer ignoring MSB Bank changes for drum channels (second try after #176)
* Make the preset fallback logic on drum channels more predictable, to migitage my concerns in 883b640bef7fe7cb35625eabdef1223abbecf966. I.e. instead of directly falling back to preset `128:0`, we are now falling back to bank 128, while keeping the currently set program. And only if that fails as well, we pick the standard drum kit at  `128:0`.