### PR TITLE
Replace deprecated Windows 2019 CI, drop WinXP binaries

### DIFF
--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -44,7 +44,7 @@ jobs:
         CXXFLAGS: ""
         CMAKEFLAGS: ""
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
     - task: DownloadBuildArtifacts@0
       inputs:
@@ -161,7 +161,7 @@ jobs:
         CMAKE_FLAGS: -Denable-ipv6=0 -Denable-network=0 -Denable-aufile=0 -Denable-threads=0 -Denable-winmidi=0 -Denable-waveout=0 -Denable-dsound=0 -Denable-libsndfile=0 -Denable-floats=1
         CMAKE_CONFIG: Release
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
     - script: |
         @ECHO ON
@@ -222,7 +222,7 @@ jobs:
         mingw-url: $(mingw-url-x64)
         sdl3-url: 'https://github.com/libsdl-org/SDL/releases/download/release-3.2.10/SDL3-devel-3.2.10-mingw.tar.gz'
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
     - task: DownloadBuildArtifacts@0
       inputs:

--- a/.azure/azure-pipelines-win.yml
+++ b/.azure/azure-pipelines-win.yml
@@ -22,7 +22,7 @@ variables:
 jobs:
 - job: WindowsXP
   variables:
-    toolset: v141_xp
+    toolset: v143
   strategy:
     matrix:
       x86:
@@ -31,8 +31,8 @@ jobs:
         gtk-bundle: $(gtk-bundle-x86)
         libsndfile-url: $(libsndfile-url-x86)
         artifactPrefix: "fluidsynth"
-        CFLAGS: "/arch:IA32"
-        CXXFLAGS: "/arch:IA32"
+        CFLAGS: ""
+        CXXFLAGS: ""
         CMAKEFLAGS: "-Denable-libinstpatch=0"
       x64:
         platform: x64
@@ -97,7 +97,7 @@ jobs:
         SET "PATH=d:\deps\bin;%PATH%"
         pkg-config --list-all
         mkdir build && cd build || exit -1
-        cmake -Werror=dev -A $(platform) -T $(toolset) -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-sdl2=0 $(CMAKEFLAGS) -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1 -Dwindows-version=0x0501 .. || exit -1
+        cmake -Werror=dev -A $(platform) -T $(toolset) -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -Denable-readline=0 -Denable-floats=1 -Denable-jack=0 -Denable-sdl2=0 $(CMAKEFLAGS) -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 -DNO_GUI=1  .. || exit -1
         cmake --build . --config Release --parallel 3 || exit -1
       displayName: 'Compile fluidsynth'
     - script: |


### PR DESCRIPTION
The Windows Server 2019 image on Azure Pipeline (and Github Actions) will be removed on 2025-06-30, see actions/runner-images#12045 . Changing to the Server 2022 image has the side effect, that v141_xp toolset is no longer available. That means, the precompiled binaries of upcoming version 2.4.7 will no longer be compatible to Windows XP and we will no longer be able to validate that our changes will compile for Windows XP.

If anybody believes that this is a problem, a solution for this would be to create a custom Windows-Container image, that we'd use for compiling for Windows XP. FWIW, I have already been through this "fun", see here: https://github.com/derselbst/ANPV/blob/master/docker/Dockerfile.win