### PR TITLE
Revise INFO subchunk parsing

### DIFF
--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -805,7 +805,7 @@ static int process_info(SFData *sf, int size)
                 }
             }
         }
-        ignore_chunk:
+
         size -= chunk.size;
     }
 


### PR DESCRIPTION
Previously, the chunk size validations were based on the well-known INFO subchunks as described by the spec. The validation was not intended to work with unknown chunks. This PR fixes this logic to also work well with both, subchunks that are known but unexpected within an INFO chunk as well as completely unknown subchunks.

Resolves #1644 