### PR TITLE
Fix a nullpointer dereference during legato mode

### DIFF
--- a/src/synth/fluid_synth_monopoly.c
+++ b/src/synth/fluid_synth_monopoly.c
@@ -410,7 +410,7 @@ int fluid_synth_noteoff_mono_LOCAL(fluid_synth_t *synth, int chan, int key)
                 fluid_channel_breath_msb(channel))
         {
             /* legato playing detection */
-            if(channel->mode  & FLUID_CHANNEL_LEGATO_PLAYING)
+            if (channel->mode & FLUID_CHANNEL_LEGATO_PLAYING && channel->preset != NULL)
             {
                 /* the list contains others notes */
                 if(i_prev >= 0)


### PR DESCRIPTION
A code path was discovered that allowed a null pointer deref when a channel has no preset assigned while invoking a noteOff, when the channel is in mono / legato mode.

This addresses the problem by preventing spawning a noteOn during a noteOff when no preset is assigned. In this case, any potentially playing note will be offed via `fluid_synth_noteoff_monopoly`.

Resolves #1602 