### PR TITLE
Put fluidsynth.lock in its own directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -917,6 +917,9 @@ if ( UNIX )
         configure_file ( fluidsynth.service.in
         ${FluidSynth_BINARY_DIR}/fluidsynth.service @ONLY )
 
+        configure_file ( fluidsynth.tmpfiles.in
+        ${FluidSynth_BINARY_DIR}/fluidsynth.tmpfiles @ONLY )
+
         configure_file ( fluidsynth.conf.in
         ${FluidSynth_BINARY_DIR}/fluidsynth.conf @ONLY )
 

--- a/contrib/fluidsynth.spec
+++ b/contrib/fluidsynth.spec
@@ -95,9 +95,10 @@ This package contains the shared library for Fluidsynth.
 
 %if 0%{?suse_version}
 
-# manually install systemd service files
+# manually install systemd files
 install -Dm 644 build/fluidsynth.conf %{buildroot}%{_fillupdir}/sysconfig.%{name}
 install -Dm 644 build/fluidsynth.service %{buildroot}%{_unitdir}/%{name}.service
+install -Dm 644 build/fluidsynth.tmpfiles %{buildroot}%{_tmpfilesdir}/%{name}.conf
 install -d %{buildroot}%{_sbindir}
 ln -s %{_sbindir}/service %{buildroot}%{_sbindir}/rc%{name}
 

--- a/fluidsynth.service.in
+++ b/fluidsynth.service.in
@@ -5,7 +5,7 @@ After=sound.target
 After=pipewire.service pulseaudio.service
 Wants=pipewire.service pulseaudio.service
 # If you need more than one instance, use `systemctl edit` to override this:
-ConditionPathExists=!/run/lock/fluidsynth.lock
+ConditionPathExists=!/run/lock/fluidsynth/fluidsynth.lock
 ConditionUser=!@system
 
 [Service]
@@ -27,8 +27,8 @@ Environment=OTHER_OPTS= SOUND_FONT=
 EnvironmentFile=@FLUID_DAEMON_ENV_FILE@
 EnvironmentFile=-%h/.config/fluidsynth
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/fluidsynth -is $OTHER_OPTS $SOUND_FONT
-ExecStartPre=touch /run/lock/fluidsynth.lock
-ExecStopPost=rm -f /run/lock/fluidsynth.lock
+ExecStartPre=touch /run/lock/fluidsynth/fluidsynth.lock
+ExecStopPost=rm -f /run/lock/fluidsynth/fluidsynth.lock
 
 [Install]
 WantedBy=default.target

--- a/fluidsynth.tmpfiles.in
+++ b/fluidsynth.tmpfiles.in
@@ -1,0 +1,1 @@
+d /run/lock/fluidsynth 0777 root root


### PR DESCRIPTION
In some distributions (e.g. Fedora), /run/lock is only writable by root.

Create /run/lock/fluidsynth with appropriate permissions.

Fixes #1527.

Some issues with rolling this out:

I can't see where the `cmake` installer installs the `.service` files, so haven't added an equivalent to install `fluidsynth.tmpfiles`.  If the installer doesn't do that, this is fine.

I've added the relevant line to `contrib/fluidsynth.spec`, and [the documentation claims `%{_tmpfilesdir}` is the correct incantation](https://docs.fedoraproject.org/en-US/packaging-guidelines/Tmpfiles.d/), but I don't have a Fedora system to test on.  Should we give the Fedora maintainer a heads-up somehow?

I haven't added the relevant line to `contrib/debian.fluidsynth.install`, because Debian's version of that file has drifted out of sync.  To see their version, go to [Debian's package page](https://packages.debian.org/sid/fluidsynth), download [fluidsynth_2.4.4+dfsg-1.debian.tar.xz](http://deb.debian.org/debian/pool/main/f/fluidsynth/fluidsynth_2.4.4+dfsg-1.debian.tar.xz) and take a look at `debian/fluidsynth.install`.  The relevant line is probably `*/fluidsynth.tmpfiles usr/lib/tmpfiles.d/fluidsynth.conf` - do you want to resync these, or shall I just send them a bug report explaining they'll need to fix their version?