### PR TITLE
Fix inconsistent library naming on Windows

### DIFF
--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -30,7 +30,7 @@ jobs:
         platformAlt: x86
         gtk-bundle: $(gtk-bundle-x86)
         libsndfile-url: $(libsndfile-url-x86)
-        artifact-prefix: "fluidsynth"
+        artifactPrefix: "fluidsynth"
         CFLAGS: "/arch:IA32"
         CXXFLAGS: "/arch:IA32"
         CMAKEFLAGS: "-Denable-libinstpatch=0"
@@ -39,7 +39,7 @@ jobs:
         platformAlt: x64
         gtk-bundle: $(gtk-bundle-x64)
         libsndfile-url: $(libsndfile-url-x64)
-        artifact-prefix: "fluidsynth"
+        artifactPrefix: "fluidsynth"
         CFLAGS: ""
         CXXFLAGS: ""
         CMAKEFLAGS: ""
@@ -136,7 +136,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
-          artifactName: $(artifact-prefix)-$(platform)
+          artifactName: $(artifactPrefix)-$(platform)
 
 - job: Windows10
   variables:
@@ -207,7 +207,7 @@ jobs:
     matrix:
       x64:
         CMAKE_FLAGS: ""
-        artifact-prefix: "fluidsynth-mingw"
+        artifactPrefix: "fluidsynth-mingw"
         platform: x64
         gtk-bundle: $(gtk-bundle-x64)
         libsndfile-url: $(libsndfile-url-x64)
@@ -215,7 +215,7 @@ jobs:
         sdl3-url: 'https://github.com/libsdl-org/SDL/releases/download/release-3.2.10/SDL3-devel-3.2.10-mingw.tar.gz'
       x64-static:
         CMAKE_FLAGS: '-DBUILD_SHARED_LIBS=0'
-        artifact-prefix: "fluidsynth-mingw-static"
+        artifactPrefix: "fluidsynth-mingw-static"
         platform: x64
         gtk-bundle: $(gtk-bundle-x64)
         libsndfile-url: $(libsndfile-url-x64)
@@ -314,7 +314,8 @@ jobs:
         fi
       displayName: 'Validate library name'
       workingDirectory: $(Build.ArtifactStagingDirectory)\bin
+      condition: and(succeeded(), not(contains(variables.artifactPrefix, 'static')))
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
-          artifactName: $(artifact-prefix)-$(platform)
+          artifactName: $(artifactPrefix)-$(platform)

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -125,6 +125,13 @@ jobs:
         rd  $(Build.ArtifactStagingDirectory)\lib\x64
         rd $(Build.ArtifactStagingDirectory)\include\libinstpatch-2 /s /q
       displayName: 'Copy Artifacts'
+    - bash: |
+        if [ ! -f "libfluidsynth-3.dll" ]; then
+          echo "Fluidsynth library has unexpected filename!"
+          exit -1
+        fi
+      displayName: 'Validate library name'
+      workingDirectory: $(Build.ArtifactStagingDirectory)
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
@@ -298,6 +305,13 @@ jobs:
         del $(Build.ArtifactStagingDirectory)\lib\pkgconfig\libinstpatch*.pc
         rd $(Build.ArtifactStagingDirectory)\include\libinstpatch-2 /s /q
       displayName: 'Copy Artifacts'
+    - bash: |
+        if [ ! -f "libfluidsynth-3.dll" ]; then
+          echo "Fluidsynth library has unexpected filename!"
+          exit -1
+        fi
+      displayName: 'Validate library name'
+      workingDirectory: $(Build.ArtifactStagingDirectory)
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -126,13 +126,13 @@ jobs:
         rd $(Build.ArtifactStagingDirectory)\include\libinstpatch-2 /s /q
       displayName: 'Copy Artifacts'
     - bash: |
-        if [ ! -f "libfluidsynth-3.dll" ]; then
+        if [ ! -f "bin/libfluidsynth-3.dll" ] || [ ! -f "lib/libfluidsynth-3.lib" ]; then
           echo "Fluidsynth library has unexpected filename!"
-          ls -la
+          ls -la . bin lib
           exit -1
         fi
       displayName: 'Validate library name'
-      workingDirectory: $(Build.ArtifactStagingDirectory)\bin
+      workingDirectory: $(Build.ArtifactStagingDirectory)
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
@@ -307,14 +307,23 @@ jobs:
         rd $(Build.ArtifactStagingDirectory)\include\libinstpatch-2 /s /q
       displayName: 'Copy Artifacts'
     - bash: |
-        if [ ! -f "libfluidsynth-3.dll" ]; then
+        if [ ! -f "bin/libfluidsynth-3.dll" ] || [ ! -f "lib/libfluidsynth-3.dll.a" ]; then
           echo "Fluidsynth library has unexpected filename!"
-          ls -la
+          ls -la . bin lib
           exit -1
         fi
       displayName: 'Validate library name'
-      workingDirectory: $(Build.ArtifactStagingDirectory)\bin
+      workingDirectory: $(Build.ArtifactStagingDirectory)
       condition: and(succeeded(), not(contains(variables.artifactPrefix, 'static')))
