### PR TITLE
Optimize fluid_ct2hz_real() for negative values

### DIFF
--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -51,8 +51,8 @@ fluid_ct2hz_real(fluid_real_t cents)
     int icents = (int)cents;
 
     // Offset the input argument by 300 cents, so that if cents==6900 +300 gives 7200 cents,
-    // which is nicely divisble by 1200 and yields 2^6, which just perfectly matches the
-    // 440/2^6 Hz refernce value of our lookup table. Magic.
+    // which is nicely divisible by 1200 and yields 2^6, which just perfectly matches the
+    // 440/2^6 Hz reference value of our lookup table. Magic.
     icents += 300u;
 
     // don't use stdlib div() here, it turned out have poor performance

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -66,7 +66,7 @@ fluid_ct2hz_real(fluid_real_t cents)
     }
     else
     {
-        rem = icents % 1200u;
+        rem = ((unsigned)icents) % 1200u;
     }
 
     // Handle negative remainder values

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -46,20 +46,37 @@
 fluid_real_t
 fluid_ct2hz_real(fluid_real_t cents)
 {
-    if(FLUID_UNLIKELY(cents < 0))
+    fluid_real_t mult;
+    int fac, rem;
+    int icents = (int)cents;
+    icents += 300u;
+
+    // don't use stdlib div() here, it turned out have poor performance
+    fac = icents / 1200;
+
+    // Calculating the modulo of negative numbers is implementation defined behavior in C!
+    // So make sure all these calculations are unsigned!
+    if(icents < 0)
     {
-        return fluid_act2hz(cents);
+        rem = -(-icents % 1200u);
     }
     else
     {
-        unsigned int mult, fac, rem;
-        unsigned int icents = (unsigned int)cents;
-        icents += 300u;
-
-        // don't use stdlib div() here, it turned out have poor performance
-        fac = icents / 1200u;
         rem = icents % 1200u;
+    }
 
+    // Handle negative remainder values
+    if (rem < 0)
+    {
+        // Bump rem back into positive range so that it fits our lookup table indexing below
+        rem += 1200;
+        // Since we've bump the reminder up by a whole, we need to decrement the factor
+        --fac;
+    }
+
+    // Compute the first factor (mult) using powers of two
+    if (fac >= 0)
+    {
         // Think of "mult" as the factor that we multiply (440/2^6)Hz with,
         // or in other words mult is the "first factor" of the above
         // functions comment.
@@ -69,11 +86,15 @@ fluid_ct2hz_real(fluid_real_t cents)
         // which is much more than ever needed. For bigger values, just
         // safely wrap around (the & is just a replacement for the quick
         // modulo operation % 32).
-        mult = 1u << (fac & (sizeof(mult)*8u - 1u));
-
-        // don't use ldexp() either (poor performance)
-        return mult * fluid_ct2hz_tab[rem];
+        mult = 1u << (fac & (sizeof(unsigned int)*8u - 1u));
     }
+    else
+    {
+        mult = 1.0 / (fluid_real_t)(1u << ((-fac) & (sizeof(unsigned int) * 8u - 1u)));
+    }
+
+    // don't use ldexp() either (poor performance)
+    return mult * fluid_ct2hz_tab[rem];
 }
 
 /*

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -58,15 +58,15 @@ fluid_ct2hz_real(fluid_real_t cents)
     // don't use stdlib div() here, it turned out have poor performance
     fac = icents / 1200;
 
-    // Calculating the modulo of negative numbers is implementation defined behavior in C!
+    // Calculating the modulo of negative numbers is implementation-defined behavior in C!
     // So make sure all these calculations are unsigned!
     if(icents < 0)
     {
-        rem = -(((unsigned)-icents) % 1200u);
+        rem = -(signed)(((unsigned)-icents) % 1200u);
     }
     else
     {
-        rem = ((unsigned)icents) % 1200u;
+        rem = (signed)((unsigned)icents) % 1200u;
     }
 
     // Handle negative remainder values
@@ -74,7 +74,7 @@ fluid_ct2hz_real(fluid_real_t cents)
     {
         // Bump rem back into positive range so that it fits our lookup table indexing below
         rem += 1200;
-        // Since we've bump the reminder up by a whole, we need to decrement the factor
+        // Since we've bumped the reminder up by a whole, we need to decrement the factor
         --fac;
     }
 
@@ -97,7 +97,7 @@ fluid_ct2hz_real(fluid_real_t cents)
     }
     else
     {
-        // Same mult calculation as for positive case, but here we need to take the inverse from it.
+        // Same mult calculation as for positive case, but here we need to take the inverse of it.
         // We could do:
         // mult = 1.0 / fast_shift
         // return mult * lookuptable

--- a/src/utils/fluid_conv.c
+++ b/src/utils/fluid_conv.c
@@ -62,7 +62,7 @@ fluid_ct2hz_real(fluid_real_t cents)
     // So make sure all these calculations are unsigned!
     if(icents < 0)
     {
-        rem = -(-icents % 1200u);
+        rem = -(((unsigned)-icents) % 1200u);
     }
     else
     {

--- a/test/test_ct2hz.c
+++ b/test/test_ct2hz.c
@@ -45,9 +45,9 @@ int main(void)
     TEST_ASSERT(float_eq(fluid_ct2hz_real(-15900), fluid_act2hz(-15900)));
 
     // Test the entire possible range: from lowest permitted value of MODLFOFREQ up to filter fc limit
-    for(i = -16000*100; i < 13500*100; i++)
+    for(i = -16000*1000; i < 13500*1000; i++)
     {
-        TEST_ASSERT(float_eq(fluid_ct2hz_real(i/100.0), fluid_act2hz(i/100.0)));
+        TEST_ASSERT(float_eq(fluid_ct2hz_real(i/1000.0), fluid_act2hz(i/1000.0)));
     }
     return EXIT_SUCCESS;
 }

--- a/test/test_ct2hz.c
+++ b/test/test_ct2hz.c
@@ -9,8 +9,13 @@
 int float_eq(double x, double y)
 {
     static const double EPS = 1e-3;
-    FLUID_LOG(FLUID_INFO, "Comparing %.9f and %.9f", x, y);
-    return fabs(x-y) < EPS;
+    double diff = (x - y) / fmax(y,x);
+    int ok = fabs(diff) < EPS;
+    if(!ok)
+    {
+        FLUID_LOG(FLUID_INFO, "Comparing %.9f and %.9f failed, diff is %.9f", x, y, diff);
+    }
+    return ok;
 }
 
 int main(void)
@@ -35,10 +40,14 @@ int main(void)
     TEST_ASSERT(float_eq(fluid_ct2hz_real(1), 8.1805228064648688650522010380302841769481091116));
     TEST_ASSERT(float_eq(fluid_ct2hz_real(0), 8.1757989156437073336828122976032719176391831357)); // often referred to as Absolute zero in the SF2 spec
 
+    TEST_ASSERT(float_eq(fluid_ct2hz_real(-725), fluid_act2hz(-725)));
+    TEST_ASSERT(float_eq(fluid_ct2hz_real(-14700), fluid_act2hz(-14700)));
+    TEST_ASSERT(float_eq(fluid_ct2hz_real(-15900), fluid_act2hz(-15900)));
+
     // Test the entire possible range: from lowest permitted value of MODLFOFREQ up to filter fc limit
-    for(i = -16000; i < 13500; i++)
+    for(i = -16000*100; i < 13500*100; i++)
     {
-        TEST_ASSERT(float_eq(fluid_ct2hz_real(i), fluid_act2hz(i)));
+        TEST_ASSERT(float_eq(fluid_ct2hz_real(i/100.0), fluid_act2hz(i/100.0)));
     }
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Previously, if `cents` was negative when calling `fluid_ct2hz_real()` it would have passed on that call to the expensive `fluid_act2hz()` function which uses `pow()`.

Negative `cents` values seem to be quite common for the `GEN_VIBLFOFREQ` and `GEN_MODLFOFREQ` generators.

This PR optimizes away this expensive call. It also expands the unit test to test also fractional `cents` values. Comparing the performance with that newly modified unit test gives:

```
time test/test_ct2hz

real    0m1.569s
user    0m1.562s
sys     0m0.004s
```

before applying this optimization, and

```
time test/test_ct2hz

real    0m1.142s
user    0m1.138s
sys     0m0.004s
```

after applying the optimization of this PR.