### PR TITLE
Apply *_FOR_BUILD environment variables to gentables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -547,19 +547,13 @@ set (GENTAB_BDIR ${CMAKE_CURRENT_BINARY_DIR}/gentables)
 # To fix cross-compiling fluidsynth from Win32 to ARM (using vcpkg), we need to pass the current generator
 # on to the external project, otherwise (for some unknown reason) the target compiler will be used rather
 # than the host compiler.
-#
-# Some use-cases however cannot rely on this logic, therefore, FLUID_HOST_COMPILER can be specified to
-# force using a particular host compiler, see https://github.com/FluidSynth/fluidsynth/issues/1301
-if ( FLUID_HOST_COMPILER )
-  set ( EXPLICIT_HOST_COMPILER_STR "-DCMAKE_C_COMPILER=${FLUID_HOST_COMPILER}" )
-endif ()
 
 ExternalProject_Add(gentables
     DOWNLOAD_COMMAND ""
     SOURCE_DIR ${GENTAB_SDIR}
     BINARY_DIR ${GENTAB_BDIR}
     CONFIGURE_COMMAND
-        "${CMAKE_COMMAND}" -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE} ${EXPLICIT_HOST_COMPILER_STR} -G "${CMAKE_GENERATOR}" -B "${GENTAB_BDIR}" "${GENTAB_SDIR}"
+        "${CMAKE_COMMAND}" -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE} -G "${CMAKE_GENERATOR}" -B "${GENTAB_BDIR}" "${GENTAB_SDIR}"
     BUILD_COMMAND
         "${CMAKE_COMMAND}" --build "${GENTAB_BDIR}"
     INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${FluidSynth_BINARY_DIR}/"

--- a/src/gentables/CMakeLists.txt
+++ b/src/gentables/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 
 # remove $CC from the current environment and by that force cmake to look for a (working) C compiler,
 # which hopefully will be the host compiler
-unset(ENV{CC})
+set(ENV{CC} "$ENV{CC_FOR_BUILD}")
 
 # also unset $CFLAGS to avoid passing any cross compilation flags to the host compiler
-unset(ENV{CFLAGS})
+set(ENV{CFLAGS} "$ENV{CFLAGS_FOR_BUILD} $ENV{CPPFLAGS_FOR_BUILD}")
 
 # linker flags as well
-unset(ENV{LDFLAGS})
+set(ENV{LDFLAGS} "$ENV{LDFLAGS_FOR_BUILD}")
 
 project (gentables C)
 

--- a/src/gentables/CMakeLists.txt
+++ b/src/gentables/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 
-# remove $CC from the current environment and by that force cmake to look for a (working) C compiler,
-# which hopefully will be the host compiler
+# Set the CC, CFLAGS and LDFLAGS variables to the corresponding *_FOR_BUILD environment variables.
+# If the CC_FOR_BUILD environment variable is unset or empty, this will unset the CC CMake variable
+# and by that force CMake to look for a (working) C compiler, which hopefully will be the host compiler.
 set(ENV{CC} "$ENV{CC_FOR_BUILD}")
 
-# also unset $CFLAGS to avoid passing any cross compilation flags to the host compiler
+# CMake is notorious for ignoring the CPPFLAGS variable, so explicitly append it to the CFLAGS variable here.
 set(ENV{CFLAGS} "$ENV{CFLAGS_FOR_BUILD} $ENV{CPPFLAGS_FOR_BUILD}")
 
-# linker flags as well
 set(ENV{LDFLAGS} "$ENV{LDFLAGS_FOR_BUILD}")
 
 project (gentables C)


### PR DESCRIPTION
This is the last attempt (I promise!) to address this unfortunate topic. This patch has been applied to the fluidsynth_2.4.3+dfsg-3 Debian package since February 25th and has proved doing what it's supposed to do:

https://salsa.debian.org/multimedia-team/fluidsynth/-/jobs/7156765

It has also proved to work well in a cross building environment:

http://crossqa.debian.net/src/fluidsynth

