### PR TITLE
Compile Android binaries with 16kB page alignment

### DIFF
--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -530,6 +530,12 @@ jobs:
       displayName: 'Verify all libs exist'
       workingDirectory: '$(PREFIX)/lib'
 
+    - script: |
+        set -ex
+        chmod +x contrib/check_elf_alignment.sh
+        contrib/check_elf_alignment.sh "$(PREFIX)/lib"
+      displayName: 'Assert 16K page alignment'
+
     - task: PublishBuildArtifacts@1
       displayName: 'Publishing Artefacts for Android API$(ANDROID_API) $(ANDROID_ABI_CMAKE)'
       inputs:

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -189,7 +189,7 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '$(ARCH) | "$(NDK)" | $(DEV)/*.tar.*'
+        key: '$(ARCH) | "$(NDK)" | $(DEV)/*.tar.* | ver1'
         path: '$(PREFIX)'
         cacheHitVar: 'CACHE_RESTORED'
       displayName: 'Cache fluidsynth dependency libraries'
@@ -229,7 +229,7 @@ jobs:
         LIBPATH2=$(NDK_TOOLCHAIN)/sysroot/usr/lib/$(ARCH)-linux-android$(ANDROID_TARGET_ABI)/$(ANDROID_API)
         LIBPATH3=$(NDK_TOOLCHAIN)/sysroot/usr/lib/$(ARCH)-linux-android$(ANDROID_TARGET_ABI)
 
-        export LDFLAGS="-pie -Wl,-rpath-link=${LIBPATH1} -L${LIBPATH1} -Wl,-rpath-link=${LIBPATH2} -L${LIBPATH2} -Wl,-rpath-link=${LIBPATH3} -L${LIBPATH3} -Wl,-rpath-link=${LIBPATH0} -L${LIBPATH0}"
+        export LDFLAGS="-pie -Wl,-z,max-page-size=16384 -Wl,-rpath-link=${LIBPATH1} -L${LIBPATH1} -Wl,-rpath-link=${LIBPATH2} -L${LIBPATH2} -Wl,-rpath-link=${LIBPATH3} -L${LIBPATH3} -Wl,-rpath-link=${LIBPATH0} -L${LIBPATH0}"
         echo "##vso[task.setvariable variable=LDFLAGS]$LDFLAGS"
 
         # Tell configure what tools to use.

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -229,6 +229,7 @@ jobs:
         LIBPATH2=$(NDK_TOOLCHAIN)/sysroot/usr/lib/$(ARCH)-linux-android$(ANDROID_TARGET_ABI)/$(ANDROID_API)
         LIBPATH3=$(NDK_TOOLCHAIN)/sysroot/usr/lib/$(ARCH)-linux-android$(ANDROID_TARGET_ABI)
 
+        # Add max. page size to linker flag, see https://developer.android.com/guide/practices/page-sizes
         export LDFLAGS="-pie -Wl,-z,max-page-size=16384 -Wl,-rpath-link=${LIBPATH1} -L${LIBPATH1} -Wl,-rpath-link=${LIBPATH2} -L${LIBPATH2} -Wl,-rpath-link=${LIBPATH3} -L${LIBPATH3} -Wl,-rpath-link=${LIBPATH0} -L${LIBPATH0}"
         echo "##vso[task.setvariable variable=LDFLAGS]$LDFLAGS"
 

