### PR TITLE
Fix errors when switching user

### DIFF
--- a/fluidsynth.service.in
+++ b/fluidsynth.service.in
@@ -3,6 +3,8 @@ Description=FluidSynth Daemon
 Documentation=man:fluidsynth(1)
 After=sound.target
 After=pipewire.service
+# If you need more than one instance, use `systemctl edit` to override this:
+ConditionPathExists=!/run/lock/fluidsynth.lock
 
 [Service]
 # added automatically, for details please see
@@ -23,6 +25,8 @@ Environment=OTHER_OPTS= SOUND_FONT=
 EnvironmentFile=@FLUID_DAEMON_ENV_FILE@
 EnvironmentFile=-%h/.config/fluidsynth
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/fluidsynth -is $OTHER_OPTS $SOUND_FONT
+ExecStartPre=touch /run/lock/fluidsynth.lock
+ExecStopPost=rm -f /run/lock/fluidsynth.lock
 
 [Install]
 WantedBy=default.target

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -1137,6 +1137,10 @@ cleanup:
 #endif
         delete_fluid_server(server);
     }
+    else if(with_server)
+    {
+        result = 1;
+    }
 
 #endif	/* NETWORK_SUPPORT */
 

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -1567,7 +1567,7 @@ static fluid_thread_return_t fluid_server_socket_run(void *data)
         {
             if(server_socket->cont)
             {
-                FLUID_LOG(FLUID_ERR, "Failed to accept connection: %d", fluid_socket_get_error());
+                FLUID_LOG(FLUID_ERR, "Got error %d while trying to accept connection", fluid_socket_get_error());
             }
 
             server_socket->cont = 0;
@@ -1640,7 +1640,7 @@ new_fluid_server_socket(int port, fluid_server_func_t func, void *data)
 
     if(sock == INVALID_SOCKET)
     {
-        FLUID_LOG(FLUID_WARN, "Failed to create IPv6 server socket: %d (will try with IPv4)", fluid_socket_get_error());
+        FLUID_LOG(FLUID_WARN, "Got error %d while trying to create IPv6 server socket (will try with IPv4)", fluid_socket_get_error());
 
         sock = socket(AF_INET, SOCK_STREAM, 0);
         addr = (const struct sockaddr *) &addr4;
@@ -1655,14 +1655,14 @@ new_fluid_server_socket(int port, fluid_server_func_t func, void *data)
 
     if(sock == INVALID_SOCKET)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to create server socket: %d", fluid_socket_get_error());
+        FLUID_LOG(FLUID_ERR, "Got error %d while trying to create server socket", fluid_socket_get_error());
         fluid_socket_cleanup();
         return NULL;
     }
     
     if(bind(sock, addr, (int) addr_size) == SOCKET_ERROR)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to bind server socket: %d", fluid_socket_get_error());
+        FLUID_LOG(FLUID_ERR, "Got error %d while trying to bind server socket", fluid_socket_get_error());
         fluid_socket_close(sock);
         fluid_socket_cleanup();
         return NULL;
@@ -1670,7 +1670,7 @@ new_fluid_server_socket(int port, fluid_server_func_t func, void *data)
 
     if(listen(sock, SOMAXCONN) == SOCKET_ERROR)
     {
-        FLUID_LOG(FLUID_ERR, "Failed to listen on server socket: %d", fluid_socket_get_error());
+        FLUID_LOG(FLUID_ERR, "Got error %d while trying to listen on server socket", fluid_socket_get_error());
         fluid_socket_close(sock);
         fluid_socket_cleanup();
         return NULL;


### PR DESCRIPTION
Fluidsynth includes a systemd user service, which listens on TCP port 9800 by default.  So if a computer starts a second user session, that session's service immediately fails because port 9800 is already in use.  Lightdm implements its login prompt as a user session, so this can happen just by misclicking the "switch user" button.  I assume other display managers are the same, but haven't checked.

This PR is a set of loosely-connected suggestions that would have helped as I went down this particular rabbit hole.  I figure they're easier to review together, but happy to edit/split out/remove anything that doesn't fit.