### PR TITLE
Disable openMP in Android CI

### DIFF
--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -460,7 +460,7 @@ jobs:
         workDir: '$(System.DefaultWorkingDirectory)'
         sourceDir: '.'
         condition: succeeded()
-        cmakeArgs: '-Denable-opensles=1 -Denable-floats=1 -Denable-oboe=1 -Denable-dbus=0 -Denable-oss=0 -Denable-ubsan=1'
+        cmakeArgs: '-Denable-opensles=1 -Denable-floats=1 -Denable-oboe=1 -Denable-dbus=0 -Denable-oss=0 -Denable-openmp=0'
         installCommand: ''
 
     - script: |

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -460,7 +460,7 @@ jobs:
         workDir: '$(System.DefaultWorkingDirectory)'
         sourceDir: '.'
         condition: succeeded()
-        cmakeArgs: '-Denable-opensles=1 -Denable-floats=1 -Denable-oboe=1 -Denable-dbus=0 -Denable-oss=0'
+        cmakeArgs: '-Denable-opensles=1 -Denable-floats=1 -Denable-oboe=1 -Denable-dbus=0 -Denable-oss=0 -Denable-ubsan=1'
         installCommand: ''
 
     - script: |

--- a/.azure/cmake-android.yml
+++ b/.azure/cmake-android.yml
@@ -33,7 +33,7 @@ steps:
     cmake -G "Unix Makefiles" \
         -DCMAKE_MAKE_PROGRAM=make \
         -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake \
-        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DANDROID_NATIVE_API_LEVEL=${ANDROID_API} \
         -DANDROID_ABI=${ANDROID_ABI_CMAKE} \
         -DANDROID_TOOLCHAIN=${CC} \

--- a/.azure/cmake-android.yml
+++ b/.azure/cmake-android.yml
@@ -33,7 +33,7 @@ steps:
     cmake -G "Unix Makefiles" \
         -DCMAKE_MAKE_PROGRAM=make \
         -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_BUILD_TYPE=Debug \
         -DANDROID_NATIVE_API_LEVEL=${ANDROID_API} \
         -DANDROID_ABI=${ANDROID_ABI_CMAKE} \
         -DANDROID_TOOLCHAIN=${CC} \


### PR DESCRIPTION
Due to mysterious crashes on Android related to openMP, Android binaries will be compiled without openMP support.