### PR TITLE
Fix debug builds of C++11 OSAL due to missing assert include

### DIFF
--- a/src/utils/fluid_sys_cpp11.h
+++ b/src/utils/fluid_sys_cpp11.h
@@ -31,6 +31,7 @@
 #include "fluidsynth_priv.h"
 #include "fluid_stub_functions.h"
 
+#include <assert.h>
 #include <stdbool.h>
 
 #define FALSE (0)


### PR DESCRIPTION
This one somehow got missed and breaks debug builds.