### PR TITLE
Remove ubsan / asan CI build

### DIFF
--- a/.github/workflows/api_doc_build.yml
+++ b/.github/workflows/api_doc_build.yml
@@ -16,7 +16,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    
+
+    - name: Update Dependencies
+      run: sudo apt-get update
+
     - name: Install Dependencies
       run: sudo apt-get install doxygen xsltproc
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,14 +34,14 @@ jobs:
         CXX: [""]
         CMAKE_FLAGS: ["-Denable-profiling=1","-Denable-floats=1 -Denable-profiling=1","-Denable-floats=1","-Denable-trap-on-fpe=1","-Denable-fpe-check=1","-Denable-ipv6=0","-Denable-network=0","-Denable-aufile=0","-DBUILD_SHARED_LIBS=0", "-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold", "-Dosal=cpp11 -Denable-libinstpatch=0 -Denable-ladspa=0"]
         include:
-          - CC: "clang-12"
-            CXX: "clang++-12"
+          - CC: "clang-15"
+            CXX: "clang++-15"
             CMAKE_FLAGS: ""
-          - CC: "clang-12"
-            CXX: "clang++-12"
+          - CC: "clang-15"
+            CXX: "clang++-15"
             CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
-          - CC: "clang-12"
-            CXX: "clang++-12"
+          - CC: "clang-15"
+            CXX: "clang++-15"
             CMAKE_FLAGS: "-Denable-ubsan=1 -Denable-debug=1"
 # clang9 is covered by openSUSE Leap 15.2
 # clang11 is covered by openSUSE Leap 15.3
@@ -58,8 +58,8 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get -yq --no-install-suggests --no-install-recommends install \
-          clang-12 \
-          libclang-rt-12-dev
+          clang-15 \
+          libclang-15-dev \
           clang-tidy \
           cmake \
           cmake-data \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         CC: [""]
         CXX: [""]
-        CMAKE_FLAGS: ["-Denable-profiling=1","-Denable-floats=1 -Denable-profiling=1","-Denable-floats=1","-Denable-trap-on-fpe=1","-Denable-fpe-check=1","-Denable-ipv6=0","-Denable-network=0","-Denable-aufile=0","-DBUILD_SHARED_LIBS=0","-Denable-ubsan=1 -Denable-debug=1", "-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold", "-Dosal=cpp11 -Denable-libinstpatch=0 -Denable-ladspa=0"]
+        CMAKE_FLAGS: ["-Denable-profiling=1","-Denable-floats=1 -Denable-profiling=1","-Denable-floats=1","-Denable-trap-on-fpe=1","-Denable-fpe-check=1","-Denable-ipv6=0","-Denable-network=0","-Denable-aufile=0","-DBUILD_SHARED_LIBS=0", "-Denable-debug=1 -DCMAKE_C_FLAGS_DEBUG=-fuse-ld=gold", "-Dosal=cpp11 -Denable-libinstpatch=0 -Denable-ladspa=0"]
         include:
           - CC: "clang-12"
             CXX: "clang++-12"
@@ -40,6 +40,9 @@ jobs:
           - CC: "clang-12"
             CXX: "clang++-12"
             CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
+          - CC: "clang-12"
+            CXX: "clang++-12"
+            CMAKE_FLAGS: "-Denable-ubsan=1 -Denable-debug=1"
 # clang9 is covered by openSUSE Leap 15.2
 # clang11 is covered by openSUSE Leap 15.3
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,6 +59,7 @@ jobs:
       run: |
         sudo apt-get -yq --no-install-suggests --no-install-recommends install \
           clang-12 \
+          libclang-rt-12-dev
           clang-tidy \
           cmake \
           cmake-data \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,9 +40,6 @@ jobs:
           - CC: "clang-15"
             CXX: "clang++-15"
             CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=0"
-          - CC: "clang-15"
-            CXX: "clang++-15"
-            CMAKE_FLAGS: "-Denable-ubsan=1 -Denable-debug=1"
 # clang9 is covered by openSUSE Leap 15.2
 # clang11 is covered by openSUSE Leap 15.3
 
@@ -59,7 +56,6 @@ jobs:
       run: |
         sudo apt-get -yq --no-install-suggests --no-install-recommends install \
           clang-15 \
-          libclang-15-dev \
           clang-tidy \
           cmake \
           cmake-data \


### PR DESCRIPTION
ASAN reports a leak

```
24/28 Test #24: test_threading ........................***Failed    0.36 sec
fluidsynth: incremented 58295 regular vs. 100000 atomic

=================================================================
==5559==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7f88f30b4887 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88f3b08923  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xa4923)

SUMMARY: AddressSanitizer: 4 byte(s) leaked in 1 allocation(s).
```

Which I'm unable to solve or comprehend at this time.