### PR TITLE
Fix XG Drum bank selection

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -181,7 +181,7 @@ Developers:
                     <li>gs: (default) CC0 becomes the bank number, CC32 is ignored.</li>
                     <li>gm: ignores CC0 and CC32 messages.</li>
                     <li>mma: bank is calculated as CC0*128+CC32.</li>
-                    <li>xg: If CC0 is equal to 120, 126, or 127 then channel is set to drum and the bank number is set to 128 (CC32 is ignored). Otherwise the channel is set to melodic and CC32 is the bank number. Note that you need fluidsynth &gt;=2.3.5 for this to work correctly, previous versions behaved incorrectly.</li>
+                    <li>xg: If CC0 is equal to 120, 126, or 127 then channel is set to drum mode and the bank number is set to [<code>128</code> (fluidsynth &lt;= 2.4.4) | <code>CC0</code> (fluidsynth &gt;=2.4.5)] and CC32 is ignored in this case. If the SoundFont does not provide a bank 120, 126 or 127, fluidsynth will fallback to default drum bank 128. If CC0 has a different value, the channel is set to melodic and CC32 becomes the bank number. Note that before fluidsynth 2.3.5 the logic for CC0 was broken.</li>
                 </ul>
             </desc>
         </setting>

--- a/src/synth/fluid_chan.c
+++ b/src/synth/fluid_chan.c
@@ -297,8 +297,7 @@ fluid_channel_set_bank_lsb(fluid_channel_t *chan, int banklsb)
 
     style = chan->synth->bank_select;
 
-    if(style == FLUID_BANK_STYLE_GM ||
-            style == FLUID_BANK_STYLE_GS)
+    if(style == FLUID_BANK_STYLE_GM || style == FLUID_BANK_STYLE_GS)
     {
         return;    /* ignored */
     }
@@ -307,6 +306,10 @@ fluid_channel_set_bank_lsb(fluid_channel_t *chan, int banklsb)
 
     if(style == FLUID_BANK_STYLE_XG)
     {
+        if(chan->channel_type == CHANNEL_TYPE_DRUM)
+        {
+            return; // bankLSB is ignored for drum channels
+        }
         newval = (oldval & ~BANK_MASKVAL) | (banklsb << BANK_SHIFTVAL);
     }
     else /* style == FLUID_BANK_STYLE_MMA */
@@ -324,6 +327,7 @@ fluid_channel_set_bank_msb(fluid_channel_t *chan, int bankmsb)
     int oldval, newval, style;
 
     style = chan->synth->bank_select;
+    oldval = chan->sfont_bank_prog;
 
     if(style == FLUID_BANK_STYLE_XG)
     {
@@ -331,17 +335,22 @@ fluid_channel_set_bank_msb(fluid_channel_t *chan, int bankmsb)
         /* The number "120" was based on several keyboards having drums at 120 - 127,
            reference: https://lists.nongnu.org/archive/html/fluid-dev/2011-02/msg00003.html */
         chan->channel_type = (120 == bankmsb || 126 == bankmsb || 127 == bankmsb) ? CHANNEL_TYPE_DRUM : CHANNEL_TYPE_MELODIC;
-        return;
-    }
+        if(chan->channel_type == CHANNEL_TYPE_MELODIC)
+        {
+            // bankMSB is ignored for meldodic channels
+            return;
+        }
 
-    if(style == FLUID_BANK_STYLE_GM )
+        // ...but for drum channels, we use bankMSB as bank number. It is likely, that the Soundfont does not
+        // provide a bank for 127,126,120, in which case we will fallback to default drum bank 128 and everything
+        // will sound just fine.
+        newval = (oldval & ~BANK_MASKVAL) | (bankmsb << BANK_SHIFTVAL);
+    }
+    else if(style == FLUID_BANK_STYLE_GM )
     {
         return;    /* ignored */
     }
-
-    oldval = chan->sfont_bank_prog;
-
-    if(style == FLUID_BANK_STYLE_GS)
+    else if(style == FLUID_BANK_STYLE_GS)
     {
         if(chan->channel_type == CHANNEL_TYPE_DRUM)
         {
@@ -355,7 +364,6 @@ fluid_channel_set_bank_msb(fluid_channel_t *chan, int bankmsb)
     }
 
     chan->sfont_bank_prog = newval;
-
 }
 
 /* Get SoundFont ID, MIDI bank and/or program.  Use NULL to ignore a value. */


### PR DESCRIPTION
A regression introduced in #1486 causes the bankmsb setter to not update the bank for drum channels. This fixes this behavior, by applying the bankMsb as bank number in case it's an XG drum bank.

Fixes #1508 