+    - bash: |
+        if [ ! -f "lib/libfluidsynth-3.a" ]; then
+          echo "Fluidsynth static library has unexpected filename!"
+          ls -la . bin lib
+          exit -1
+        fi
+      displayName: 'Validate library name'
+      workingDirectory: $(Build.ArtifactStagingDirectory)
+      condition: and(succeeded(), contains(variables.artifactPrefix, 'static'))
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -128,10 +128,11 @@ jobs:
     - bash: |
         if [ ! -f "libfluidsynth-3.dll" ]; then
           echo "Fluidsynth library has unexpected filename!"
+          ls -la
           exit -1
         fi
       displayName: 'Validate library name'
-      workingDirectory: $(Build.ArtifactStagingDirectory)
+      workingDirectory: $(Build.ArtifactStagingDirectory)\bin
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
@@ -308,10 +309,11 @@ jobs:
     - bash: |
         if [ ! -f "libfluidsynth-3.dll" ]; then
           echo "Fluidsynth library has unexpected filename!"
+          ls -la
           exit -1
         fi
       displayName: 'Validate library name'
-      workingDirectory: $(Build.ArtifactStagingDirectory)
+      workingDirectory: $(Build.ArtifactStagingDirectory)\bin
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -64,6 +64,16 @@ jobs:
     - name: '${{ matrix.icon }} Install'
       run: cmake --install build && ls -la $INSTALL_LOCATION
 
+    - name:  ''
+      shell: bash
+      working-directory: ${{env.INSTALL_LOCATION}}
+      run: |
+        if [ ! -f "bin/libfluidsynth-3.dll" ] || [ ! -f "lib/libfluidsynth-3.dll.a" ]; then
+          echo "Fluidsynth library has unexpected filename!"
+          ls -la . bin lib
+          exit -1
+        fi
+
     - name: '${{ matrix.icon }} Upload Artifacts'
       uses: actions/upload-artifact@v4
       with:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,17 +323,10 @@ elseif ( WIN32 )
   set_target_properties ( libfluidsynth
     PROPERTIES
       PUBLIC_HEADER "${public_HEADERS}"
-      ARCHIVE_OUTPUT_NAME "libfluidsynth-${LIB_VERSION_CURRENT}"
-      OUTPUT_NAME "libfluidsynth-${LIB_VERSION_CURRENT}"
-	  # Do NOT use prefix!
-	  # PREFIX applies to
-	  # import lib + static lib of MinGW, and
-	  # the DLL itself obviously.
-	  # But it does not apply to the import lib MSVC!
-	  # In order to name everything "libfluidsynth" consistently, specify an empty prefix.
-	  # See #1546.
-      PREFIX ""
-      IMPORT_PREFIX ""
+      ARCHIVE_OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
+      OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
+      PREFIX "lib"
+      IMPORT_PREFIX "lib"
       VERSION ${LIB_VERSION_INFO}
       SOVERSION ${LIB_VERSION_CURRENT}
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,10 +323,10 @@ elseif ( WIN32 )
   set_target_properties ( libfluidsynth
     PROPERTIES
       PUBLIC_HEADER "${public_HEADERS}"
-      ARCHIVE_OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
-      OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
       PREFIX "lib"
+      OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
       IMPORT_PREFIX "lib"
+      ARCHIVE_OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
       VERSION ${LIB_VERSION_INFO}
       SOVERSION ${LIB_VERSION_CURRENT}
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -324,8 +324,15 @@ elseif ( WIN32 )
     PROPERTIES
       PUBLIC_HEADER "${public_HEADERS}"
       ARCHIVE_OUTPUT_NAME "libfluidsynth-${LIB_VERSION_CURRENT}"
-      PREFIX "lib"
-      OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
+      OUTPUT_NAME "libfluidsynth-${LIB_VERSION_CURRENT}"
+	  # Do NOT use prefix!
+	  # PREFIX applies to
+	  # import lib + static lib of MinGW, and
+	  # the DLL itself obviously.
+	  # But it does not apply to the import lib MSVC!
+	  # In order to name everything "libfluidsynth" consistently, specify an empty prefix.
+	  # See #1546.
+      PREFIX ""
       VERSION ${LIB_VERSION_INFO}
       SOVERSION ${LIB_VERSION_CURRENT}
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,6 +323,8 @@ elseif ( WIN32 )
   set_target_properties ( libfluidsynth
     PROPERTIES
       PUBLIC_HEADER "${public_HEADERS}"
+      ARCHIVE_OUTPUT_NAME "libfluidsynth-${LIB_VERSION_CURRENT}"
+      PREFIX "lib"
       OUTPUT_NAME "fluidsynth-${LIB_VERSION_CURRENT}"
       VERSION ${LIB_VERSION_INFO}
       SOVERSION ${LIB_VERSION_CURRENT}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -333,6 +333,7 @@ elseif ( WIN32 )
 	  # In order to name everything "libfluidsynth" consistently, specify an empty prefix.
 	  # See #1546.
       PREFIX ""
+      IMPORT_PREFIX ""
       VERSION ${LIB_VERSION_INFO}
       SOVERSION ${LIB_VERSION_CURRENT}
     )


### PR DESCRIPTION
This PR reverts an unintended change introduced by #1469. It also adds an extra check to the CI build to verify the filename of the DLL.

Fixes #1543.