### PR TITLE
Fix exclusion of fluid_thread_self_set_prio in embedded OSAL

### DIFF
--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -384,6 +384,8 @@ unsigned int fluid_curtime(void)
 }
 
 
+#if !OSAL_embedded
+
 #if defined(_WIN32)      /* Windoze specific stuff */
 
 void
@@ -407,7 +409,7 @@ fluid_thread_self_set_prio(int prio_level)
     }
 }
 
-#elif !OSAL_embedded  /* POSIX stuff..  Nice POSIX..  Good POSIX. */
+#else /* POSIX stuff..  Nice POSIX..  Good POSIX. */
 
 void
 fluid_thread_self_set_prio(int prio_level)
@@ -438,7 +440,13 @@ fluid_thread_self_set_prio(int prio_level)
     }
 }
 
-#ifdef FPE_CHECK
+
+#endif	// #else    (its POSIX)
+
+#endif	// #if !OSAL_embedded
+
+
+#if defined(FPE_CHECK) && !defined(_WIN32) && !defined(__OS2__)
 
 /***************************************************************
  *
@@ -505,10 +513,7 @@ void fluid_clear_fpe_i386(void)
     _FPU_CLR_SW();
 }
 
-#endif	// ifdef FPE_CHECK
-
-
-#endif	// #else    (its POSIX)
+#endif	// #if defined(FPE_CHECK) && !defined(_WIN32) && !defined(__OS2__)
 
 
 /***************************************************************

--- a/src/utils/fluid_sys.h
+++ b/src/utils/fluid_sys.h
@@ -278,9 +278,7 @@ typedef struct
 fluid_thread_t *new_fluid_thread(const char *name, fluid_thread_func_t func, void *data,
                                  int prio_level, int detach);
 void delete_fluid_thread(fluid_thread_t *thread);
-#if !OSAL_embedded
 void fluid_thread_self_set_prio(int prio_level);
-#endif
 
 int fluid_thread_join(fluid_thread_t *thread);
 


### PR DESCRIPTION
This is a rework of the change in #1575. The embedded OSAL may be used on non-POSIX platforms as well, so the exclusion of the fluid_thread_self_set_prio definition needs to apply to all of them.

Also the declaration of the function doesn't need to be excluded as it is defined in all cases, just possibly as a stub.