### PR TITLE
Fix ordering and dependencies in fluidsynth.service file

### DIFF
--- a/fluidsynth.service.in
+++ b/fluidsynth.service.in
@@ -2,9 +2,11 @@
 Description=FluidSynth Daemon
 Documentation=man:fluidsynth(1)
 After=sound.target
-After=pipewire.service
+After=pipewire.service pulseaudio.service
+Wants=pipewire.service pulseaudio.service
 # If you need more than one instance, use `systemctl edit` to override this:
 ConditionPathExists=!/run/lock/fluidsynth.lock
+ConditionUser=!@system
 
 [Service]
 # added automatically, for details please see


### PR DESCRIPTION
* Add pulseaudio.service next to pipewire.service on the After= line. Fluidsynth may work with either audio backend, but both cannot be installed at the same time.
* Add a Wants= line with both pipewire.service and pulseaudio.service. While the After= line merely means that fluidsynth should be loaded after the respective audio backends, the Wants= relationship means that fluidsynth will actually try to load the audio backends before it starts itself, but will not fail itself if loading a wanted service fails (weak dependency). Adding this adds *dependency* (Wants=) to *ordering* (After=).
* Add ConditionUser=!@system to prevent system users from starting a fluidsynth daemon. For example, the GDM login screen will never have to playback MIDI music.

This change has been motivated by release critical bug #1053245 in Debian:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1053245

It has been discussed with and acknowledged by the systemd developers on the systemd-devel mailing list, e.g.:

https://lists.freedesktop.org/archives/systemd-devel/2025-March/051276.html