### PR TITLE
Fix missing argument name for fluid_thread_self_set_prio stub.

### DIFF
--- a/src/utils/fluid_sys_embedded.h
+++ b/src/utils/fluid_sys_embedded.h
@@ -220,7 +220,7 @@ typedef int fluid_thread_t;
 STUB_FUNCTION(new_fluid_thread, fluid_thread_t *, NULL, (const char *name, fluid_thread_func_t func, void *data, int prio_level, int detach))
 STUB_FUNCTION_VOID_SILENT(delete_fluid_thread, (fluid_thread_t *thread))
 STUB_FUNCTION_SILENT(fluid_thread_join, int, FLUID_OK, (fluid_thread_t *thread))
-STUB_FUNCTION_VOID_SILENT(fluid_thread_self_set_prio, (int))
+STUB_FUNCTION_VOID_SILENT(fluid_thread_self_set_prio, (int prio_level))
 
 
 /* File access */


### PR DESCRIPTION
This defines an inline function and the int argument needs a name on some compilers.