### PR TITLE
Don't use compile-time `long double` arithmetic in src/gentables

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -141,3 +141,58 @@ jobs:
           -DFluidSynth_DIR="$INSTALL_LOCATION/lib/cmake/fluidsynth" \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE
         cmake --build consume-install
+
+  # Tests to see if FluidSynth will build with GCC for PowerPC targets that use the IBM long double ABI
+  build-ibm-long-double:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:trixie
+      options: -u root
+      volumes:
+        - /etc/ssl/certs:/etc/ssl/certs
+
+    steps:
+    - name: Update apt
+      run: |
+        dpkg --add-architecture ppc64el
+        apt-get update -y
+
+    - name: Install Dependencies
+      run: |
+        apt-get -yq --no-install-suggests --no-install-recommends install \
+          git \
+          gcc-powerpc64le-linux-gnu \
+          g++-powerpc64le-linux-gnu \
+          cmake \
+          cmake-data \
+          ninja-build
+
+    - uses: actions/checkout@v5
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: |
+        export CC=${{ matrix.CC }}
+        export CXX=${{ matrix.CXX }}
+        export CFLAGS="$CFLAGS -mabi=ibmlongdouble -Wno-psabi"
+        export CXXFLAGS="$CXXFLAGS -mabi=ibmlongdouble -Wno-psabi"
+        cmake -S . \
+          -B build \
+          -G Ninja \
+          -DCMAKE_SYSTEM_NAME=Linux \
+          -DCMAKE_SYSTEM_PROCESSOR=ppc64le \
+          -DCMAKE_C_COMPILER=powerpc64le-linux-gnu-gcc \
+          -DCMAKE_CXX_COMPILER=powerpc64le-linux-gnu-g++ \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_VERBOSE_MAKEFILE=1 \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=1 \
+          -Werror=dev \
+          -DCMAKE_INSTALL_PREFIX=$INSTALL_LOCATION \
+          -Dosal=embedded \
+          -Denable-libinstpatch=0 \
+          -DNO_GUI=1 \
+          ${{ matrix.CMAKE_FLAGS }}
+
+    - name: Build
+      run: cmake --build build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -173,8 +173,6 @@ jobs:
 
     - name: Configure CMake
       run: |
-        export CC=${{ matrix.CC }}
-        export CXX=${{ matrix.CXX }}
         export CFLAGS="$CFLAGS -mabi=ibmlongdouble -Wno-psabi"
         export CXXFLAGS="$CXXFLAGS -mabi=ibmlongdouble -Wno-psabi"
         cmake -S . \
@@ -191,8 +189,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=$INSTALL_LOCATION \
           -Dosal=embedded \
           -Denable-libinstpatch=0 \
-          -DNO_GUI=1 \
-          ${{ matrix.CMAKE_FLAGS }}
+          -DNO_GUI=1
 
     - name: Build
       run: cmake --build build

--- a/src/gentables/fluid_cb2amp.cpp
+++ b/src/gentables/fluid_cb2amp.cpp
@@ -2,6 +2,7 @@
 #include "utils/fluid_conv_tables.h"
 #include "gentables/ConstExprArr.hpp"
 
+#define GCEM_E static_cast<double>(2.7182818284590452353602874713526624977572L)
 #include "gcem.hpp"
 
 struct Cb2AmpFunctor
@@ -13,7 +14,7 @@ struct Cb2AmpFunctor
          * between 0 and 144 dB. Therefore a negative attenuation is
          * not allowed.
          */
-       return gcem::pow(10.0L, static_cast<fluid_real_t>(i) / -200.0L);
+       return gcem::pow(10.0, static_cast<fluid_real_t>(i) / -200.0);
     }
 };
 

--- a/src/gentables/fluid_concave.cpp
+++ b/src/gentables/fluid_concave.cpp
@@ -14,7 +14,7 @@ struct ConcaveFunctor
             ? 0
             : ((i == FLUID_VEL_CB_SIZE - 1)
                 ? 1
-                : ((-200.0L * 2 / FLUID_PEAK_ATTENUATION) * gcem::log(((FLUID_VEL_CB_SIZE - 1) - i) / (FLUID_VEL_CB_SIZE - 1.0L)) / GCEM_LOG_10)
+                : ((-200.0 * 2 / FLUID_PEAK_ATTENUATION) * gcem::log(((FLUID_VEL_CB_SIZE - 1) - i) / (FLUID_VEL_CB_SIZE - 1.0)) / static_cast<double>(GCEM_LOG_10))
                 ));
     }
 };

--- a/src/gentables/fluid_convex.cpp
+++ b/src/gentables/fluid_convex.cpp
@@ -14,7 +14,7 @@ struct ConvexFunctor
             ? 0
             : ((i == FLUID_VEL_CB_SIZE - 1)
                 ? 1
-                : (1.0L - ((-200.0L * 2 / FLUID_PEAK_ATTENUATION) * gcem::log(i / (FLUID_VEL_CB_SIZE - 1.0L)) / GCEM_LOG_10))
+                : (1.0 - ((-200.0 * 2 / FLUID_PEAK_ATTENUATION) * gcem::log(i / (FLUID_VEL_CB_SIZE - 1.0)) / static_cast<double>(GCEM_LOG_10)))
                 ));
     }
 };

--- a/src/gentables/fluid_interp_coeff_sinc7.cpp
+++ b/src/gentables/fluid_interp_coeff_sinc7.cpp
@@ -66,7 +66,7 @@ struct InterpSincFunctor
 #define I (i % SINC_INTERP_ORDER)
 #define x ((fluid_real_t)I_NUM / (fluid_real_t)FLUID_INTERP_MAX)
 #define I_SHIFTED ((fluid_real_t)I - ((fluid_real_t)SINC_INTERP_ORDER / 2.0) + (fluid_real_t)(FLUID_INTERP_MAX - I2 - 1) / (fluid_real_t)FLUID_INTERP_MAX)
-#define ARG (GCEM_PI * I_SHIFTED)
+#define ARG (static_cast<double>(GCEM_PI) * I_SHIFTED)
 
         return gcem::fabs(I_SHIFTED) > 0.000001
         ? (gcem::sin(ARG) / (ARG)) * (0.5 * (1.0 + gcem::cos(2.0 * ARG / (fluid_real_t)SINC_INTERP_ORDER)))

--- a/src/gentables/fluid_pan.cpp
+++ b/src/gentables/fluid_pan.cpp
@@ -9,7 +9,7 @@ struct PanFunctor
     static constexpr fluid_real_t calc(int i)
     {
         /* initialize the pan conversion table */
-        return static_cast<fluid_real_t>(gcem::sin(i * (GCEM_HALF_PI / (FLUID_PAN_SIZE - 1.0L))));
+        return static_cast<fluid_real_t>(gcem::sin(i * (static_cast<double>(GCEM_HALF_PI) / (FLUID_PAN_SIZE - 1.0))));
     }
 };
 


### PR DESCRIPTION
GCC doesn't support certain types of `long double` arithmetic at compile time on PowerPC platforms that use the IBM `long double` ABI, so this changes all of the compile-time `long double` arithmetic added in #1620 to use `double` instead.

I've also added a test for a platform where this causes compilation errors. Although Debian currently uses the IBM ABI by default, making the `-mabi=ibmlongdouble` flag unnecessary, I put it there explicitly in case Debian eventually switches to the IEEE 754 ABI.