### PR TITLE
Add support for the DMOD chunk

### DIFF
--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -443,6 +443,10 @@ int fluid_defsfont_load_all_sampledata(fluid_defsfont_t *defsfont, SFData *sfdat
     return sample_parsing_result;
 }
 
+// declared here so it can be used for default modulators in fluid_defsfont_load
+static int
+fluid_mod_import_sfont(fluid_mod_t **mod, fluid_list_t *sfmod);
+
 /*
  * fluid_defsfont_load
  */
@@ -450,6 +454,7 @@ int fluid_defsfont_load(fluid_defsfont_t *defsfont, const fluid_file_callbacks_t
 {
     SFData *sfdata;
     fluid_list_t *p;
+    fluid_list_t *dmod_data;
     SFPreset *sfpreset;
     SFSample *sfsample;
     fluid_sample_t *sample;
@@ -478,6 +483,17 @@ int fluid_defsfont_load(fluid_defsfont_t *defsfont, const fluid_file_callbacks_t
     {
         FLUID_LOG(FLUID_ERR, "Couldn't parse presets from soundfont file");
         goto err_exit;
+    }
+
+    dmod_data = sfdata->default_mod_list;
+    if (dmod_data != NULL)
+    {
+        /* Load the default modulators*/
+        if (fluid_mod_import_sfont(&defsfont->default_mod_list, dmod_data) != FLUID_OK)
+        {
+            FLUID_LOG(FLUID_ERR, "Unable to load the default modulators");
+            goto err_exit;
+        }
     }
 
     /* Keep track of the position and size of the sample data because
@@ -1562,26 +1578,31 @@ fluid_zone_mod_source_import_sfont(unsigned char *src, unsigned char *flags, uns
     return TRUE;
 }
 
-/*
+/**
  * fluid_zone_mod_import_sfont
  * Imports modulators from sfzone to modulators list mod.
- * @param zone_name, zone name.
- * @param mod, address of pointer on modulators list to return.
- * @param sfzone, pointer on soundfont zone.
+ * @param mod -  address of pointer on modulators list to return.
+ * @param sfmod - pointer on the modulator list.
  * @return FLUID_OK if success, FLUID_FAILED otherwise.
  */
 static int
-fluid_zone_mod_import_sfont(char *zone_name, fluid_mod_t **mod, SFZone *sfzone)
+fluid_mod_import_sfont(fluid_mod_t **mod, fluid_list_t *sfmod)
 {
     fluid_list_t *r;
     int count;
 
     /* Import the modulators (only SF2.1 and higher) */
-    for(count = 0, r = sfzone->mod; r != NULL; count++)
+    for(count = 0, r = sfmod; r != NULL; count++)
     {
 
-        SFMod *mod_src = (SFMod *)fluid_list_get(r);
+        SFMod *mod_src = (SFMod*)(r->data);
         fluid_mod_t *mod_dest = new_fluid_mod();
+
+        if (mod_src == NULL)
+        {
+            // empty list (DMOD case) - nothing to do!
+            return FLUID_OK;
+        }
 
         if(mod_dest == NULL)
         {
@@ -1650,6 +1671,24 @@ fluid_zone_mod_import_sfont(char *zone_name, fluid_mod_t **mod, SFZone *sfzone)
 
         r = fluid_list_next(r);
     } /* foreach modulator */
+    return FLUID_OK;
+}
+
+/*
+ * fluid_zone_mod_import_sfont
+ * Imports modulators from sfzone to modulators list mod.
+ * @param zone_name, zone name.
+ * @param mod, address of pointer on modulators list to return.
+ * @param sfzone, pointer on soundfont zone.
+ * @return FLUID_OK if success, FLUID_FAILED otherwise.
+ */
+static int
+fluid_zone_mod_import_sfont(char *zone_name, fluid_mod_t **mod, SFZone *sfzone)
+{
+    if (fluid_mod_import_sfont(mod, sfzone->mod) != FLUID_OK)
+    {
+        return FLUID_FAILED;
+    }
 
     /* checks and removes invalid modulators in modulators list*/
     fluid_zone_check_mod(zone_name, mod);
@@ -2074,6 +2113,7 @@ fluid_sample_import_sfont(fluid_sample_t *sample, SFSample *sfsample, fluid_defs
     sample->origpitch = sfsample->origpitch;
     sample->pitchadj = sfsample->pitchadj;
     sample->sampletype = sfsample->sampletype;
+    sample->default_modulators = defsfont->default_mod_list;
 
     if(defsfont->dynamic_samples)
     {

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -107,16 +107,17 @@ struct _fluid_defsfont_t
     unsigned int samplesize;  /* the size of the sample data in bytes */
     short *sampledata;        /* the sample data, loaded in ram */
 
-    unsigned int sample24pos;		/* position within sffd of the sm24 chunk, set to zero if no 24 bit sample support */
-    unsigned int sample24size;		/* length within sffd of the sm24 chunk */
+    unsigned int sample24pos;       /* position within sffd of the sm24 chunk, set to zero if no 24 bit sample support */
+    unsigned int sample24size;      /* length within sffd of the sm24 chunk */
     char *sample24data;        /* if not NULL, the least significant byte of the 24bit sample data, loaded in ram */
 
-    fluid_sfont_t *sfont;      /* pointer to parent sfont */
-    fluid_list_t *sample;      /* the samples in this soundfont */
-    fluid_list_t *preset;      /* the presets of this soundfont */
-    fluid_list_t *inst;        /* the instruments of this soundfont */
-    int mlock;                 /* Should we try memlock (avoid swapping)? */
-    int dynamic_samples;       /* Enables dynamic sample loading if set */
+    fluid_sfont_t *sfont;           /* pointer to parent sfont */
+    fluid_list_t *sample;           /* the samples in this soundfont */
+    fluid_list_t *preset;           /* the presets of this soundfont */
+    fluid_list_t *inst;             /* the instruments of this soundfont */
+    fluid_mod_t *default_mod_list;  /* the default modulator list of this soundfont */
+    int mlock;                      /* Should we try memlock (avoid swapping)? */
+    int dynamic_samples;            /* Enables dynamic sample loading if set */
 
     fluid_list_t *preset_iter_cur;       /* the current preset in the iteration */
 };
@@ -147,6 +148,7 @@ struct _fluid_defpreset_t
     unsigned int num;                     /* the preset number */
     fluid_preset_zone_t *global_zone;        /* the global zone of the preset */
     fluid_preset_zone_t *zone;               /* the chained list of preset zones */
+    fluid_mod_t *default_mod;             /* default mods for the soundfont */
     int pinned;                           /* preset samples pinned to sample cache? */
 };
 

--- a/src/sfloader/fluid_sffile.h
+++ b/src/sfloader/fluid_sffile.h
@@ -157,6 +157,7 @@ struct _SFData
     fluid_list_t *preset; /* linked list of preset info */
     fluid_list_t *inst; /* linked list of instrument info */
     fluid_list_t *sample; /* linked list of sample info */
+    fluid_list_t *default_mod_list; /* default modulator list */
 };
 
 /* functions */

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -175,8 +175,9 @@ struct _fluid_sample_t
     int amplitude_that_reaches_noise_floor_is_valid;      /**< Indicates if \a amplitude_that_reaches_noise_floor is valid (TRUE), set to FALSE initially to calculate. */
     double amplitude_that_reaches_noise_floor;            /**< The amplitude at which the sample's loop will be below the noise floor.  For voice off optimization, calculated automatically. */
 
-    unsigned int refcount;        /**< Count of voices using this sample */
-    int preset_count;             /**< Count of selected presets using this sample (used for dynamic sample loading) */
+    unsigned int refcount;             /**< Count of voices using this sample */
+    int preset_count;                  /**< Count of selected presets using this sample (used for dynamic sample loading) */
+    fluid_mod_t *default_modulators;   /**< Default soundfont modulators for this sample to allocate the voice for it. NULL will use the synth's defaults. */
 
     /**
      * Implement this function to receive notification when sample is no longer used.

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -5298,12 +5298,24 @@ fluid_synth_alloc_voice_LOCAL(fluid_synth_t *synth, fluid_sample_t *sample, int 
     */
     {
         int mono = fluid_channel_is_playing_mono(channel);
-        fluid_mod_t *default_mod = synth->default_mod;
+        int override_default_modulators = FALSE;
+        fluid_mod_t *default_mod;
+        if (sample->default_modulators != NULL)
+        {
+            default_mod = sample->default_modulators;
+            override_default_modulators = TRUE;
+        }
+        else
+        {
+            default_mod = synth->default_mod;
+        }
 
         while(default_mod != NULL)
         {
             if(
-                /* See if default_mod is the velocity_to_attenuation modulator */
+                /* if SF explicitly wants the default vel2att modulator, keep it*/
+                override_default_modulators != TRUE &&
+                /* Otherwise, see if default_mod is the velocity_to_attenuation modulator */
                 fluid_mod_test_identity(default_mod, &default_vel2att_mod) &&
                 // See if a replacement by custom_breath2att_modulator has been demanded
                 // for this channel


### PR DESCRIPTION
I figured it out! :D

This PR adds support for the DMOD chunk per the [extension specification](https://github.com/spessasus/soundfont-proposals/blob/main/default_modulators.md).
I've extracted the mod importing code from the zone_mod_import so it can be used for DMOD without duplicated coede.

Here's a quick DMOD sf2 tester that makes it instantly audible, as it has a single default modulator that is a pitch wheel with a switch, and a fixed range of 3 semitones. The MIDI tests pitch bend range, so we can hear and verify that it's always the same.

[Quick_and_dirty_dmod_test.zip](https://github.com/user-attachments/files/21068924/Quick_and_dirty_dmod_test.zip)

All regular SF2 files and DLS files seem to work fine.
Note that I've also added a few `FLUID_DBG` logs to the INFO chunk as they were very handy. I can remove them if needed.

Resolves #1582 

