### PR TITLE
Reduce structs sizes using scoped enums and strict types

### DIFF
--- a/include/fluidsynth/event.h
+++ b/include/fluidsynth/event.h
@@ -37,7 +37,7 @@ extern "C" {
 /**
  * Sequencer event type enumeration.
  */
-enum fluid_seq_event_type
+enum fluid_seq_event_type : unsigned char
 {
     FLUID_SEQ_NOTE = 0,		/**< Note event with duration */
     FLUID_SEQ_NOTEON,		/**< Note on event */
@@ -120,7 +120,7 @@ FLUIDSYNTH_API void fluid_event_scale(fluid_event_t *evt, double new_scale);
 FLUIDSYNTH_API int fluid_event_from_midi_event(fluid_event_t *, const fluid_midi_event_t *);
 
 /* Accessing event data */
-FLUIDSYNTH_API int fluid_event_get_type(fluid_event_t *evt);
+FLUIDSYNTH_API unsigned char fluid_event_get_type(fluid_event_t *evt);
 FLUIDSYNTH_API fluid_seq_id_t fluid_event_get_source(fluid_event_t *evt);
 FLUIDSYNTH_API fluid_seq_id_t fluid_event_get_dest(fluid_event_t *evt);
 FLUIDSYNTH_API int fluid_event_get_channel(fluid_event_t *evt);

--- a/include/fluidsynth/gen.h
+++ b/include/fluidsynth/gen.h
@@ -37,7 +37,7 @@ extern "C" {
 /**
  * Generator (effect) numbers (Soundfont 2.01 specifications section 8.1.3)
  */
-enum fluid_gen_type
+enum fluid_gen_type : unsigned char
 {
     GEN_STARTADDROFS,		/**< Sample start address offset (0-32767) */
     GEN_ENDADDROFS,		/**< Sample end address offset (-32767-0) */

--- a/include/fluidsynth/log.h
+++ b/include/fluidsynth/log.h
@@ -72,18 +72,18 @@ enum fluid_log_level : unsigned char
 /**
  * Log function handler callback type used by fluid_set_log_function().
  *
- * @param level Log level (#fluid_log_level)
+ * @param level Log level uchar (#fluid_log_level)
  * @param message Log message text
  * @param data User data pointer supplied to fluid_set_log_function().
  */
-typedef void (*fluid_log_function_t)(int level, const char *message, void *data);
+typedef void (*fluid_log_function_t)(unsigned char level, const char *message, void *data);
 
 FLUIDSYNTH_API
-fluid_log_function_t fluid_set_log_function(int level, fluid_log_function_t fun, void *data);
+fluid_log_function_t fluid_set_log_function(unsigned char level, fluid_log_function_t fun, void *data);
 
-FLUIDSYNTH_API void fluid_default_log_function(int level, const char *message, void *data);
+FLUIDSYNTH_API void fluid_default_log_function(unsigned char level, const char *message, void *data);
 
-FLUIDSYNTH_API int fluid_log(int level, const char *fmt, ...)
+FLUIDSYNTH_API int fluid_log(unsigned char level, const char *fmt, ...)
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
 __attribute__ ((format (printf, 2, 3)))
 #endif

--- a/include/fluidsynth/log.h
+++ b/include/fluidsynth/log.h
@@ -58,7 +58,7 @@ extern "C" {
 /**
  * FluidSynth log levels.
  */
-enum fluid_log_level
+enum fluid_log_level : unsigned char
 {
     FLUID_PANIC,   /**< The synth can't function correctly any more */
     FLUID_ERR,     /**< Serious error occurred */

--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -155,7 +155,7 @@ FLUIDSYNTH_API int fluid_midi_event_get_lyrics(fluid_midi_event_t *evt,
  *
  * @since 1.1.0
  */
-typedef enum
+typedef enum : unsigned char
 {
     FLUID_MIDI_ROUTER_RULE_NOTE,                  /**< MIDI note rule */
     FLUID_MIDI_ROUTER_RULE_CC,                    /**< MIDI controller rule */
@@ -242,7 +242,7 @@ FLUIDSYNTH_API void delete_fluid_midi_driver(fluid_midi_driver_t *driver);
  * MIDI File Player status enum.
  * @since 1.1.0
  */
-enum fluid_player_status
+enum fluid_player_status : unsigned char
 {
     FLUID_PLAYER_READY,           /**< Player is ready */
     FLUID_PLAYER_PLAYING,         /**< Player is currently playing */
@@ -254,7 +254,7 @@ enum fluid_player_status
  * MIDI File Player tempo enum.
  * @since 2.2.0
  */
-enum fluid_player_set_tempo_type
+enum fluid_player_set_tempo_type : unsigned char
 {
     FLUID_PLAYER_TEMPO_INTERNAL,      /**< Use midi file tempo set in midi file (120 bpm by default). Multiplied by a factor */
     FLUID_PLAYER_TEMPO_EXTERNAL_BPM,  /**< Set player tempo in bpm, supersede midi file tempo */

--- a/include/fluidsynth/midi.h
+++ b/include/fluidsynth/midi.h
@@ -273,13 +273,13 @@ FLUIDSYNTH_API int fluid_player_play(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_stop(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_join(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_set_loop(fluid_player_t *player, int loop);
-FLUIDSYNTH_API int fluid_player_set_tempo(fluid_player_t *player, int tempo_type, double tempo);
+FLUIDSYNTH_API int fluid_player_set_tempo(fluid_player_t *player, unsigned char tempo_type, double tempo);
 FLUID_DEPRECATED FLUIDSYNTH_API int fluid_player_set_midi_tempo(fluid_player_t *player, int tempo);
 FLUID_DEPRECATED FLUIDSYNTH_API int fluid_player_set_bpm(fluid_player_t *player, int bpm);
 FLUIDSYNTH_API int fluid_player_set_playback_callback(fluid_player_t *player, handle_midi_event_func_t handler, void *handler_data);
 FLUIDSYNTH_API int fluid_player_set_tick_callback(fluid_player_t *player, handle_midi_tick_func_t handler, void *handler_data);
 
-FLUIDSYNTH_API int fluid_player_get_status(fluid_player_t *player);
+FLUIDSYNTH_API unsigned char fluid_player_get_status(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_get_current_tick(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_get_total_ticks(fluid_player_t *player);
 FLUIDSYNTH_API int fluid_player_get_bpm(fluid_player_t *player);

--- a/include/fluidsynth/mod.h
+++ b/include/fluidsynth/mod.h
@@ -88,22 +88,22 @@ FLUIDSYNTH_API void delete_fluid_mod(fluid_mod_t *mod);
 
 FLUIDSYNTH_API size_t fluid_mod_sizeof(void);
 
-FLUIDSYNTH_API void fluid_mod_set_source1(fluid_mod_t *mod, int src, int flags);
-FLUIDSYNTH_API void fluid_mod_set_source2(fluid_mod_t *mod, int src, int flags);
+FLUIDSYNTH_API void fluid_mod_set_source1(fluid_mod_t *mod, unsigned char src, unsigned char flags);
+FLUIDSYNTH_API void fluid_mod_set_source2(fluid_mod_t *mod, unsigned char src, unsigned char flags);
 FLUIDSYNTH_API void fluid_mod_set_dest(fluid_mod_t *mod, unsigned char dst);
 FLUIDSYNTH_API void fluid_mod_set_amount(fluid_mod_t *mod, double amount);
-FLUIDSYNTH_API void fluid_mod_set_transform(fluid_mod_t *mod, int type);
+FLUIDSYNTH_API void fluid_mod_set_transform(fluid_mod_t *mod, unsigned char type);
 
-FLUIDSYNTH_API int fluid_mod_get_source1(const fluid_mod_t *mod);
+FLUIDSYNTH_API unsigned char fluid_mod_get_source1(const fluid_mod_t *mod);
 FLUIDSYNTH_API int fluid_mod_get_flags1(const fluid_mod_t *mod);
-FLUIDSYNTH_API int fluid_mod_get_source2(const fluid_mod_t *mod);
+FLUIDSYNTH_API unsigned char fluid_mod_get_source2(const fluid_mod_t *mod);
 FLUIDSYNTH_API int fluid_mod_get_flags2(const fluid_mod_t *mod);
 FLUIDSYNTH_API unsigned char fluid_mod_get_dest(const fluid_mod_t *mod);
 FLUIDSYNTH_API double fluid_mod_get_amount(const fluid_mod_t *mod);
-FLUIDSYNTH_API int fluid_mod_get_transform(fluid_mod_t *mod);
+FLUIDSYNTH_API unsigned char fluid_mod_get_transform(fluid_mod_t *mod);
 
 FLUIDSYNTH_API int fluid_mod_test_identity(const fluid_mod_t *mod1, const fluid_mod_t *mod2);
-FLUIDSYNTH_API int fluid_mod_has_source(const fluid_mod_t *mod, int cc, int ctrl);
+FLUIDSYNTH_API int fluid_mod_has_source(const fluid_mod_t *mod, int cc, unsigned char ctrl);
 FLUIDSYNTH_API int fluid_mod_has_dest(const fluid_mod_t *mod, unsigned char gen);
 
 FLUIDSYNTH_API void fluid_mod_clone(fluid_mod_t *mod, const fluid_mod_t *src);

--- a/include/fluidsynth/mod.h
+++ b/include/fluidsynth/mod.h
@@ -41,7 +41,7 @@ extern "C" {
  * Note: Bit values do not correspond to the SoundFont spec!  Also note that
  * #FLUID_MOD_GC and #FLUID_MOD_CC are in the flags field instead of the source field.
  */
-enum fluid_mod_flags
+enum fluid_mod_flags : unsigned char
 {
     FLUID_MOD_POSITIVE = 0,       /**< Mapping function is positive */
     FLUID_MOD_NEGATIVE = 1,       /**< Mapping function is negative */
@@ -60,7 +60,7 @@ enum fluid_mod_flags
 /**
  * Transform types for the SoundFont2 modulators as defined by SoundFont 2.04 section 8.3.
  */
-enum fluid_mod_transforms
+enum fluid_mod_transforms : unsigned char
 {
     FLUID_MOD_TRANSFORM_LINEAR = 0, /**< Linear: directly add the computed value to summing node */
     FLUID_MOD_TRANSFORM_ABS = 2     /**< Abs: add the absolute value of the computed to summing node */
@@ -70,7 +70,7 @@ enum fluid_mod_transforms
  * General controller (if #FLUID_MOD_GC in flags).  This
  * corresponds to SoundFont 2.04 PDF section 8.2.1
  */
-enum fluid_mod_src
+enum fluid_mod_src : unsigned char
 {
     FLUID_MOD_NONE = 0,                   /**< No source controller */
     FLUID_MOD_VELOCITY = 2,               /**< MIDI note-on velocity */
@@ -90,7 +90,7 @@ FLUIDSYNTH_API size_t fluid_mod_sizeof(void);
 
 FLUIDSYNTH_API void fluid_mod_set_source1(fluid_mod_t *mod, int src, int flags);
 FLUIDSYNTH_API void fluid_mod_set_source2(fluid_mod_t *mod, int src, int flags);
-FLUIDSYNTH_API void fluid_mod_set_dest(fluid_mod_t *mod, int dst);
+FLUIDSYNTH_API void fluid_mod_set_dest(fluid_mod_t *mod, unsigned char dst);
 FLUIDSYNTH_API void fluid_mod_set_amount(fluid_mod_t *mod, double amount);
 FLUIDSYNTH_API void fluid_mod_set_transform(fluid_mod_t *mod, int type);
 
@@ -98,13 +98,13 @@ FLUIDSYNTH_API int fluid_mod_get_source1(const fluid_mod_t *mod);
 FLUIDSYNTH_API int fluid_mod_get_flags1(const fluid_mod_t *mod);
 FLUIDSYNTH_API int fluid_mod_get_source2(const fluid_mod_t *mod);
 FLUIDSYNTH_API int fluid_mod_get_flags2(const fluid_mod_t *mod);
-FLUIDSYNTH_API int fluid_mod_get_dest(const fluid_mod_t *mod);
+FLUIDSYNTH_API unsigned char fluid_mod_get_dest(const fluid_mod_t *mod);
 FLUIDSYNTH_API double fluid_mod_get_amount(const fluid_mod_t *mod);
 FLUIDSYNTH_API int fluid_mod_get_transform(fluid_mod_t *mod);
 
 FLUIDSYNTH_API int fluid_mod_test_identity(const fluid_mod_t *mod1, const fluid_mod_t *mod2);
 FLUIDSYNTH_API int fluid_mod_has_source(const fluid_mod_t *mod, int cc, int ctrl);
-FLUIDSYNTH_API int fluid_mod_has_dest(const fluid_mod_t *mod, int gen);
+FLUIDSYNTH_API int fluid_mod_has_dest(const fluid_mod_t *mod, unsigned char gen);
 
 FLUIDSYNTH_API void fluid_mod_clone(fluid_mod_t *mod, const fluid_mod_t *src);
 /** @} */

--- a/include/fluidsynth/seq.h
+++ b/include/fluidsynth/seq.h
@@ -79,7 +79,7 @@ FLUIDSYNTH_API
 int fluid_sequencer_send_at(fluid_sequencer_t *seq, fluid_event_t *evt,
                             unsigned int time, int absolute);
 FLUIDSYNTH_API
-void fluid_sequencer_remove_events(fluid_sequencer_t *seq, fluid_seq_id_t source, fluid_seq_id_t dest, int type);
+void fluid_sequencer_remove_events(fluid_sequencer_t *seq, fluid_seq_id_t source, fluid_seq_id_t dest, unsigned char type);
 FLUIDSYNTH_API unsigned int fluid_sequencer_get_tick(fluid_sequencer_t *seq);
 FLUIDSYNTH_API void fluid_sequencer_set_time_scale(fluid_sequencer_t *seq, double scale);
 FLUIDSYNTH_API double fluid_sequencer_get_time_scale(fluid_sequencer_t *seq);

--- a/include/fluidsynth/settings.h
+++ b/include/fluidsynth/settings.h
@@ -108,7 +108,7 @@ FLUIDSYNTH_API void delete_fluid_settings(fluid_settings_t *settings);
 /** @endlifecycle */
 
 FLUIDSYNTH_API
-int fluid_settings_get_type(fluid_settings_t *settings, const char *name);
+short fluid_settings_get_type(fluid_settings_t *settings, const char *name);
 
 FLUIDSYNTH_API
 int fluid_settings_get_hints(fluid_settings_t *settings, const char *name, int *val);
@@ -181,9 +181,9 @@ FLUIDSYNTH_API char *fluid_settings_option_concat(fluid_settings_t *settings,
  *
  * @param data User defined data pointer
  * @param name Setting name
- * @param type Setting type (#fluid_types_enum)
+ * @param type Setting type short (#fluid_types_enum)
  */
-typedef void (*fluid_settings_foreach_t)(void *data, const char *name, int type);
+typedef void (*fluid_settings_foreach_t)(void *data, const char *name, short type);
 
 FLUIDSYNTH_API
 void fluid_settings_foreach(fluid_settings_t *settings, void *data,

--- a/include/fluidsynth/settings.h
+++ b/include/fluidsynth/settings.h
@@ -93,7 +93,7 @@ extern "C" {
  * set of values. The type of each setting can be retrieved using the
  * function fluid_settings_get_type()
  */
-enum fluid_types_enum
+enum fluid_types_enum : short
 {
     FLUID_NO_TYPE = -1, /**< Undefined type */
     FLUID_NUM_TYPE,     /**< Numeric (double) */

--- a/include/fluidsynth/sfont.h
+++ b/include/fluidsynth/sfont.h
@@ -92,7 +92,7 @@ enum
  * This enum corresponds to the \c SFSampleLink enum in the SoundFont spec.
  * One \c flag may be bit-wise OR-ed with one \c value.
  */
-enum fluid_sample_type
+enum fluid_sample_type : unsigned short
 {
     FLUID_SAMPLETYPE_MONO = 0x1, /**< Value used for mono samples */
     FLUID_SAMPLETYPE_RIGHT = 0x2, /**< Value used for right samples of a stereo pair */

--- a/include/fluidsynth/synth.h
+++ b/include/fluidsynth/synth.h
@@ -100,8 +100,8 @@ FLUIDSYNTH_API int fluid_synth_all_notes_off(fluid_synth_t *synth, int chan);
 FLUIDSYNTH_API int fluid_synth_all_sounds_off(fluid_synth_t *synth, int chan);
 
 FLUIDSYNTH_API int fluid_synth_set_gen(fluid_synth_t *synth, int chan,
-                                       int param, float value);
-FLUIDSYNTH_API float fluid_synth_get_gen(fluid_synth_t *synth, int chan, int param);
+                                       unsigned char param, float value);
+FLUIDSYNTH_API float fluid_synth_get_gen(fluid_synth_t *synth, int chan, unsigned char param);
 /** @} MIDI Channel Messages */
 
 
@@ -198,7 +198,7 @@ FLUIDSYNTH_API int fluid_synth_get_reverb_group_level(fluid_synth_t *synth, int 
 /**
  * Chorus modulation waveform type.
  */
-enum fluid_chorus_mod
+enum fluid_chorus_mod : unsigned char
 {
     FLUID_CHORUS_MOD_SINE = 0,            /**< Sine wave chorus modulation */
     FLUID_CHORUS_MOD_TRIANGLE = 1         /**< Triangle wave chorus modulation */
@@ -264,7 +264,7 @@ int fluid_synth_set_interp_method(fluid_synth_t *synth, int chan, int interp_met
 /**
  * Synthesis interpolation method.
  */
-enum fluid_interp
+enum fluid_interp : unsigned char
 {
     FLUID_INTERP_NONE = 0,        /**< No interpolation: Fastest, but questionable audio quality */
     FLUID_INTERP_LINEAR = 1,      /**< Straight-line interpolation: A bit slower, reasonable audio quality */
@@ -285,7 +285,7 @@ enum fluid_interp
 /**
  * Enum used with fluid_synth_add_default_mod() to specify how to handle duplicate modulators.
  */
-enum fluid_synth_add_mod
+enum fluid_synth_add_mod : unsigned char
 {
     FLUID_SYNTH_OVERWRITE,        /**< Overwrite any existing matching modulator */
     FLUID_SYNTH_ADD,              /**< Sum up modulator amounts */
@@ -379,7 +379,7 @@ FLUIDSYNTH_API int fluid_synth_process(fluid_synth_t *synth, int len,
 /**
  * Specifies the type of filter to use for the custom IIR filter
  */
-enum fluid_iir_filter_type
+enum fluid_iir_filter_type : unsigned char
 {
     FLUID_IIR_DISABLED = 0, /**< Custom IIR filter is not operating */
     FLUID_IIR_LOWPASS, /**< Custom IIR filter is operating as low-pass filter */
@@ -390,7 +390,7 @@ enum fluid_iir_filter_type
 /**
  * Specifies optional settings to use for the custom IIR filter. Can be bitwise ORed.
  */
-enum fluid_iir_filter_flags
+enum fluid_iir_filter_flags : unsigned char
 {
     FLUID_IIR_Q_LINEAR = 1 << 0, /**< The Soundfont spec requires the filter Q to be interpreted in dB. If this flag is set the filter Q is instead assumed to be in a linear range */
     FLUID_IIR_Q_ZERO_OFF = 1 << 1, /**< If this flag the filter is switched off if Q == 0 (prior to any transformation) */
@@ -420,7 +420,7 @@ FLUIDSYNTH_API int fluid_synth_set_custom_filter(fluid_synth_t *, int type, int 
 /**
  * The midi channel type used by fluid_synth_set_channel_type()
  */
-enum fluid_midi_channel_type
+enum fluid_midi_channel_type : unsigned char
 {
     CHANNEL_TYPE_MELODIC = 0, /**< Melodic midi channel */
     CHANNEL_TYPE_DRUM = 1 /**< Drum midi channel */
@@ -437,7 +437,7 @@ FLUIDSYNTH_API int fluid_synth_set_channel_type(fluid_synth_t *synth, int chan, 
 /**
  * Channel mode bits OR-ed together so that it matches with the midi spec: poly omnion (0), mono omnion (1), poly omnioff (2), mono omnioff (3)
  */
-enum fluid_channel_mode_flags
+enum fluid_channel_mode_flags : unsigned char
 {
     FLUID_CHANNEL_POLY_OFF = 0x01, /**< if flag is set, the basic channel is in mono on state, if not set poly is on */
     FLUID_CHANNEL_OMNI_OFF = 0x02, /**< if flag is set, the basic channel is in omni off state, if not set omni is on */
@@ -446,7 +446,7 @@ enum fluid_channel_mode_flags
 /**
  * Indicates the mode a basic channel is set to
  */
-enum fluid_basic_channel_modes
+enum fluid_basic_channel_modes : unsigned char
 {
     FLUID_CHANNEL_MODE_MASK = (FLUID_CHANNEL_OMNI_OFF | FLUID_CHANNEL_POLY_OFF), /**< Mask Poly and Omni bits of #fluid_channel_mode_flags, usually only used internally */
     FLUID_CHANNEL_MODE_OMNION_POLY = FLUID_CHANNEL_MODE_MASK & (~FLUID_CHANNEL_OMNI_OFF & ~FLUID_CHANNEL_POLY_OFF), /**< corresponds to MIDI mode 0 */
@@ -473,7 +473,7 @@ FLUIDSYNTH_API int fluid_synth_set_basic_channel(fluid_synth_t *synth, int chan,
 /**
  * Indicates the legato mode a channel is set to
  * n1,n2,n3,.. is a legato passage. n1 is the first note, and n2,n3,n4 are played legato with previous note. */
-enum fluid_channel_legato_mode
+enum fluid_channel_legato_mode : unsigned char
 {
     FLUID_CHANNEL_LEGATO_MODE_RETRIGGER, /**< Mode 0 - Release previous note, start a new note */
     FLUID_CHANNEL_LEGATO_MODE_MULTI_RETRIGGER, /**< Mode 1 - On contiguous notes retrigger in attack section using current value, shape attack using current dynamic and make use of previous voices if any */
@@ -491,7 +491,7 @@ FLUIDSYNTH_API int fluid_synth_get_legato_mode(fluid_synth_t *synth, int chan, i
 /**
  * Indicates the portamento mode a channel is set to
  */
-enum fluid_channel_portamento_mode
+enum fluid_channel_portamento_mode : unsigned char
 {
     FLUID_CHANNEL_PORTAMENTO_MODE_EACH_NOTE, /**< Mode 0 - Portamento on each note (staccato or legato) */
     FLUID_CHANNEL_PORTAMENTO_MODE_LEGATO_ONLY, /**< Mode 1 - Portamento only on legato note */
@@ -514,7 +514,7 @@ FLUIDSYNTH_API int fluid_synth_get_portamento_mode(fluid_synth_t *synth,
 /**
  * Indicates the breath mode a channel is set to
  */
-enum fluid_channel_breath_flags
+enum fluid_channel_breath_flags : unsigned char
 {
     FLUID_CHANNEL_BREATH_POLY = 0x10,  /**< when channel is poly, this flag indicates that the default velocity to initial attenuation modulator is replaced by a breath to initial attenuation modulator */
     FLUID_CHANNEL_BREATH_MONO = 0x20,  /**< when channel is mono, this flag indicates that the default velocity to initial attenuation modulator is replaced by a breath modulator */

--- a/include/fluidsynth/voice.h
+++ b/include/fluidsynth/voice.h
@@ -44,7 +44,7 @@ extern "C" {
 /**
  * Enum used with fluid_voice_add_mod() to specify how to handle duplicate modulators.
  */
-enum fluid_voice_add_mod
+enum fluid_voice_add_mod : unsigned char
 {
     FLUID_VOICE_OVERWRITE,        /**< Overwrite any existing matching modulator */
     FLUID_VOICE_ADD,              /**< Add (sum) modulator amounts */
@@ -52,9 +52,9 @@ enum fluid_voice_add_mod
 };
 
 FLUIDSYNTH_API void fluid_voice_add_mod(fluid_voice_t *voice, fluid_mod_t *mod, int mode);
-FLUIDSYNTH_API float fluid_voice_gen_get(fluid_voice_t *voice, int gen);
-FLUIDSYNTH_API void fluid_voice_gen_set(fluid_voice_t *voice, int gen, float val);
-FLUIDSYNTH_API void fluid_voice_gen_incr(fluid_voice_t *voice, int gen, float val);
+FLUIDSYNTH_API float fluid_voice_gen_get(fluid_voice_t *voice, unsigned char gen);
+FLUIDSYNTH_API void fluid_voice_gen_set(fluid_voice_t *voice, unsigned char gen, float val);
+FLUIDSYNTH_API void fluid_voice_gen_incr(fluid_voice_t *voice, unsigned char gen, float val);
 
 FLUIDSYNTH_API unsigned int fluid_voice_get_id(const fluid_voice_t *voice);
 FLUIDSYNTH_API int fluid_voice_get_channel(const fluid_voice_t *voice);

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -2157,7 +2157,7 @@ struct _fluid_handle_settings_data_t
     fluid_ostream_t out;
 };
 
-static void fluid_handle_settings_iter1(void *data, const char *name, int type)
+static void fluid_handle_settings_iter1(void *data, const char *name, short type)
 {
     struct _fluid_handle_settings_data_t *d = (struct _fluid_handle_settings_data_t *) data;
 
@@ -2169,7 +2169,7 @@ static void fluid_handle_settings_iter1(void *data, const char *name, int type)
     }
 }
 
-static void fluid_handle_settings_iter2(void *data, const char *name, int type)
+static void fluid_handle_settings_iter2(void *data, const char *name, short type)
 {
     struct _fluid_handle_settings_data_t *d = (struct _fluid_handle_settings_data_t *) data;
 

--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -44,7 +44,7 @@ struct _fluid_cmd_handler_t
     fluid_cmd_hash_t *commands;
 
     fluid_midi_router_rule_t *cmd_rule;        /* Rule currently being processed by shell command handler */
-    int cmd_rule_type;                         /* Type of the rule (#fluid_midi_router_rule_type) */
+    unsigned char cmd_rule_type;                         /* Type of the rule (#fluid_midi_router_rule_type) */
 };
 
 
@@ -1350,7 +1350,7 @@ fluid_handle_reverbsetlevel(void *data, int ac, char **av, fluid_ostream_t out)
 }
 
 /* reverb/chorus on/off commands enum */
-enum rev_chor_on_cde
+enum rev_chor_on_cde : unsigned char
 {
     REVERB_ON_CDE,
     CHORUS_ON_CDE,

--- a/src/bindings/fluid_ladspa.c
+++ b/src/bindings/fluid_ladspa.c
@@ -34,7 +34,7 @@
 #include <ladspa.h>
 
 
-typedef enum _fluid_ladspa_state_t
+typedef enum _fluid_ladspa_state_t : unsigned char
 {
     FLUID_LADSPA_INACTIVE = 0,
     FLUID_LADSPA_ACTIVE,
@@ -42,14 +42,14 @@ typedef enum _fluid_ladspa_state_t
 
 } fluid_ladspa_state_t;
 
-typedef enum _fluid_ladspa_dir_t
+typedef enum _fluid_ladspa_dir_t : unsigned char
 {
     FLUID_LADSPA_INPUT,
     FLUID_LADSPA_OUTPUT,
 
 } fluid_ladspa_dir_t;
 
-typedef enum _fluid_ladspa_node_type_t
+typedef enum _fluid_ladspa_node_type_t : unsigned char
 {
     FLUID_LADSPA_NODE_AUDIO = 1,
     FLUID_LADSPA_NODE_CONTROL = 2,
@@ -62,7 +62,7 @@ typedef enum _fluid_ladspa_node_type_t
 typedef struct _fluid_ladspa_node_t
 {
     char *name;
-    fluid_ladspa_node_type_t type;
+    unsigned char type; /* Type of the node (#fluid_ladspa_node_type_t) */
 
     /* The buffer that LADSPA effects read and/or write to.
      * If FluidSynth has been compiled WITH_FLOAT, then this

--- a/src/fluidsynth.c
+++ b/src/fluidsynth.c
@@ -187,7 +187,7 @@ settings_option_foreach_func(void *data, const char *name, const char *option)
 
 /* fluid_settings_foreach function for displaying option help  "-o help" */
 static void
-settings_foreach_func(void *data, const char *name, int type)
+settings_foreach_func(void *data, const char *name, short type)
 {
     fluid_settings_t *settings = (fluid_settings_t *)data;
     double dmin, dmax, ddef;

--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2337,13 +2337,13 @@ fluid_player_stop(fluid_player_t *player)
 /**
  * Get MIDI player status.
  * @param player MIDI player instance
- * @return Player status (#fluid_player_status)
+ * @return Player status uchar (#fluid_player_status)
  * @since 1.1.0
  */
-int
+unsigned char
 fluid_player_get_status(fluid_player_t *player)
 {
-    return fluid_atomic_int_get(&player->status);
+    return player->status; // needs fluid_atomic_int_get with uchar ???
 }
 
 /**
@@ -2459,7 +2459,7 @@ static void fluid_player_update_tempo(fluid_player_t *player)
  * per quarter note.
  *
  * @param player MIDI player instance. Must be a valid pointer.
- * @param tempo_type Must a be value of #fluid_player_set_tempo_type and indicates the
+ * @param tempo_type Must a be value of uchar (#fluid_player_set_tempo_type) and indicates the
  *  meaning of tempo value and how the player will be controlled, see below.
  * @param tempo Tempo value or multiplier.
  * 
@@ -2496,7 +2496,7 @@ static void fluid_player_update_tempo(fluid_player_t *player)
  * @return #FLUID_OK if success or #FLUID_FAILED otherwise (incorrect parameters).
  * @since 2.2.0
  */
-int fluid_player_set_tempo(fluid_player_t *player, int tempo_type, double tempo)
+int fluid_player_set_tempo(fluid_player_t *player, unsigned char tempo_type, double tempo)
 {
     fluid_return_val_if_fail(player != NULL, FLUID_FAILED);
     fluid_return_val_if_fail(tempo_type >= FLUID_PLAYER_TEMPO_INTERNAL, FLUID_FAILED);

--- a/src/midi/fluid_midi.h
+++ b/src/midi/fluid_midi.h
@@ -285,7 +285,7 @@ typedef struct
  */
 struct _fluid_player_t
 {
-    fluid_atomic_int_t status;
+    unsigned char status; /* Type of the status uchar (#fluid_player_status) */
     fluid_atomic_int_t stopping; /* Flag for sending all_notes_off when player is stopped */
     int ntracks;
     fluid_track_t *track[MAX_NUMBER_OF_TRACKS];

--- a/src/midi/fluid_midi.h
+++ b/src/midi/fluid_midi.h
@@ -41,7 +41,7 @@ fluid_midi_event_t *fluid_midi_parser_parse(fluid_midi_parser_t *parser, unsigne
 #define MAX_NUMBER_OF_TRACKS 128
 #define MAX_NUMBER_OF_CHANNELS 16
 
-enum fluid_midi_event_type
+enum fluid_midi_event_type : unsigned char
 {
     /* channel messages */
     NOTE_OFF = 0x80,
@@ -71,7 +71,7 @@ enum fluid_midi_event_type
     MIDI_META_EVENT = 0xff
 };
 
-enum fluid_midi_control_change
+enum fluid_midi_control_change : unsigned char
 {
     BANK_SELECT_MSB = 0x00,
     MODULATION_MSB = 0x01,
@@ -148,7 +148,7 @@ enum fluid_midi_control_change
 };
 
 /* General MIDI RPN event numbers (LSB, MSB = 0) */
-enum midi_rpn_event
+enum midi_rpn_event : unsigned char
 {
     RPN_PITCH_BEND_RANGE = 0x00,
     RPN_CHANNEL_FINE_TUNE = 0x01,
@@ -158,7 +158,7 @@ enum midi_rpn_event
     RPN_MODULATION_DEPTH_RANGE = 0x05
 };
 
-enum midi_meta_event
+enum midi_meta_event : unsigned char
 {
     MIDI_TEXT = 0x01,
     MIDI_COPYRIGHT = 0x02,
@@ -176,7 +176,7 @@ enum midi_meta_event
 };
 
 /* MIDI SYSEX useful manufacturer values */
-enum midi_sysex_manuf
+enum midi_sysex_manuf : unsigned char
 {
     MIDI_SYSEX_MANUF_ROLAND       = 0x41,         /**< Roland manufacturer ID */
     MIDI_SYSEX_MANUF_YAMAHA       = 0x43,
@@ -195,7 +195,7 @@ enum midi_sysex_manuf
 /**
  * SYSEX tuning message IDs.
  */
-enum midi_sysex_tuning_msg_id
+enum midi_sysex_tuning_msg_id : unsigned char
 {
     MIDI_SYSEX_TUNING_BULK_DUMP_REQ       = 0x00, /**< Bulk tuning dump request (non-realtime) */
     MIDI_SYSEX_TUNING_BULK_DUMP           = 0x01, /**< Bulk tuning dump response (non-realtime) */
@@ -215,7 +215,7 @@ enum midi_sysex_tuning_msg_id
 #define MIDI_SYSEX_GM2_ON               0x03    /**< Enable GM2 mode */
 #define MIDI_SYSEX_GS_DT1               0x12    /**< GS DT1 command */
 
-enum fluid_driver_status
+enum fluid_driver_status : unsigned char
 {
     FLUID_MIDI_READY,
     FLUID_MIDI_LISTENING,

--- a/src/midi/fluid_seq.c
+++ b/src/midi/fluid_seq.c
@@ -504,11 +504,11 @@ fluid_sequencer_send_at(fluid_sequencer_t *seq, fluid_event_t *evt,
  * @param seq Sequencer object
  * @param source Source client ID to match or -1 for wildcard
  * @param dest Destination client ID to match or -1 for wildcard
- * @param type Event type to match or -1 for wildcard (#fluid_seq_event_type)
+ * @param type Event type to match or -1 for wildcard uchar (#fluid_seq_event_type)
  */
 void
 fluid_sequencer_remove_events(fluid_sequencer_t *seq, fluid_seq_id_t source,
-                              fluid_seq_id_t dest, int type)
+                              fluid_seq_id_t dest, unsigned char type)
 {
     fluid_return_if_fail(seq != NULL);
 

--- a/src/rvoice/fluid_adsr_env.h
+++ b/src/rvoice/fluid_adsr_env.h
@@ -40,7 +40,7 @@ struct _fluid_env_data_t
 };
 
 /* Indices for envelope tables */
-enum fluid_voice_envelope_index
+enum fluid_voice_envelope_index : unsigned char
 {
     FLUID_VOICE_ENVDELAY=0,
     FLUID_VOICE_ENVATTACK,

--- a/src/rvoice/fluid_chorus.c
+++ b/src/rvoice/fluid_chorus.c
@@ -707,7 +707,7 @@ fluid_chorus_reset(fluid_chorus_t *chorus)
  * Set one or more chorus parameters.
  *
  * @param chorus Chorus instance.
- * @param set Flags indicating which chorus parameters to set (#fluid_chorus_set_t).
+ * @param set Flags indicating which chorus parameters to set uchar (#fluid_chorus_set_t).
  * @param nr Chorus voice count (0-99, CPU time consumption proportional to
  *   this value).
  * @param level Chorus level (0.0-10.0).
@@ -717,7 +717,7 @@ fluid_chorus_reset(fluid_chorus_t *chorus)
  * @param type Chorus waveform type (#fluid_chorus_mod).
  */
 void
-fluid_chorus_set(fluid_chorus_t *chorus, int set, int nr, fluid_real_t level,
+fluid_chorus_set(fluid_chorus_t *chorus, unsigned char set, int nr, fluid_real_t level,
                  fluid_real_t speed, fluid_real_t depth_ms, int type)
 {
     if(set & FLUID_CHORUS_SET_NR) /* number of block */

--- a/src/rvoice/fluid_chorus.h
+++ b/src/rvoice/fluid_chorus.h
@@ -28,7 +28,7 @@
 typedef struct _fluid_chorus_t fluid_chorus_t;
 
 /* enum describing each chorus parameter */
-enum fluid_chorus_param
+enum fluid_chorus_param : unsigned char
 {
     FLUID_CHORUS_NR,        /**< number of delay line */
     FLUID_CHORUS_LEVEL,     /**< output level */
@@ -42,7 +42,7 @@ enum fluid_chorus_param
 #define FLUID_CHORPARAM_TO_SETFLAG(param) (1 << param)
 
 /** Flags for fluid_chorus_set() */
-typedef enum
+typedef enum : unsigned char
 {
     FLUID_CHORUS_SET_NR    = FLUID_CHORPARAM_TO_SETFLAG(FLUID_CHORUS_NR),
     FLUID_CHORUS_SET_LEVEL = FLUID_CHORPARAM_TO_SETFLAG(FLUID_CHORUS_LEVEL),
@@ -65,7 +65,7 @@ fluid_chorus_t *new_fluid_chorus(fluid_real_t sample_rate);
 void delete_fluid_chorus(fluid_chorus_t *chorus);
 void fluid_chorus_reset(fluid_chorus_t *chorus);
 
-void fluid_chorus_set(fluid_chorus_t *chorus, int set, int nr, fluid_real_t level,
+void fluid_chorus_set(fluid_chorus_t *chorus, unsigned char set, int nr, fluid_real_t level,
                       fluid_real_t speed, fluid_real_t depth_ms, int type);
 void
 fluid_chorus_samplerate_change(fluid_chorus_t *chorus, fluid_real_t sample_rate);

--- a/src/rvoice/fluid_rev.c
+++ b/src/rvoice/fluid_rev.c
@@ -1162,7 +1162,7 @@ delete_fluid_revmodel(fluid_revmodel_t *rev)
 * fluid_revmodel_set().
 *
 * @param rev Reverb instance.
-* @param set One or more flags from #fluid_revmodel_set_t indicating what
+* @param set One or more flags from uchar (#fluid_revmodel_set_t) indicating what
 *   parameters to set (#FLUID_REVMODEL_SET_ALL to set all parameters).
 * @param roomsize Reverb room size.
 * @param damping Reverb damping.
@@ -1172,7 +1172,7 @@ delete_fluid_revmodel(fluid_revmodel_t *rev)
 * Reverb API.
 */
 void
-fluid_revmodel_set(fluid_revmodel_t *rev, int set, fluid_real_t roomsize,
+fluid_revmodel_set(fluid_revmodel_t *rev, unsigned char set, fluid_real_t roomsize,
                    fluid_real_t damping, fluid_real_t width, fluid_real_t level)
 {
     fluid_return_if_fail(rev != NULL);

--- a/src/rvoice/fluid_rev.h
+++ b/src/rvoice/fluid_rev.h
@@ -27,7 +27,7 @@
 typedef struct _fluid_revmodel_t fluid_revmodel_t;
 
 /* enum describing each reverb parameter */
-enum fluid_reverb_param
+enum fluid_reverb_param : unsigned char
 {
     FLUID_REVERB_ROOMSIZE,  /**< reverb time */
     FLUID_REVERB_DAMP,      /**< high frequency damping */
@@ -40,7 +40,7 @@ enum fluid_reverb_param
 #define FLUID_REVPARAM_TO_SETFLAG(param) (1 << param)
 
 /** Flags for fluid_revmodel_set() */
-typedef enum
+typedef enum : unsigned char
 {
     FLUID_REVMODEL_SET_ROOMSIZE       = FLUID_REVPARAM_TO_SETFLAG(FLUID_REVERB_ROOMSIZE),
     FLUID_REVMODEL_SET_DAMPING        = FLUID_REVPARAM_TO_SETFLAG(FLUID_REVERB_DAMP),
@@ -83,7 +83,7 @@ void fluid_revmodel_processreplace(fluid_revmodel_t *rev, const fluid_real_t *in
 
 void fluid_revmodel_reset(fluid_revmodel_t *rev);
 
-void fluid_revmodel_set(fluid_revmodel_t *rev, int set, fluid_real_t roomsize,
+void fluid_revmodel_set(fluid_revmodel_t *rev, unsigned char set, fluid_real_t roomsize,
                         fluid_real_t damping, fluid_real_t width, fluid_real_t level);
 
 int fluid_revmodel_samplerate_change(fluid_revmodel_t *rev, fluid_real_t sample_rate);

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -44,7 +44,7 @@ typedef struct _fluid_rvoice_t fluid_rvoice_t;
  */
 #define FLUID_NOISE_FLOOR ((fluid_real_t)2.e-7)
 
-enum fluid_loop
+enum fluid_loop : unsigned char
 {
     FLUID_UNLOOPED = 0,
     FLUID_LOOP_DURING_RELEASE = 1,

--- a/src/rvoice/fluid_rvoice_mixer.c
+++ b/src/rvoice/fluid_rvoice_mixer.c
@@ -995,12 +995,12 @@ void fluid_rvoice_mixer_set_ladspa(fluid_rvoice_mixer_t *mixer,
  * @param fx_group index of the fx group to which parameters must be set.
  *  must be in the range [-1..mixer->fx_units[. If -1 the changes are applied to
  *  all fx units.
- * @param set Flags indicating which parameters should be set (#fluid_revmodel_set_t)
+ * @param set Flags indicating which parameters should be set uchar (#fluid_revmodel_set_t)
  * @param values table of parameters values.
  */
 void
 fluid_rvoice_mixer_set_reverb_full(const fluid_rvoice_mixer_t *mixer,
-                                   int fx_group, int set, const double values[])
+                                   int fx_group, unsigned char set, const double values[])
 {
     fluid_mixer_fx_t *fx = mixer->fx;
     int nr_units = mixer->fx_units;
@@ -1059,12 +1059,12 @@ fluid_rvoice_mixer_reverb_get_param(const fluid_rvoice_mixer_t *mixer,
  *  must be in the range [-1..mixer->fx_units[. If -1 the changes are applied
  *  to all fx group.
  * Keep in mind, that the needed CPU time is proportional to 'nr'.
- * @param set Flags indicating which parameters to set (#fluid_chorus_set_t)
+ * @param set Flags indicating which parameters to set uchar (#fluid_chorus_set_t)
  * @param values table of pararameters.
  */
 void
 fluid_rvoice_mixer_set_chorus_full(const fluid_rvoice_mixer_t *mixer,
-                                   int fx_group, int set, const double values[])
+                                   int fx_group, unsigned char set, const double values[])
 {
     fluid_mixer_fx_t *fx = mixer->fx;
     int nr_units = mixer->fx_units;
@@ -1099,7 +1099,7 @@ fluid_rvoice_mixer_set_chorus_full(const fluid_rvoice_mixer_t *mixer,
  * @param mixer that contains all fx groups units.
  * @param fx_group index of the fx group to get parameter from.
  *  must be in the range [0..mixer->fx_units[.
- * @param get Flags indicating which parameter to get (#fluid_chorus_set_t)
+ * @param get Flags indicating which parameter to get uchar (#fluid_chorus_set_t)
  * @return the parameter value (0.0 is returned if error)
  */
 double

--- a/src/rvoice/fluid_rvoice_mixer.h
+++ b/src/rvoice/fluid_rvoice_mixer.h
@@ -45,14 +45,14 @@ void delete_fluid_rvoice_mixer(fluid_rvoice_mixer_t *);
 
 void
 fluid_rvoice_mixer_set_reverb_full(const fluid_rvoice_mixer_t *mixer,
-                                   int fx_group, int set, const double values[]);
+                                   int fx_group, unsigned char set, const double values[]);
 
 double
 fluid_rvoice_mixer_reverb_get_param(const fluid_rvoice_mixer_t *mixer,
                                     int fx_group, int param);
 void
 fluid_rvoice_mixer_set_chorus_full(const fluid_rvoice_mixer_t *mixer,
-                                   int fx_group, int set, const double values[]);
+                                   int fx_group, unsigned char set, const double values[]);
 double
 fluid_rvoice_mixer_chorus_get_param(const fluid_rvoice_mixer_t *mixer,
                                     int fx_group, int param);

--- a/src/sfloader/fluid_samplecache.c
+++ b/src/sfloader/fluid_samplecache.c
@@ -48,9 +48,9 @@ struct _fluid_samplecache_entry_t
     int sample_type;
     /*  End of cache key members */
 
+    int sample_count;
     short *sample_data;
     char *sample_data24;
-    int sample_count;
 
     int num_references;
     int mlocked;

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -165,13 +165,13 @@ struct _fluid_sample_t
     unsigned int loopstart;       /**< Loop start index */
     unsigned int loopend;         /**< Loop end index, first point following the loop (superimposed on loopstart) */
 
+    short *data;                  /**< Pointer to the sample's 16 bit PCM data */
+    char *data24;                 /**< If not NULL, pointer to the least significant byte counterparts of each sample data point in order to create 24 bit audio samples */
     unsigned int samplerate;      /**< Sample rate */
     int origpitch;                /**< Original pitch (MIDI note number, 0-127) */
     int pitchadj;                 /**< Fine pitch adjustment (+/- 99 cents) */
     int sampletype;               /**< Specifies the type of this sample as indicated by the #fluid_sample_type enum */
     int auto_free;                /**< TRUE if _fluid_sample_t::data and _fluid_sample_t::data24 should be freed upon sample destruction */
-    short *data;                  /**< Pointer to the sample's 16 bit PCM data */
-    char *data24;                 /**< If not NULL, pointer to the least significant byte counterparts of each sample data point in order to create 24 bit audio samples */
 
     int amplitude_that_reaches_noise_floor_is_valid;      /**< Indicates if \a amplitude_that_reaches_noise_floor is valid (TRUE), set to FALSE initially to calculate. */
     double amplitude_that_reaches_noise_floor;            /**< The amplitude at which the sample's loop will be below the noise floor.  For voice off optimization, calculated automatically. */

--- a/src/synth/fluid_chan.h
+++ b/src/synth/fluid_chan.h
@@ -122,7 +122,7 @@ struct _fluid_channel_t
     int sfont_bank_prog;                  /**< SoundFont ID (bit 21-31), bank (bit 7-20), program (bit 0-6) */
 
     /* NRPN system */
-    enum fluid_gen_type nrpn_select;      /* Generator ID of SoundFont NRPN message */
+    unsigned char nrpn_select;      /* Generator ID of SoundFont NRPN message */
     char nrpn_active;      /* 1 if data entry CCs are for NRPN, 0 if RPN */
     
     /* The values of the generators, set by NRPN messages, or by
@@ -248,7 +248,7 @@ fluid_real_t fluid_channel_get_key_pitch(fluid_channel_t *chan, int key);
 #define fluid_channel_prev_note(chan)	(chan->prev_note)
 
 /* Interface to poly/mono mode variables */
-enum fluid_channel_mode_flags_internal
+enum fluid_channel_mode_flags_internal : unsigned char
 {
     FLUID_CHANNEL_BASIC = 0x04,    /**< if flag set the corresponding midi channel is a basic channel */
     FLUID_CHANNEL_ENABLED = 0x08,  /**< if flag set the corresponding midi channel is enabled, else disabled, i.e. channel ignores any MIDI messages */

--- a/src/synth/fluid_event.c
+++ b/src/synth/fluid_event.c
@@ -666,11 +666,11 @@ int fluid_event_from_midi_event(fluid_event_t *evt, const fluid_midi_event_t *ev
  */
 
 /**
- * Get the event type (#fluid_seq_event_type) field from a sequencer event structure.
+ * Get the event type uchar (#fluid_seq_event_type) field from a sequencer event structure.
  * @param evt Sequencer event structure
- * @return Event type (#fluid_seq_event_type).
+ * @return Event type uchar (#fluid_seq_event_type).
  */
-int fluid_event_get_type(fluid_event_t *evt)
+unsigned char fluid_event_get_type(fluid_event_t *evt)
 {
     return evt->type;
 }

--- a/src/synth/fluid_event.h
+++ b/src/synth/fluid_event.h
@@ -35,7 +35,7 @@ typedef int fluid_note_id_t;
 struct _fluid_event_t
 {
     unsigned int time;
-    int type;
+    unsigned char type;
     fluid_seq_id_t src;
     fluid_seq_id_t dest;
     int channel;

--- a/src/synth/fluid_gen.h
+++ b/src/synth/fluid_gen.h
@@ -49,7 +49,7 @@ typedef struct _fluid_gen_t
 /*
  * Enum value for 'flags' field of #fluid_gen_t (not really flags).
  */
-enum fluid_gen_flags
+enum fluid_gen_flags : unsigned char
 {
     GEN_UNUSED,		/**< Generator value is not set */
     GEN_SET,		/**< Generator value is set */

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -78,10 +78,10 @@ fluid_mod_set_source2(fluid_mod_t *mod, int src, int flags)
  * Set the destination effect of a modulator.
  *
  * @param mod The modulator instance
- * @param dest Destination generator (#fluid_gen_type)
+ * @param dest Destination generator uchar (#fluid_gen_type)
  */
 void
-fluid_mod_set_dest(fluid_mod_t *mod, int dest)
+fluid_mod_set_dest(fluid_mod_t *mod, unsigned char dest)
 {
     mod->dest = dest;
 }
@@ -168,9 +168,9 @@ fluid_mod_get_flags2(const fluid_mod_t *mod)
  * Get destination effect from a modulator.
  *
  * @param mod The modulator instance
- * @return Destination generator (#fluid_gen_type)
+ * @return Destination generator uchar (#fluid_gen_type)
  */
-int
+unsigned char
 fluid_mod_get_dest(const fluid_mod_t *mod)
 {
     return mod->dest;
@@ -745,10 +745,10 @@ int fluid_mod_has_source(const fluid_mod_t *mod, int cc, int ctrl)
  * Check if the modulator has the given destination.
  *
  * @param mod The modulator instance
- * @param gen The destination generator of type #fluid_gen_type to check for
+ * @param gen The destination generator of type uchar (#fluid_gen_type) to check for
  * @return TRUE if the modulator has the given destination, FALSE otherwise.
  */
-int fluid_mod_has_dest(const fluid_mod_t *mod, int gen)
+int fluid_mod_has_dest(const fluid_mod_t *mod, unsigned char gen)
 {
     return mod->dest == gen;
 }

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -46,13 +46,13 @@ fluid_mod_clone(fluid_mod_t *mod, const fluid_mod_t *src)
  * Set a modulator's primary source controller and flags.
  *
  * @param mod The modulator instance
- * @param src Modulator source (#fluid_mod_src or a MIDI controller number)
+ * @param src Modulator source uchar (#fluid_mod_src or a MIDI controller number)
  * @param flags Flags determining mapping function and whether the source
  *   controller is a general controller (#FLUID_MOD_GC) or a MIDI CC controller
- *   (#FLUID_MOD_CC), see #fluid_mod_flags.
+ *   (#FLUID_MOD_CC), see uchar (#fluid_mod_flags).
  */
 void
-fluid_mod_set_source1(fluid_mod_t *mod, int src, int flags)
+fluid_mod_set_source1(fluid_mod_t *mod, unsigned char src, unsigned char flags)
 {
     mod->src1 = src;
     mod->flags1 = flags;
@@ -62,13 +62,13 @@ fluid_mod_set_source1(fluid_mod_t *mod, int src, int flags)
  * Set a modulator's secondary source controller and flags.
  *
  * @param mod The modulator instance
- * @param src Modulator source (#fluid_mod_src or a MIDI controller number)
+ * @param src Modulator source uchar (#fluid_mod_src or a MIDI controller number)
  * @param flags Flags determining mapping function and whether the source
  *   controller is a general controller (#FLUID_MOD_GC) or a MIDI CC controller
- *   (#FLUID_MOD_CC), see #fluid_mod_flags.
+ *   (#FLUID_MOD_CC), see uchar (#fluid_mod_flags).
  */
 void
-fluid_mod_set_source2(fluid_mod_t *mod, int src, int flags)
+fluid_mod_set_source2(fluid_mod_t *mod, unsigned char src, unsigned char flags)
 {
     mod->src2 = src;
     mod->flags2 = flags;
@@ -102,12 +102,12 @@ fluid_mod_set_amount(fluid_mod_t *mod, double amount)
  * Set the transform type of a modulator.
  *
  * @param mod The modulator instance
- * @param type Transform type, see #fluid_mod_transforms
+ * @param type Transform type, see uchar (#fluid_mod_transforms)
  */
 void
-fluid_mod_set_transform(fluid_mod_t *mod, int type)
+fluid_mod_set_transform(fluid_mod_t *mod, unsigned char type)
 {
-    unsigned char flag = (unsigned char) type;
+    unsigned char flag = type;
     if(flag != FLUID_MOD_TRANSFORM_LINEAR && flag != FLUID_MOD_TRANSFORM_ABS)
     {
         FLUID_LOG(FLUID_ERR, "fluid_mod_set_transform() called with invalid transform type %d", type);
@@ -120,9 +120,9 @@ fluid_mod_set_transform(fluid_mod_t *mod, int type)
  * Get the primary source value from a modulator.
  *
  * @param mod The modulator instance
- * @return The primary source value (#fluid_mod_src or a MIDI CC controller value).
+ * @return The primary source value uchar (#fluid_mod_src or a MIDI CC controller value).
  */
-int
+unsigned char
 fluid_mod_get_source1(const fluid_mod_t *mod)
 {
     return mod->src1;
@@ -144,9 +144,9 @@ fluid_mod_get_flags1(const fluid_mod_t *mod)
  * Get the secondary source value from a modulator.
  *
  * @param mod The modulator instance
- * @return The secondary source value (#fluid_mod_src or a MIDI CC controller value).
+ * @return The secondary source value uchar (#fluid_mod_src or a MIDI CC controller value).
  */
-int
+unsigned char
 fluid_mod_get_source2(const fluid_mod_t *mod)
 {
     return mod->src2;
@@ -192,12 +192,12 @@ fluid_mod_get_amount(const fluid_mod_t *mod)
  * Get the transform type of a modulator.
  *
  * @param mod The modulator instance
- * @param type Transform type, see #fluid_mod_transforms
+ * @param type Transform type, see uchar (#fluid_mod_transforms)
  */
-int
+unsigned char
 fluid_mod_get_transform(fluid_mod_t *mod)
 {
-    return (int) mod->trans;
+    return mod->trans;
 }
 
 /*
@@ -721,11 +721,11 @@ fluid_mod_test_identity(const fluid_mod_t *mod1, const fluid_mod_t *mod2)
  *
  * @param mod The modulator instance
  * @param cc Boolean value indicating if ctrl is a CC controller or not
- * @param ctrl The source to check for (if \c cc == FALSE : a value of type #fluid_mod_src, else the value of the MIDI CC to check for)
+ * @param ctrl The source to check for (if \c cc == FALSE : a value of type uchar (#fluid_mod_src), else the value of the MIDI CC to check for)
  *
  * @return TRUE if the modulator has the given source, FALSE otherwise.
  */
-int fluid_mod_has_source(const fluid_mod_t *mod, int cc, int ctrl)
+int fluid_mod_has_source(const fluid_mod_t *mod, int cc, unsigned char ctrl)
 {
     return
         (

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -7602,11 +7602,11 @@ fluid_synth_get_settings(fluid_synth_t *synth)
  * generator parameters and valid ranges, as well as paragraph 9.6 for details on NRPN messages.
  * @param synth FluidSynth instance
  * @param chan MIDI channel number (0 to MIDI channel count - 1)
- * @param param SoundFont generator ID (#fluid_gen_type)
+ * @param param SoundFont generator ID uchar (#fluid_gen_type)
  * @param value Offset value (in native units of the generator) to assign to the MIDI channel
  * @return #FLUID_OK on success, #FLUID_FAILED otherwise
  */
-int fluid_synth_set_gen(fluid_synth_t *synth, int chan, int param, float value)
+int fluid_synth_set_gen(fluid_synth_t *synth, int chan, unsigned char param, float value)
 {
     fluid_return_val_if_fail(param >= 0 && param < GEN_LAST, FLUID_FAILED);
     FLUID_API_ENTRY_CHAN(FLUID_FAILED);
@@ -7835,11 +7835,11 @@ static void fluid_synth_process_awe32_nrpn_LOCAL(fluid_synth_t *synth, int chan,
  * The value returned is in native units of the generator. By default, the offset is zero.
  * @param synth FluidSynth instance
  * @param chan MIDI channel number (0 to MIDI channel count - 1)
- * @param param SoundFont generator ID (#fluid_gen_type)
+ * @param param SoundFont generator ID uchar (#fluid_gen_type)
  * @return Current NRPN generator offset value assigned to the MIDI channel
  */
 float
-fluid_synth_get_gen(fluid_synth_t *synth, int chan, int param)
+fluid_synth_get_gen(fluid_synth_t *synth, int chan, unsigned char param)
 {
     float result;
     fluid_return_val_if_fail(param >= 0 && param < GEN_LAST, FLUID_FAILED);

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -65,7 +65,7 @@
 /**
  * Bank Select MIDI message styles. Default style is GS.
  */
-enum fluid_midi_bank_select
+enum fluid_midi_bank_select : unsigned char
 {
     FLUID_BANK_STYLE_GM,  /**< GM style, bank = 0 always (CC0/MSB and CC32/LSB ignored) */
     FLUID_BANK_STYLE_GS,  /**< GS style, bank = CC0/MSB (CC32/LSB ignored) */
@@ -73,7 +73,7 @@ enum fluid_midi_bank_select
     FLUID_BANK_STYLE_MMA  /**< MMA style bank = 128*MSB+LSB */
 };
 
-enum fluid_synth_status
+enum fluid_synth_status : unsigned char
 {
     FLUID_SYNTH_CLEAN,
     FLUID_SYNTH_PLAYING,
@@ -81,7 +81,7 @@ enum fluid_synth_status
     FLUID_SYNTH_STOPPED
 };
 
-enum fluid_msgs_note_cut
+enum fluid_msgs_note_cut : unsigned char
 {
     FLUID_MSGS_DISABLED = 0,
     FLUID_MSGS_DRUM_CUT = 1,

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -393,11 +393,11 @@ fluid_voice_set_output_rate(fluid_voice_t *voice, fluid_real_t value)
  * Set the value of a generator.
  *
  * @param voice Voice instance
- * @param i Generator ID (#fluid_gen_type)
+ * @param i Generator ID uchar (#fluid_gen_type)
  * @param val Generator value
  */
 void
-fluid_voice_gen_set(fluid_voice_t *voice, int i, float val)
+fluid_voice_gen_set(fluid_voice_t *voice, unsigned char i, float val)
 {
     voice->gen[i].val = val;
     voice->gen[i].flags = GEN_SET;
@@ -412,11 +412,11 @@ fluid_voice_gen_set(fluid_voice_t *voice, int i, float val)
  * Offset the value of a generator.
  *
  * @param voice Voice instance
- * @param i Generator ID (#fluid_gen_type)
+ * @param i Generator ID uchar (#fluid_gen_type)
  * @param val Value to add to the existing value
  */
 void
-fluid_voice_gen_incr(fluid_voice_t *voice, int i, float val)
+fluid_voice_gen_incr(fluid_voice_t *voice, unsigned char i, float val)
 {
     voice->gen[i].val += val;
     voice->gen[i].flags = GEN_SET;
@@ -426,11 +426,11 @@ fluid_voice_gen_incr(fluid_voice_t *voice, int i, float val)
  * Get the value of a generator.
  *
  * @param voice Voice instance
- * @param gen Generator ID (#fluid_gen_type)
+ * @param gen Generator ID uchar (#fluid_gen_type)
  * @return Current generator value
  */
 float
-fluid_voice_gen_get(fluid_voice_t *voice, int gen)
+fluid_voice_gen_get(fluid_voice_t *voice, unsigned char gen)
 {
     return voice->gen[gen].val;
 }

--- a/src/synth/fluid_voice.h
+++ b/src/synth/fluid_voice.h
@@ -47,7 +47,7 @@ struct _fluid_overflow_prio_t
     int num_important_channels; /**< Number of elements in the important_channels array */
 };
 
-enum fluid_voice_status
+enum fluid_voice_status : unsigned char
 {
     FLUID_VOICE_CLEAN,
     FLUID_VOICE_ON,

--- a/src/utils/fluid_settings.c
+++ b/src/utils/fluid_settings.c
@@ -76,7 +76,7 @@ typedef struct
 
 typedef struct
 {
-    int type;             /**< fluid_types_enum */
+    short type;             /* Type of the fluid short (#fluid_types_enum) */
 
     union
     {
@@ -833,13 +833,13 @@ void* fluid_settings_get_user_data(fluid_settings_t * settings, const char *name
  *
  * @param settings a settings object
  * @param name a setting's name
- * @return the type for the named setting (see #fluid_types_enum), or #FLUID_NO_TYPE when it does not exist
+ * @return the type for the named setting see short (#fluid_types_enum), or #FLUID_NO_TYPE when it does not exist
  */
-int
+short
 fluid_settings_get_type(fluid_settings_t *settings, const char *name)
 {
     fluid_setting_node_t *node;
-    int type = FLUID_NO_TYPE;
+    short type = FLUID_NO_TYPE;
 
     fluid_return_val_if_fail(settings != NULL, type);
     fluid_return_val_if_fail(name != NULL, type);

--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -107,11 +107,11 @@ static const char fluid_libname[] = "fluidsynth";
  * @return The previously installed function.
  */
 fluid_log_function_t
-fluid_set_log_function(int level, fluid_log_function_t fun, void *data)
+fluid_set_log_function(unsigned char level, fluid_log_function_t fun, void *data)
 {
     fluid_log_function_t old = NULL;
 
-    if((level >= 0) && (level < LAST_LOG_LEVEL))
+    if(level < LAST_LOG_LEVEL)
     {
         old = fluid_log_function[level];
         fluid_log_function[level] = fun;
@@ -128,7 +128,7 @@ fluid_set_log_function(int level, fluid_log_function_t fun, void *data)
  * @param data User supplied data (not used)
  */
 void
-fluid_default_log_function(int level, const char *message, void *data)
+fluid_default_log_function(unsigned char  level, const char *message, void *data)
 {
     FILE *out;
 
@@ -170,15 +170,15 @@ fluid_default_log_function(int level, const char *message, void *data)
 
 /**
  * Print a message to the log.
- * @param level Log level (#fluid_log_level).
+ * @param level Log level uchar (#fluid_log_level).
  * @param fmt Printf style format string for log message
  * @param ... Arguments for printf 'fmt' message string
  * @return Always returns #FLUID_FAILED
  */
 int
-fluid_log(int level, const char *fmt, ...)
+fluid_log(unsigned char level, const char *fmt, ...)
 {
-    if((level >= 0) && (level < LAST_LOG_LEVEL))
+    if(level < LAST_LOG_LEVEL)
     {
         fluid_log_function_t fun = fluid_log_function[level];
 


### PR DESCRIPTION
@derselbst,
I started reducing the structures as you suggested, there is a lot of work judging by the number of enums.

How to fix func `#define fluid_atomic_int_set(_pi, _val) g_atomic_int_set(_pi, _val)`
I have type value `short`, but function accepts only int. Use C-cast?