### PR TITLE
Fix MIDI player skipping some events when seeking

### DIFF
--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -1575,7 +1575,10 @@ fluid_track_send_events(fluid_track_t *track,
     {
         ticks = seek_ticks; /* update target ticks */
 
-        if(track->ticks > ticks)
+        // the track ticks is beyound the current ticks,
+        // or if the track ticks is equal to the current ticks,
+        // we want to play all events from the beginning of that tick
+        if(track->ticks >= ticks)
         {
             fluid_track_reset(track);    /* reset track if seeking backwards */
         }


### PR DESCRIPTION
If the player has advanced to `N` ticks, and we're seeking to `N`, we need to reset the tracks, to ensure that all events due on `N` will be played again. Esp. audible when seeking to the beginning of a MIDI file, where tick zero may contain all bunch of initializing events, that previously would have been skipped.

Resolves #1532