### PR TITLE
Fix for OpenMP thread affinity crashes on Android devices

### DIFF
--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -400,20 +400,6 @@ int main(int argc, char **argv)
     }
 #endif
 
-/* 
- * Disable OpenMP thread affinity on Android to prevent crashes.
- * 
- * On several Android devices (particularly Xiaomi), OpenMP's attempt to set thread 
- * affinity fails with EINVAL, causing process abortion during parallel SoundFont loading. 
- * This is due to an unresolved bug in Android NDK's OpenMP implementation 
- * (see https://github.com/android/ndk/issues/1180).
- */
-#ifdef __ANDROID__
-    if (setenv("KMP_AFFINITY", "disabled", 1) != 0) {
-        fprintf(stderr, "Warning: Failed to disable KMP_AFFINITY, OpenMP crashes may occur on some devices\n");
-    }
-#endif
-
 #if SDL2_SUPPORT
     // Tell SDL that it shouldn't intercept signals, otherwise SIGINT and SIGTERM won't quit fluidsynth
     SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -400,6 +400,12 @@ int main(int argc, char **argv)
     }
 #endif
 
+#ifdef __ANDROID__
+    if (setenv("KMP_AFFINITY", "disabled", 1) != 0) {
+        fprintf(stderr, "Warning: Failed to disable KMP_AFFINITY, OpenMP crashes may occur on some devices\n");
+    }
+#endif
+
 #if SDL2_SUPPORT
     // Tell SDL that it shouldn't intercept signals, otherwise SIGINT and SIGTERM won't quit fluidsynth
     SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -400,6 +400,14 @@ int main(int argc, char **argv)
     }
 #endif
 
+/* 
+ * Disable OpenMP thread affinity on Android to prevent crashes.
+ * 
+ * On several Android devices (particularly Xiaomi), OpenMP's attempt to set thread 
+ * affinity fails with EINVAL, causing process abortion during parallel SoundFont loading. 
+ * This is due to an unresolved bug in Android NDK's OpenMP implementation 
+ * (see https://github.com/android/ndk/issues/1180).
+ */
 #ifdef __ANDROID__
     if (setenv("KMP_AFFINITY", "disabled", 1) != 0) {
         fprintf(stderr, "Warning: Failed to disable KMP_AFFINITY, OpenMP crashes may occur on some devices\n");

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -309,8 +309,9 @@ fluid_synth_init(void)
  * (see https://github.com/android/ndk/issues/1180).
  */
 #ifdef __ANDROID__
-    if (setenv("KMP_AFFINITY", "disabled", 1) != 0) {
-        fprintf(stderr, "Warning: Failed to disable KMP_AFFINITY, OpenMP crashes may occur on some devices\n");
+    if (setenv("KMP_AFFINITY", "disabled", 1) != 0)
+    {
+        FLUID_LOG(FLUID_WARN, "Failed to disable KMP_AFFINITY, OpenMP crashes may occur on some devices!");
     }
 #endif
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -300,6 +300,20 @@ fluid_synth_init(void)
   #endif
 #endif
 
+/*
+ * Disable OpenMP thread affinity on Android to prevent crashes.
+ *
+ * On several Android devices (particularly Xiaomi), OpenMP's attempt to set thread
+ * affinity fails with EINVAL, causing process abortion during parallel SoundFont loading.
+ * This is due to an unresolved bug in Android NDK's OpenMP implementation
+ * (see https://github.com/android/ndk/issues/1180).
+ */
+#ifdef __ANDROID__
+    if (setenv("KMP_AFFINITY", "disabled", 1) != 0) {
+        fprintf(stderr, "Warning: Failed to disable KMP_AFFINITY, OpenMP crashes may occur on some devices\n");
+    }
+#endif
+
     init_dither();
 
     /* custom_breath2att_mod is not a default modulator specified in SF2.01.


### PR DESCRIPTION
## Issue

FluidSynth crashes on multiple Android devices (predominantly Xiaomi models) when loading SoundFonts. 
These crashes occur when OpenMP attempts to set thread affinity during parallel sample loading in 
fluid_defsfont_load_all_sampledata().

Crash stack trace shows failure in KMPNativeAffinity::Mask::set_system_affinity() with EINVAL error.

## Root Cause

This is a documented issue in Android NDK's OpenMP implementation. When thread affinity setting fails on certain devices, libomp.so terminates the process instead of handling the error gracefully. The issue (Android NDK [#1180](https://github.com/android/ndk/issues/1180)) remains unresolved as it's difficult to reproduce. It still affects Xiaomi/Redmi devices.

``` 
11 libomp.so __kmp_abort_process + 52
12 libomp.so __kmp_fatal + 128
13 libomp.so KMPNativeAffinity::Mask::set_system_affinity(bool) const + 208
14 libomp.so __kmp_affinity_set_init_mask + 864
15 libomp.so __kmp_parallel_initialize + 320
16 libomp.so __kmp_fork_call + 160
17 libomp.so __kmpc_fork_call + 236
18 libfluidsynth.so fluid_defsfont.c - line 398  fluid_defsfont_load_all_sampledata + 398
19 libfluidsynth.so fluid_defsfont.c - line 540  fluid_defsfont_load + 540
20 libfluidsynth.so fluid_defsfont.c - line 108  fluid_defsfloader_load + 108
21 libfluidsynth.so fluid_synth.c - line 5365  fluid_synth_sfload + 5365
```

## Solution

Disable KMP_AFFINITY on Android by setting the environment variable early in initialization. This approach is successfully used in other libraries (e.g., Tencent's ncnn).

## Affected Devices

   - Xiaomi Redmi Note 13 Pro | Redmi Note12 Turbo | Xiaomi 12Pro | Xiaomi 12 ultra
   + Confirmed on:
      - Xiaomi Redmi Note 13 Pro (Android 15)
      - Xiaomi 12 Pro

## References

- Android NDK Issue (open since 2020): https://github.com/android/ndk/issues/1180
- Recent report (2024): https://github.com/android/ndk/issues/1180#issuecomment-2455637462
- Similar fix in ncnn: https://github.com/Tencent/ncnn/pull/4370


**Note: While setting KMP_AFFINITY=disabled in JNI_OnLoad successfully resolves the crashes in our application, I have not yet verified if placing this setting within FluidSynth's initialization will have the same effect. This issue is raised to bring attention to the problem and propose a potential solution that worked at the application level.**