### PR TITLE
Align structures for 64-bit platforms reduce cost move, copy, create objects

### DIFF
--- a/src/sfloader/fluid_samplecache.c
+++ b/src/sfloader/fluid_samplecache.c
@@ -48,9 +48,9 @@ struct _fluid_samplecache_entry_t
     int sample_type;
     /*  End of cache key members */
 
+    int sample_count;
     short *sample_data;
     char *sample_data24;
-    int sample_count;
 
     int num_references;
     int mlocked;

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -165,13 +165,13 @@ struct _fluid_sample_t
     unsigned int loopstart;       /**< Loop start index */
     unsigned int loopend;         /**< Loop end index, first point following the loop (superimposed on loopstart) */
 
+    short *data;                  /**< Pointer to the sample's 16 bit PCM data */
+    char *data24;                 /**< If not NULL, pointer to the least significant byte counterparts of each sample data point in order to create 24 bit audio samples */
     unsigned int samplerate;      /**< Sample rate */
     int origpitch;                /**< Original pitch (MIDI note number, 0-127) */
     int pitchadj;                 /**< Fine pitch adjustment (+/- 99 cents) */
     int sampletype;               /**< Specifies the type of this sample as indicated by the #fluid_sample_type enum */
     int auto_free;                /**< TRUE if _fluid_sample_t::data and _fluid_sample_t::data24 should be freed upon sample destruction */
-    short *data;                  /**< Pointer to the sample's 16 bit PCM data */
-    char *data24;                 /**< If not NULL, pointer to the least significant byte counterparts of each sample data point in order to create 24 bit audio samples */
 
     int amplitude_that_reaches_noise_floor_is_valid;      /**< Indicates if \a amplitude_that_reaches_noise_floor is valid (TRUE), set to FALSE initially to calculate. */
     double amplitude_that_reaches_noise_floor;            /**< The amplitude at which the sample's loop will be below the noise floor.  For voice off optimization, calculated automatically. */


### PR DESCRIPTION
@derselbst, hi. Thanks for huge contribution to open source development FluidSynth for Linux and others platforms.

## About PR changes:

Smaller size structure or class, higher chance putting into cpu cache.

Most processors are already 64 bit, so the change won't make it any worse.

More info about: https://stackoverflow.com/a/20882083

## Affected structs:

- _fluid_sample_t 128 to 120 bytes
- _fluid_samplecache_entry_t 80 to 72 bytes