--- a/contrib/check_elf_alignment.sh
+++ b/contrib/check_elf_alignment.sh
@@ -111,7 +111,9 @@ done
 
 if [ ${#unaligned_libs[@]} -gt 0 ]; then
   echo -e "${RED}Found ${#unaligned_libs[@]} unaligned libs (only arm64-v8a/x86_64 libs need to be aligned).${ENDCOLOR}"
+  exit -1
 elif [ -n "${dir_filename}" ]; then
   echo -e "ELF Verification Successful"
+  exit 0
 fi
 echo "====================="

--- a/contrib/check_elf_alignment.sh
+++ b/contrib/check_elf_alignment.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# source: https://developer.android.com/guide/practices/page-sizes
+# https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh
+#
+progname="${0##*/}"
+progname="${progname%.sh}"
+
+# usage: check_elf_alignment.sh [path to *.so files|path to *.apk]
+
+cleanup_trap() {
+  if [ -n "${tmp}" -a -d "${tmp}" ]; then
+    rm -rf ${tmp}
+  fi
+  exit $1
+}
+
+usage() {
+  echo "Host side script to check the ELF alignment of shared libraries."
+  echo "Shared libraries are reported ALIGNED when their ELF regions are"
+  echo "16 KB or 64 KB aligned. Otherwise they are reported as UNALIGNED."
+  echo
+  echo "Usage: ${progname} [input-path|input-APK|input-APEX]"
+}
+
+if [ ${#} -ne 1 ]; then
+  usage
+  exit
+fi
+
+case ${1} in
+  --help | -h | -\?)
+    usage
+    exit
+    ;;
+
+  *)
+    dir="${1}"
+    ;;
+esac
+
+if ! [ -f "${dir}" -o -d "${dir}" ]; then
+  echo "Invalid file: ${dir}" >&2
+  exit 1
+fi
+
+if [[ "${dir}" == *.apk ]]; then
+  trap 'cleanup_trap' EXIT
+
+  echo
+  echo "Recursively analyzing $dir"
+  echo
+
+  if { zipalign --help 2>&1 | grep -q "\-P <pagesize_kb>"; }; then
+    echo "=== APK zip-alignment ==="
+    zipalign -v -c -P 16 4 "${dir}" | egrep 'lib/arm64-v8a|lib/x86_64|Verification'
+    echo "========================="
+  else
+    echo "NOTICE: Zip alignment check requires build-tools version 35.0.0-rc3 or higher."
+    echo "  You can install the latest build-tools by running the below command"
+    echo "  and updating your \$PATH:"
+    echo
+    echo "    sdkmanager \"build-tools;35.0.0-rc3\""
+  fi
+
+  dir_filename=$(basename "${dir}")
+  tmp=$(mktemp -d -t "${dir_filename%.apk}_out_XXXXX")
+  unzip "${dir}" lib/* -d "${tmp}" >/dev/null 2>&1
+  dir="${tmp}"
+fi
+
+if [[ "${dir}" == *.apex ]]; then
+  trap 'cleanup_trap' EXIT
+
+  echo
+  echo "Recursively analyzing $dir"
+  echo
+
+  dir_filename=$(basename "${dir}")
+  tmp=$(mktemp -d -t "${dir_filename%.apex}_out_XXXXX")
+  deapexer extract "${dir}" "${tmp}" || { echo "Failed to deapex." && exit 1; }
+  dir="${tmp}"
+fi
+
+RED="\e[31m"
+GREEN="\e[32m"
+ENDCOLOR="\e[0m"
+
+unaligned_libs=()
+
+echo
+echo "=== ELF alignment ==="
+
+matches="$(find "${dir}" -type f)"
+IFS=$'\n'
+for match in $matches; do
+  # We could recursively call this script or rewrite it to though.
+  [[ "${match}" == *".apk" ]] && echo "WARNING: doesn't recursively inspect .apk file: ${match}"
+  [[ "${match}" == *".apex" ]] && echo "WARNING: doesn't recursively inspect .apex file: ${match}"
+
+  [[ $(file "${match}") == *"ELF"* ]] || continue
+
+  res="$(objdump -p "${match}" | grep LOAD | awk '{ print $NF }' | head -1)"
+  if [[ $res =~ 2\*\*(1[4-9]|[2-9][0-9]|[1-9][0-9]{2,}) ]]; then
+    echo -e "${match}: ${GREEN}ALIGNED${ENDCOLOR} ($res)"
+  else
+    echo -e "${match}: ${RED}UNALIGNED${ENDCOLOR} ($res)"
+    unaligned_libs+=("${match}")
+  fi
+done
+
+if [ ${#unaligned_libs[@]} -gt 0 ]; then
+  echo -e "${RED}Found ${#unaligned_libs[@]} unaligned libs (only arm64-v8a/x86_64 libs need to be aligned).${ENDCOLOR}"
+elif [ -n "${dir_filename}" ]; then
+  echo -e "ELF Verification Successful"
+fi
+echo "====================="

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -449,11 +449,6 @@ install( TARGETS libfluidsynth-OBJ
 # Here are applied/linked the OBJECT library dependencies
 target_link_libraries ( libfluidsynth PRIVATE libfluidsynth-OBJ )
 
-if ( ANDROID )
-  target_link_options(libfluidsynth PRIVATE "-Wl,-z,max-page-size=16384")
-  target_link_options(libfluidsynth PRIVATE "-Wl,-z,common-page-size=16384")
-endif ( ANDROID )
-
 # ************ CLI program ************
 
 set ( fluidsynth_SOURCES fluidsynth.c )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -449,6 +449,11 @@ install( TARGETS libfluidsynth-OBJ
 # Here are applied/linked the OBJECT library dependencies
 target_link_libraries ( libfluidsynth PRIVATE libfluidsynth-OBJ )
 
+if ( ANDROID )
+  target_link_options(libfluidsynth PRIVATE "-Wl,-z,max-page-size=16384")
+  target_link_options(libfluidsynth PRIVATE "-Wl,-z,common-page-size=16384")
+endif ( ANDROID )
+
 # ************ CLI program ************
 
 set ( fluidsynth_SOURCES fluidsynth.c )


### PR DESCRIPTION
Google will soon require 16 KB page sizes, see https://developer.android.com/guide/practices/page-sizes

This PR, 

1. adds an additional step to the Android CI pipeline to verify that all compiled binaries satisfy this requirement, and
2. modifies the `LDFLAGS` used during compilation to force the linker to produce pages satisfying the alignment requirement for fluidsynth and all it's depending libraries.

Resolves #1600