### PR TITLE
Report buffer overruns for alsa_seq MIDI driver

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -119,7 +119,7 @@ Developers:
             <type>bool</type>
             <def>0 (FALSE)</def>
             <desc>
-                When set to 1 (TRUE), samples are loaded to and unloaded from memory whenever presets are being selected or unselected for a MIDI channel. PROGRAM_CHANGE and PROGRAM_SELECT events are typically responsible for this.
+                When set to 1 (TRUE), samples are loaded to and unloaded from memory whenever presets are being selected or unselected for a MIDI channel (PROGRAM_CHANGE and PROGRAM_SELECT events are typically responsible for this). This involves memory allocation, which is not realtime safe! So only enable this in non-realtime scenarios! E.g. when rendering to a WAVE file using the fast-file-renderer.
             </desc>
         </setting>
         <setting>

--- a/src/drivers/fluid_alsa.c
+++ b/src/drivers/fluid_alsa.c
@@ -132,6 +132,7 @@ typedef struct
     fluid_atomic_int_t should_quit;
     int port_count;
     int autoconn_inputs;
+    int dyn_sample_loading_is_active;
     snd_seq_addr_t autoconn_dest;
 } fluid_alsa_seq_driver_t;
 
@@ -1238,6 +1239,7 @@ new_fluid_alsa_seq_driver(fluid_settings_t *settings,
     }
 
     fluid_settings_getint(settings, "midi.autoconnect", &dev->autoconn_inputs);
+    fluid_settings_getint(settings, "synth.dynamic-sample-loading", &dev->dyn_sample_loading_is_active);
 
     if(dev->autoconn_inputs)
     {
@@ -1359,11 +1361,20 @@ fluid_alsa_seq_run(void *d)
                  * (-EPERM) and input event buffer overrun (-ENOSPC) */
                 if(ev < 0)
                 {
-                    /* FIXME - report buffer overrun? */
                     if(ev != -EPERM && ev != -ENOSPC)
                     {
                         FLUID_LOG(FLUID_ERR, "Error while reading ALSA sequencer (code=%d)", ev);
                         fluid_atomic_int_set(&dev->should_quit, 1);
+                    }
+                    else
+                    {
+                        FLUID_LOG(FLUID_WARN, "ALSA sequencer buffer overrun, some MIDI events where lost (code=%d)", ev);
+                        if(dev->dyn_sample_loading_is_active)
+                        {
+                            FLUID_LOG(FLUID_INFO, "Hint: To mitigate buffer overruns, you should consider to disable synth.dynamic-sample-loading!");
+                            // avoid spamming those hints
+                            dev->dyn_sample_loading_is_active = 0;
+                        }
                     }
 
                     break;


### PR DESCRIPTION
Buffer overrun for alsa_seq MIDI events was previously not reported, but commented as `FIXME` in the code. A user ran into this issue. This PR hopefully provides more clarity.

Resolves #1627