### PR TITLE
Add an API for manipulating soundfont-specific default modulators

### DIFF
--- a/doc/recent_changes.txt
+++ b/doc/recent_changes.txt
@@ -5,6 +5,7 @@
 - #FLUID_MOD_SIN is now deprecated, use the newly added fluid_mod_set_custom_mapping()
 - A new mode for the custom IIR filter has been added: #FLUID_IIR_BEANLAND
 - fluid_mod_get_transform() now receives a <code>const</code> argument
+- An API for manipulating fluid_sfont_t specific default modulators has been added: fluid_sfont_get_default_mod() and fluid_sfont_set_default_mod()
 
 \section NewIn2_4_5 What's new in 2.4.5?
 - In order to use the sdl3 audio driver, the downstream application is responsible for calling <code>SDL_Init()</code> and <code>SDL_Quit()</code>, just like it was practice for the sdl2 audio driver. Fluidsynth may raise a warning if this isn't done, see \ref CreatingAudioDriver

--- a/include/fluidsynth/sfont.h
+++ b/include/fluidsynth/sfont.h
@@ -247,6 +247,9 @@ FLUIDSYNTH_API int delete_fluid_sfont(fluid_sfont_t *sfont);
 FLUIDSYNTH_API int fluid_sfont_set_data(fluid_sfont_t *sfont, void *data);
 FLUIDSYNTH_API void *fluid_sfont_get_data(fluid_sfont_t *sfont);
 
+FLUIDSYNTH_API int fluid_sfont_get_default_mod(fluid_sfont_t *sfont, fluid_mod_t **mod_out);
+FLUIDSYNTH_API int fluid_sfont_set_default_mod(fluid_sfont_t *sfont, const fluid_mod_t *mods, int nmods);
+
 FLUIDSYNTH_API int fluid_sfont_get_id(fluid_sfont_t *sfont);
 FLUIDSYNTH_API const char *fluid_sfont_get_name(fluid_sfont_t *sfont);
 FLUIDSYNTH_API fluid_preset_t *fluid_sfont_get_preset(fluid_sfont_t *sfont, int bank, int prenum);

--- a/src/sfloader/fluid_defsfont.c
+++ b/src/sfloader/fluid_defsfont.c
@@ -273,8 +273,6 @@ int delete_fluid_defsfont(fluid_defsfont_t *defsfont)
         delete_fluid_sample(sample);
     }
 
-    delete_fluid_list_mod(defsfont->default_mod_list);
-
     if(defsfont->sample)
     {
         delete_fluid_list(defsfont->sample);
@@ -491,7 +489,7 @@ int fluid_defsfont_load(fluid_defsfont_t *defsfont, const fluid_file_callbacks_t
     if (dmod_data != NULL)
     {
         /* Load the default modulators*/
-        if (fluid_mod_import_sfont(&defsfont->default_mod_list, dmod_data) != FLUID_OK)
+        if (fluid_mod_import_sfont(&defsfont->sfont->default_mod_list, dmod_data) != FLUID_OK)
         {
             FLUID_LOG(FLUID_ERR, "Unable to load the default modulators");
             goto err_exit;
@@ -1223,21 +1221,6 @@ new_fluid_preset_zone(char *name)
     fluid_gen_init(&zone->gen[0], NULL);
     zone->mod = NULL; /* list of modulators */
     return zone;
-}
-
-/*
- * delete list of modulators.
- */
-void delete_fluid_list_mod(fluid_mod_t *mod)
-{
-    fluid_mod_t *tmp;
-
-    while(mod)	/* delete the modulators */
-    {
-        tmp = mod;
-        mod = mod->next;
-        delete_fluid_mod(tmp);
-    }
 }
 
 /*
@@ -2115,7 +2098,7 @@ fluid_sample_import_sfont(fluid_sample_t *sample, SFSample *sfsample, fluid_defs
     sample->origpitch = sfsample->origpitch;
     sample->pitchadj = sfsample->pitchadj;
     sample->sampletype = sfsample->sampletype;
-    sample->default_modulators = defsfont->default_mod_list;
+    sample->default_modulators = defsfont->sfont->default_mod_list;
 
     if(defsfont->dynamic_samples)
     {

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -119,7 +119,6 @@ struct _fluid_defsfont_t
     fluid_list_t *sample;           /* the samples in this soundfont */
     fluid_list_t *preset;           /* the presets of this soundfont */
     fluid_list_t *inst;             /* the instruments of this soundfont */
-    fluid_mod_t *default_mod_list;  /* the default modulator list of this soundfont */
     int mlock;                      /* Should we try memlock (avoid swapping)? */
     int dynamic_samples;            /* Enables dynamic sample loading if set */
 

--- a/src/sfloader/fluid_defsfont.h
+++ b/src/sfloader/fluid_defsfont.h
@@ -182,7 +182,6 @@ struct _fluid_preset_zone_t
 };
 
 fluid_preset_zone_t *new_fluid_preset_zone(char *name);
-void delete_fluid_list_mod(fluid_mod_t *mod);
 void delete_fluid_preset_zone(fluid_preset_zone_t *zone);
 fluid_preset_zone_t *fluid_preset_zone_next(fluid_preset_zone_t *zone);
 int fluid_preset_zone_import_sfont(fluid_preset_zone_t *zone, fluid_preset_zone_t *global_zone, SFZone *sfzone, fluid_defsfont_t *defssfont, SFData *sfdata);

--- a/src/sfloader/fluid_dls.cpp
+++ b/src/sfloader/fluid_dls.cpp
@@ -793,7 +793,7 @@ struct DLSID
 };
 
 #define DEFINE_DLSID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
-    const DLSID name = { l, w1, w2, { b1, b2, b3, b4, b5, b6, b7, b8 } }
+    static const DLSID name = { l, w1, w2, { b1, b2, b3, b4, b5, b6, b7, b8 } }
 
 // Specified in DLS-2.2 2.6 <cdl-ck>, Conditional Chunk
 // From DLS-2.2 4.2 DLS Level 2 Header File (dls2.h)
@@ -849,98 +849,98 @@ static inline void read_data_lpcm(void *dest, const void *data, fluid_long_long_
 }
 
 // DLS-2.2 2.8 <rgnh-ck>, Region Header Chunk
-constexpr uint16_t F_RGN_OPTION_SELFNONEXCLUSIVE = 0x0001;
+[[maybe_unused]] constexpr uint16_t F_RGN_OPTION_SELFNONEXCLUSIVE = 0x0001;
 
 // DLS-2.2 2.10 <art2-ck>, Level 2 Articulator Chunk; Table 9 and 10
 // DLS Level 2 (1 is included) Sources, Controls, Destinations and Transforms
 // Modulator Sources
-constexpr uint16_t CONN_SRC_NONE = 0x0000;            // No Source
-constexpr uint16_t CONN_SRC_LFO = 0x0001;             // Low Frequency Oscillator
-constexpr uint16_t CONN_SRC_KEYONVELOCITY = 0x0002;   // Note-On Velocity
-constexpr uint16_t CONN_SRC_KEYNUMBER = 0x0003;       // Note Number
-constexpr uint16_t CONN_SRC_EG1 = 0x0004;             // Envelope Generator 1
-constexpr uint16_t CONN_SRC_EG2 = 0x0005;             // Envelope Generator 2
-constexpr uint16_t CONN_SRC_PITCHWHEEL = 0x0006;      // Pitch Wheel
-constexpr uint16_t CONN_SRC_POLYPRESSURE = 0x0007;    // Polyphonic Pressure
-constexpr uint16_t CONN_SRC_CHANNELPRESSURE = 0x0008; // Channel Pressure
-constexpr uint16_t CONN_SRC_VIBRATO = 0x0009;         // Vibrato LFO
+[[maybe_unused]] constexpr uint16_t CONN_SRC_NONE = 0x0000;            // No Source
+[[maybe_unused]] constexpr uint16_t CONN_SRC_LFO = 0x0001;             // Low Frequency Oscillator
+[[maybe_unused]] constexpr uint16_t CONN_SRC_KEYONVELOCITY = 0x0002;   // Note-On Velocity
+[[maybe_unused]] constexpr uint16_t CONN_SRC_KEYNUMBER = 0x0003;       // Note Number
+[[maybe_unused]] constexpr uint16_t CONN_SRC_EG1 = 0x0004;             // Envelope Generator 1
+[[maybe_unused]] constexpr uint16_t CONN_SRC_EG2 = 0x0005;             // Envelope Generator 2
+[[maybe_unused]] constexpr uint16_t CONN_SRC_PITCHWHEEL = 0x0006;      // Pitch Wheel
+[[maybe_unused]] constexpr uint16_t CONN_SRC_POLYPRESSURE = 0x0007;    // Polyphonic Pressure
+[[maybe_unused]] constexpr uint16_t CONN_SRC_CHANNELPRESSURE = 0x0008; // Channel Pressure
+[[maybe_unused]] constexpr uint16_t CONN_SRC_VIBRATO = 0x0009;         // Vibrato LFO
 
 // MIDI Controller Sources
-constexpr uint16_t CONN_SRC_CC1 = 0x0081;  // Modulation
-constexpr uint16_t CONN_SRC_CC7 = 0x0087;  // Channel Volume
-constexpr uint16_t CONN_SRC_CC10 = 0x008a; // Pan
-constexpr uint16_t CONN_SRC_CC11 = 0x008b; // Expression
-constexpr uint16_t CONN_SRC_CC91 = 0x00db; // Chorus Send
-constexpr uint16_t CONN_SRC_CC93 = 0x00dd; // Reverb Send
+[[maybe_unused]] constexpr uint16_t CONN_SRC_CC1 = 0x0081;  // Modulation
+[[maybe_unused]] constexpr uint16_t CONN_SRC_CC7 = 0x0087;  // Channel Volume
+[[maybe_unused]] constexpr uint16_t CONN_SRC_CC10 = 0x008a; // Pan
+[[maybe_unused]] constexpr uint16_t CONN_SRC_CC11 = 0x008b; // Expression
+[[maybe_unused]] constexpr uint16_t CONN_SRC_CC91 = 0x00db; // Chorus Send
+[[maybe_unused]] constexpr uint16_t CONN_SRC_CC93 = 0x00dd; // Reverb Send
 
 // Registered Parameter Numbers
-constexpr uint16_t CONN_SRC_RPN0 = 0x0100; // RPN0 - Pitch Bend Range
-constexpr uint16_t CONN_SRC_RPN1 = 0x0101; // RPN1 - Fine Tune
-constexpr uint16_t CONN_SRC_RPN2 = 0x0102; // RPN2 - Coarse Tune
+[[maybe_unused]] constexpr uint16_t CONN_SRC_RPN0 = 0x0100; // RPN0 - Pitch Bend Range
+[[maybe_unused]] constexpr uint16_t CONN_SRC_RPN1 = 0x0101; // RPN1 - Fine Tune
+[[maybe_unused]] constexpr uint16_t CONN_SRC_RPN2 = 0x0102; // RPN2 - Coarse Tune
 
 // Generic Destinations
-constexpr uint16_t CONN_DST_NONE = 0x0000;      // No Destination
-constexpr uint16_t CONN_DST_GAIN = 0x0001;      // Gain
-constexpr uint16_t CONN_DST_RESERVED = 0x0002;  // Reserved
-constexpr uint16_t CONN_DST_PITCH = 0x0003;     // Pitch
-constexpr uint16_t CONN_DST_PAN = 0x0004;       // Pan
-constexpr uint16_t CONN_DST_KEYNUMBER = 0x0005; // Key Number Generator
+[[maybe_unused]] constexpr uint16_t CONN_DST_NONE = 0x0000;      // No Destination
+[[maybe_unused]] constexpr uint16_t CONN_DST_GAIN = 0x0001;      // Gain
+[[maybe_unused]] constexpr uint16_t CONN_DST_RESERVED = 0x0002;  // Reserved
+[[maybe_unused]] constexpr uint16_t CONN_DST_PITCH = 0x0003;     // Pitch
+[[maybe_unused]] constexpr uint16_t CONN_DST_PAN = 0x0004;       // Pan
+[[maybe_unused]] constexpr uint16_t CONN_DST_KEYNUMBER = 0x0005; // Key Number Generator
 
 // Channel Output Destinations
-constexpr uint16_t CONN_DST_LEFT = 0x0010;        // Left Channel Send
-constexpr uint16_t CONN_DST_RIGHT = 0x0011;       // Right Channel Send
-constexpr uint16_t CONN_DST_CENTER = 0x0012;      // Center Channel Send
-constexpr uint16_t CONN_DST_LFE_CHANNEL = 0x0013; // LFE Channel Send
-constexpr uint16_t CONN_DST_LEFTREAR = 0x0014;    // Left Rear Channel Send
-constexpr uint16_t CONN_DST_RIGHTREAR = 0x0015;   // Right Rear Channel Send
-constexpr uint16_t CONN_DST_CHORUS = 0x0080;      // Chorus Send
-constexpr uint16_t CONN_DST_REVERB = 0x0081;      // Reverb Send
+[[maybe_unused]] constexpr uint16_t CONN_DST_LEFT = 0x0010;        // Left Channel Send
+[[maybe_unused]] constexpr uint16_t CONN_DST_RIGHT = 0x0011;       // Right Channel Send
+[[maybe_unused]] constexpr uint16_t CONN_DST_CENTER = 0x0012;      // Center Channel Send
+[[maybe_unused]] constexpr uint16_t CONN_DST_LFE_CHANNEL = 0x0013; // LFE Channel Send
+[[maybe_unused]] constexpr uint16_t CONN_DST_LEFTREAR = 0x0014;    // Left Rear Channel Send
+[[maybe_unused]] constexpr uint16_t CONN_DST_RIGHTREAR = 0x0015;   // Right Rear Channel Send
+[[maybe_unused]] constexpr uint16_t CONN_DST_CHORUS = 0x0080;      // Chorus Send
+[[maybe_unused]] constexpr uint16_t CONN_DST_REVERB = 0x0081;      // Reverb Send
 
 // Modulator LFO Destinations
-constexpr uint16_t CONN_DST_LFO_FREQUENCY = 0x0104;  // LFO Frequency
-constexpr uint16_t CONN_DST_LFO_STARTDELAY = 0x0105; // LFO Start Delay Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_LFO_FREQUENCY = 0x0104;  // LFO Frequency
+[[maybe_unused]] constexpr uint16_t CONN_DST_LFO_STARTDELAY = 0x0105; // LFO Start Delay Time
 
 // Vibrato LFO Destinations
-constexpr uint16_t CONN_DST_VIB_FREQUENCY = 0x0114;  // Vibrato Frequency
-constexpr uint16_t CONN_DST_VIB_STARTDELAY = 0x0115; // Vibrato Start Delay
+[[maybe_unused]] constexpr uint16_t CONN_DST_VIB_FREQUENCY = 0x0114;  // Vibrato Frequency
+[[maybe_unused]] constexpr uint16_t CONN_DST_VIB_STARTDELAY = 0x0115; // Vibrato Start Delay
 
 // EG Destinations
-constexpr uint16_t CONN_DST_EG1_ATTACKTIME = 0x0206;   // EG1 Attack Time
-constexpr uint16_t CONN_DST_EG1_DECAYTIME = 0x0207;    // EG1 Decay Time
-constexpr uint16_t CONN_DST_EG1_RESERVED = 0x0208;     // EG1 Reserved
-constexpr uint16_t CONN_DST_EG1_RELEASETIME = 0x0209;  // EG1 Release Time
-constexpr uint16_t CONN_DST_EG1_SUSTAINLEVEL = 0x020A; // EG1 Sustain Level
-constexpr uint16_t CONN_DST_EG1_DELAYTIME = 0x020B;    // EG1 Delay Time
-constexpr uint16_t CONN_DST_EG1_HOLDTIME = 0x020C;     // EG1 Hold Time
-constexpr uint16_t CONN_DST_EG1_SHUTDOWNTIME = 0x020D; // EG1 Shutdown Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG1_ATTACKTIME = 0x0206;   // EG1 Attack Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG1_DECAYTIME = 0x0207;    // EG1 Decay Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG1_RESERVED = 0x0208;     // EG1 Reserved
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG1_RELEASETIME = 0x0209;  // EG1 Release Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG1_SUSTAINLEVEL = 0x020A; // EG1 Sustain Level
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG1_DELAYTIME = 0x020B;    // EG1 Delay Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG1_HOLDTIME = 0x020C;     // EG1 Hold Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG1_SHUTDOWNTIME = 0x020D; // EG1 Shutdown Time
 
-constexpr uint16_t CONN_DST_EG2_ATTACKTIME = 0x030A;   // EG2 Attack Time
-constexpr uint16_t CONN_DST_EG2_DECAYTIME = 0x030B;    // EG2 Decay Time
-constexpr uint16_t CONN_DST_EG2_RESERVED = 0x030C;     // EG2 Reserved
-constexpr uint16_t CONN_DST_EG2_RELEASETIME = 0x030D;  // EG2 Release Time
-constexpr uint16_t CONN_DST_EG2_SUSTAINLEVEL = 0x030E; // EG2 Sustain Level
-constexpr uint16_t CONN_DST_EG2_DELAYTIME = 0x030F;    // EG2 Delay Time
-constexpr uint16_t CONN_DST_EG2_HOLDTIME = 0x0310;     // EG2 Hold Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG2_ATTACKTIME = 0x030A;   // EG2 Attack Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG2_DECAYTIME = 0x030B;    // EG2 Decay Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG2_RESERVED = 0x030C;     // EG2 Reserved
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG2_RELEASETIME = 0x030D;  // EG2 Release Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG2_SUSTAINLEVEL = 0x030E; // EG2 Sustain Level
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG2_DELAYTIME = 0x030F;    // EG2 Delay Time
+[[maybe_unused]] constexpr uint16_t CONN_DST_EG2_HOLDTIME = 0x0310;     // EG2 Hold Time
 
 // Filter Destinations
-constexpr uint16_t CONN_DST_FILTER_CUTOFF = 0x0500; // Filter Cutoff Frequency
-constexpr uint16_t CONN_DST_FILTER_Q = 0x0501;      // Filter Resonance
+[[maybe_unused]] constexpr uint16_t CONN_DST_FILTER_CUTOFF = 0x0500; // Filter Cutoff Frequency
+[[maybe_unused]] constexpr uint16_t CONN_DST_FILTER_Q = 0x0501;      // Filter Resonance
 
 // Transforms
-constexpr uint16_t CONN_TRN_NONE = 0x0000;    // No Transform
-constexpr uint16_t CONN_TRN_CONCAVE = 0x0001; // Concave Transform
-constexpr uint16_t CONN_TRN_CONVEX = 0x0002;  // Convex Transform
-constexpr uint16_t CONN_TRN_SWITCH = 0x0003;  // Switch Transform
+[[maybe_unused]] constexpr uint16_t CONN_TRN_NONE = 0x0000;    // No Transform
+[[maybe_unused]] constexpr uint16_t CONN_TRN_CONCAVE = 0x0001; // Concave Transform
+[[maybe_unused]] constexpr uint16_t CONN_TRN_CONVEX = 0x0002;  // Convex Transform
+[[maybe_unused]] constexpr uint16_t CONN_TRN_SWITCH = 0x0003;  // Switch Transform
 
 // DLS-2.2 2.10 <art2-ck>, Level 2 Articulator Chunk
 // transform mask
-constexpr uint16_t TRN_SRC_INV_MASK = 0b100000'000000'0000;
-constexpr uint16_t TRN_SRC_BIP_MASK = 0b010000'000000'0000;
-constexpr uint16_t TRN_SRC_TRN_MASK = 0b001111'000000'0000;
-constexpr uint16_t TRN_CTL_INV_MASK = 0b000000'100000'0000;
-constexpr uint16_t TRN_CTL_BIP_MASK = 0b000000'010000'0000;
-constexpr uint16_t TRN_CTL_TRN_MASK = 0b000000'001111'0000;
-constexpr uint16_t TRN_OUT_TRN_MASK = 0b000000'000000'1111;
+[[maybe_unused]] constexpr uint16_t TRN_SRC_INV_MASK = 0b100000'000000'0000;
+[[maybe_unused]] constexpr uint16_t TRN_SRC_BIP_MASK = 0b010000'000000'0000;
+[[maybe_unused]] constexpr uint16_t TRN_SRC_TRN_MASK = 0b001111'000000'0000;
+[[maybe_unused]] constexpr uint16_t TRN_CTL_INV_MASK = 0b000000'100000'0000;
+[[maybe_unused]] constexpr uint16_t TRN_CTL_BIP_MASK = 0b000000'010000'0000;
+[[maybe_unused]] constexpr uint16_t TRN_CTL_TRN_MASK = 0b000000'001111'0000;
+[[maybe_unused]] constexpr uint16_t TRN_OUT_TRN_MASK = 0b000000'000000'1111;
 
 struct DLSTransform
 {
@@ -2984,18 +2984,6 @@ void fluid_dls_loader_delete(fluid_sfloader_t *loader) noexcept
     delete_fluid_sfloader(loader);
 }
 
-extern "C"
-{
-    extern fluid_mod_t default_vel2att_mod;
-    extern fluid_mod_t default_mod2viblfo_mod;
-    extern fluid_mod_t default_att_mod;
-    extern fluid_mod_t default_pan_mod;
-    extern fluid_mod_t default_expr_mod;
-    extern fluid_mod_t custom_balance_mod;
-    extern fluid_mod_t DLS_default_reverb_mod;
-    extern fluid_mod_t DLS_default_chorus_mod;
-    extern fluid_mod_t DLS_default_pitch_bend_mod;
-}
 static fluid_mod_t *fluid_dls_default_mod_list()
 {
     std::array def_mods =   // skip default_vel2filter_mod

--- a/src/sfloader/fluid_dls.h
+++ b/src/sfloader/fluid_dls.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-fluid_sfloader_t* new_fluid_dls_loader(fluid_synth_t *synth, fluid_settings_t *settings);
+fluid_sfloader_t *new_fluid_dls_loader(fluid_synth_t *synth, fluid_settings_t *settings);
 
 #ifdef __cplusplus
 }

--- a/src/sfloader/fluid_sfont.c
+++ b/src/sfloader/fluid_sfont.c
@@ -317,6 +317,7 @@ fluid_preset_t *fluid_sfont_get_preset(fluid_sfont_t *sfont, int bank, int prenu
  * @param sfont The SoundFont instance.
  * @param mod_out A reference to a fluid_mod_t buffer. The pointer will be allocated by fluidsynth, the caller is responsible for freeing the buffer with fluid_free().
  * @return FLUID_FAILED if out of memory. Otherwise it contains the number of modulators saved into the buffer. The caller must always free the buffer, even if the return value is zero!
+ * @since 2.5.0
  */
 int fluid_sfont_get_default_mod(fluid_sfont_t *sfont, fluid_mod_t **mod_out)
 {
@@ -332,7 +333,7 @@ int fluid_sfont_get_default_mod(fluid_sfont_t *sfont, fluid_mod_t **mod_out)
         res = FLUID_ARRAY(fluid_mod_t, i);
         if (res == NULL)
         {
-            mod_out = NULL;
+            *mod_out = NULL;
             FLUID_LOG(FLUID_PANIC, "Out of memory");
             return FLUID_FAILED;
         }
@@ -342,7 +343,7 @@ int fluid_sfont_get_default_mod(fluid_sfont_t *sfont, fluid_mod_t **mod_out)
             fluid_mod_clone(&res[i], mod);
             mod = mod->next;
         }
-        mod_out = res;
+        *mod_out = res;
         return i;
     }
 }
@@ -350,13 +351,17 @@ int fluid_sfont_get_default_mod(fluid_sfont_t *sfont, fluid_mod_t **mod_out)
 /**
  * Sets the default modulators of a SoundFont instance.
  *
- * @param sfont The SoundFont instance
+ * @param sfont The SoundFont instance.
  * @param mods Pointer to an array of default modulators.
  * @param nmods Number of modulators in the provided array.
  * @return FLUID_OK on success, FLUID_FAILED otherwise.
  *
- * @note If @p mods is a zero-length array or mods is NULL the default modulators attached to this
+ * @note If @p mods is a zero-length array or @p mods is NULL the default modulators attached to this
  * SoundFont will be unset, causing the synth's default modulators to be added to voices again.
+ * The behavior is undefined if the array contains multiple identical modulators
+ * (i.e. fluid_mod_test_identity() evaluates to true).
+ *
+ * @since 2.5.0
  */
 int fluid_sfont_set_default_mod(fluid_sfont_t *sfont, const fluid_mod_t *mods, int nmods)
 {

--- a/src/sfloader/fluid_sfont.c
+++ b/src/sfloader/fluid_sfont.c
@@ -219,13 +219,20 @@ fluid_sfont_t *new_fluid_sfont(fluid_sfont_get_name_t get_name,
                                fluid_sfont_iteration_next_t iter_next,
                                fluid_sfont_free_t free)
 {
-    fluid_sfont_t *sfont;
-
     fluid_return_val_if_fail(get_name != NULL, NULL);
     fluid_return_val_if_fail(get_preset != NULL, NULL);
     fluid_return_val_if_fail(free != NULL, NULL);
 
-    sfont = FLUID_NEW(fluid_sfont_t);
+    return new_fluid_sfont_local(get_name, get_preset, iter_start, iter_next, free);
+}
+
+fluid_sfont_t *new_fluid_sfont_local(fluid_sfont_get_name_t get_name,
+                               fluid_sfont_get_preset_t get_preset,
+                               fluid_sfont_iteration_start_t iter_start,
+                               fluid_sfont_iteration_next_t iter_next,
+                               fluid_sfont_free_t free)
+{
+    fluid_sfont_t *sfont = FLUID_NEW(fluid_sfont_t);
 
     if(sfont == NULL)
     {
@@ -318,6 +325,7 @@ fluid_preset_t *fluid_sfont_get_preset(fluid_sfont_t *sfont, int bank, int prenu
  * @param mod_out A reference to a fluid_mod_t buffer. The pointer will be allocated by fluidsynth, the caller is responsible for freeing the buffer with fluid_free().
  * @return FLUID_FAILED if out of memory. Otherwise it contains the number of modulators saved into the buffer. The caller must always free the buffer, even if the return value is zero!
  * @since 2.5.0
+ * @note This function involves memory allocation and is therefore not real-time safe!
  */
 int fluid_sfont_get_default_mod(fluid_sfont_t *sfont, fluid_mod_t **mod_out)
 {
@@ -360,6 +368,7 @@ int fluid_sfont_get_default_mod(fluid_sfont_t *sfont, fluid_mod_t **mod_out)
  * SoundFont will be unset, causing the synth's default modulators to be added to voices again.
  * The behavior is undefined if the array contains multiple identical modulators
  * (i.e. fluid_mod_test_identity() evaluates to true).
+ * Further note that this function involves memory allocation and is therefore not real-time safe!
  *
  * @since 2.5.0
  */
@@ -369,7 +378,7 @@ int fluid_sfont_set_default_mod(fluid_sfont_t *sfont, const fluid_mod_t *mods, i
     fluid_mod_t *list = NULL;
 
     fluid_return_val_if_fail(sfont != NULL, FLUID_FAILED);
-    fluid_return_val_if_fail(nmods < 0, FLUID_FAILED);
+    fluid_return_val_if_fail(nmods >= 0, FLUID_FAILED);
 
     delete_fluid_list_mod(sfont->default_mod_list);
 

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -37,6 +37,12 @@ int fluid_sample_sanitize_loop(fluid_sample_t *sample, unsigned int max_end);
 #define fluid_sfloader_load(_loader, _filename) (*(_loader)->load)(_loader, _filename)
 
 
+
+fluid_sfont_t *new_fluid_sfont_local(fluid_sfont_get_name_t get_name,
+                               fluid_sfont_get_preset_t get_preset,
+                               fluid_sfont_iteration_start_t iter_start,
+                               fluid_sfont_iteration_next_t iter_next,
+                               fluid_sfont_free_t free);
 #define fluid_sfont_delete_internal(_sf)   ( ((_sf) && (_sf)->free)? (*(_sf)->free)(_sf) : 0)
 
 

--- a/src/sfloader/fluid_sfont.h
+++ b/src/sfloader/fluid_sfont.h
@@ -96,6 +96,8 @@ struct _fluid_sfont_t
     int refcount;         /**< SoundFont reference count (1 if no presets referencing it) */
     int bankofs;          /**< Bank offset */
 
+    fluid_mod_t *default_mod_list; /* If not NULL, a list of default modulators for that soundfont (e.g. read from DMOD, or DLS compatibility default mods) */
+
     fluid_sfont_free_t free;
 
     fluid_sfont_get_name_t get_name;

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -532,6 +532,21 @@ delete_fluid_mod(fluid_mod_t *mod)
     FLUID_FREE(mod);
 }
 
+/*
+ * delete list of modulators.
+ */
+void delete_fluid_list_mod(fluid_mod_t *mod)
+{
+    fluid_mod_t *tmp;
+
+    while (mod) /* delete the modulators */
+    {
+        tmp = mod;
+        mod = mod->next;
+        delete_fluid_mod(tmp);
+    }
+}
+
 /**
  * Returns the size of the fluid_mod_t structure.
  *

--- a/src/synth/fluid_mod.h
+++ b/src/synth/fluid_mod.h
@@ -62,6 +62,7 @@ int fluid_mod_check_sources(const fluid_mod_t *mod, char *name);
 fluid_real_t fluid_mod_get_source_value(const unsigned char mod_src, const unsigned char mod_flags, fluid_real_t *range, const fluid_voice_t *voice);
 fluid_real_t fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid_real_t range, int is_src1);
 
+void delete_fluid_list_mod(fluid_mod_t *mod);
 
 #ifdef DEBUG
 void fluid_dump_modulator(fluid_mod_t *mod);

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -162,23 +162,27 @@ static fluid_atomic_int_t fluid_synth_initialized = {0};
  * explicitly overridden by the sound font in order to turn them off.
  */
 
-static fluid_mod_t default_vel2att_mod;        /* SF2.01 section 8.4.1  */
-/*not static */ fluid_mod_t default_vel2filter_mod;     /* SF2.01 section 8.4.2  */
-static fluid_mod_t default_at2viblfo_mod;      /* SF2.01 section 8.4.3  */
-static fluid_mod_t default_mod2viblfo_mod;     /* SF2.01 section 8.4.4  */
-static fluid_mod_t default_att_mod;            /* SF2.01 section 8.4.5  */
-static fluid_mod_t default_pan_mod;            /* SF2.01 section 8.4.6  */
-static fluid_mod_t default_expr_mod;           /* SF2.01 section 8.4.7  */
-static fluid_mod_t default_reverb_mod;         /* SF2.01 section 8.4.8  */
-static fluid_mod_t default_chorus_mod;         /* SF2.01 section 8.4.9  */
-static fluid_mod_t default_pitch_bend_mod;     /* SF2.01 section 8.4.10 */
-static fluid_mod_t custom_balance_mod;         /* Non-standard modulator */
+fluid_mod_t default_vel2att_mod;        /* SF2.01 section 8.4.1  */
+fluid_mod_t default_vel2filter_mod;     /* SF2.01 section 8.4.2  */
+fluid_mod_t default_at2viblfo_mod;      /* SF2.01 section 8.4.3  */
+fluid_mod_t default_mod2viblfo_mod;     /* SF2.01 section 8.4.4  */
+fluid_mod_t default_att_mod;            /* SF2.01 section 8.4.5  */
+fluid_mod_t default_pan_mod;            /* SF2.01 section 8.4.6  */
+fluid_mod_t default_expr_mod;           /* SF2.01 section 8.4.7  */
+fluid_mod_t default_reverb_mod;         /* SF2.01 section 8.4.8  */
+fluid_mod_t default_chorus_mod;         /* SF2.01 section 8.4.9  */
+fluid_mod_t default_pitch_bend_mod;     /* SF2.01 section 8.4.10 */
+fluid_mod_t custom_balance_mod;         /* Non-standard modulator */
 
+/* DLS specific modulators */
+fluid_mod_t DLS_default_reverb_mod;
+fluid_mod_t DLS_default_chorus_mod;
+fluid_mod_t DLS_default_pitch_bend_mod;
 
-/* custom_breath2att_modulator is not a default modulator specified in SF
-it is intended to replace default_vel2att_mod on demand using
-API fluid_set_breath_mode() or command shell setbreathmode.
-*/
+/* custom_breath2att_modulator is not a default modulator specified in SF2
+ * it is intended to replace default_vel2att_mod on demand using
+ * API fluid_set_breath_mode() or command shell setbreathmode.
+ */
 static fluid_mod_t custom_breath2att_mod;
 
 /* reverb presets */
@@ -497,6 +501,20 @@ fluid_synth_init(void)
     fluid_mod_set_dest(&custom_balance_mod, GEN_CUSTOM_BALANCE);     /* Destination: stereo balance */
     /* Amount: 96 dB of attenuation (on the opposite channel) */
     fluid_mod_set_amount(&custom_balance_mod, FLUID_PEAK_ATTENUATION); /* Amount: 960 */
+
+    // DLS-specific default MODs below
+    // 
+    // CC 91 -> reverb send 100%
+    fluid_mod_clone(&DLS_default_reverb_mod, &default_reverb_mod);
+    fluid_mod_set_amount(&DLS_default_reverb_mod, 1000);
+
+    // CC 93 -> chorus send 100%
+    fluid_mod_clone(&DLS_default_chorus_mod, &default_chorus_mod);
+    fluid_mod_set_amount(&DLS_default_chorus_mod, 1000);
+
+    // pitch wheel --(rpn 0)-> pitch 12800 cents
+    fluid_mod_clone(&DLS_default_pitch_bend_mod, &default_pitch_bend_mod);
+    fluid_mod_set_amount(&DLS_default_pitch_bend_mod, 12800);
 
 #if defined(LIBINSTPATCH_SUPPORT)
     /* defer libinstpatch init to fluid_instpatch.c to avoid #include "libinstpatch.h" */

--- a/src/synth/fluid_synth.h
+++ b/src/synth/fluid_synth.h
@@ -178,6 +178,21 @@ struct _fluid_synth_t
     fluid_iir_sincos_t iir_sincos_table[SINCOS_TAB_SIZE]; /**< Table of sin/cos values for IIR filter */
 };
 
+extern fluid_mod_t default_vel2att_mod;
+extern fluid_mod_t default_at2viblfo_mod;
+extern fluid_mod_t default_mod2viblfo_mod;
+extern fluid_mod_t default_vel2filter_mod;
+extern fluid_mod_t default_att_mod;
+extern fluid_mod_t default_pan_mod;
+extern fluid_mod_t default_expr_mod;
+extern fluid_mod_t default_pitch_bend_mod;
+extern fluid_mod_t default_chorus_mod;
+extern fluid_mod_t default_reverb_mod;
+extern fluid_mod_t custom_balance_mod;
+extern fluid_mod_t DLS_default_reverb_mod;
+extern fluid_mod_t DLS_default_chorus_mod;
+extern fluid_mod_t DLS_default_pitch_bend_mod;
+
 /**
  * Type definition of the synthesizer's audio callback function.
  * @param synth FluidSynth instance

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ ADD_FLUID_TEST(test_seq_event_queue_remove)
 ADD_FLUID_TEST(test_jack_obtaining_synth)
 ADD_FLUID_TEST(test_utf8_open)
 ADD_FLUID_TEST(test_modulator)
+ADD_FLUID_TEST(test_default_mod)
 
 if ( GLIB_SUPPORT AND GLib2_VERSION VERSION_GREATER_EQUAL 2.33.12 )
     # Earlier versions of GLib had broken comment handling and should not be compared to

--- a/test/test_default_mod.c
+++ b/test/test_default_mod.c
@@ -1,0 +1,217 @@
+
+#include "test.h"
+#include "fluidsynth.h"
+#include "fluidsynth_priv.h"
+#include "fluid_synth.h"
+#include "fluid_mod.h"
+#include "fluid_sfont.h"
+
+unsigned int count_modulator_list(fluid_mod_t *mod)
+{
+    unsigned int i = 0;
+    while(mod)
+    {
+        mod = mod->next;
+        i++;
+    }
+    return i;
+}
+
+void synth_global_default_mods(fluid_synth_t *synth)
+{
+    // Custom Modulators borrowed from https://github.com/spessasus/spessasynth_core/blob/6ce2aa37cec01c6345d08c816298706dc2e8d69d/src/soundbank/basic_soundbank/modulator.ts#L304
+    // ... might turn out to be useful
+    fluid_mod_t mod[6] = {0};
+    fluid_mod_t *my_mod = &mod[0];
+
+    unsigned int n = count_modulator_list(synth->default_mod);
+    TEST_ASSERT(n == 11);
+
+    // Poly pressure to vibrato
+    fluid_mod_set_source1(my_mod,
+                            FLUID_MOD_KEYPRESSURE,
+                            FLUID_MOD_GC | FLUID_MOD_LINEAR | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE);
+    fluid_mod_set_source2(my_mod, FLUID_MOD_NONE, 0);
+    fluid_mod_set_dest(my_mod, GEN_VIBLFOTOPITCH);
+    fluid_mod_set_amount(my_mod, 50);
+    TEST_SUCCESS(fluid_synth_add_default_mod(synth, my_mod, FLUID_SYNTH_OVERWRITE));
+
+    my_mod = &mod[1];
+    // Cc 92 (tremolo) to modLFO volume
+    fluid_mod_set_source1(my_mod,
+                            EFFECTS_DEPTH2,
+                            FLUID_MOD_CC | FLUID_MOD_LINEAR | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE);
+    fluid_mod_set_source2(my_mod, FLUID_MOD_NONE, 0);
+    fluid_mod_set_dest(my_mod, GEN_MODLFOTOVOL);
+    fluid_mod_set_amount(my_mod, 24);
+    TEST_SUCCESS(fluid_synth_add_default_mod(synth, my_mod, FLUID_SYNTH_OVERWRITE));
+
+    my_mod = &mod[2];
+    // Cc 73 (attack time) to volEnv attack
+    fluid_mod_set_source1(my_mod,
+                            SOUND_CTRL4,
+                            FLUID_MOD_CC | FLUID_MOD_CONVEX | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE);
+    fluid_mod_set_source2(my_mod, FLUID_MOD_NONE, 0);
+    fluid_mod_set_dest(my_mod, GEN_VOLENVATTACK);
+    fluid_mod_set_amount(my_mod, 6000);
+    TEST_SUCCESS(fluid_synth_add_default_mod(synth, my_mod, FLUID_SYNTH_OVERWRITE));
+
+    my_mod = &mod[3];
+    // Cc 72 (release time) to volEnv release
+    fluid_mod_set_source1(my_mod,
+                            SOUND_CTRL3,
+                            FLUID_MOD_CC | FLUID_MOD_LINEAR | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE);
+    fluid_mod_set_source2(my_mod, FLUID_MOD_NONE, 0);
+    fluid_mod_set_dest(my_mod, GEN_VOLENVRELEASE);
+    fluid_mod_set_amount(my_mod, 3600);
+    TEST_SUCCESS(fluid_synth_add_default_mod(synth, my_mod, FLUID_SYNTH_OVERWRITE));
+
+    my_mod = &mod[4];
+    // Cc 74 (brightness) to filterFc
+    fluid_mod_set_source1(my_mod,
+                            SOUND_CTRL5,
+                            FLUID_MOD_CC | FLUID_MOD_LINEAR | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE);
+    fluid_mod_set_source2(my_mod, FLUID_MOD_NONE, 0);
+    fluid_mod_set_dest(my_mod, GEN_FILTERFC);
+    fluid_mod_set_amount(my_mod, 6000);
+    TEST_SUCCESS(fluid_synth_add_default_mod(synth, my_mod, FLUID_SYNTH_OVERWRITE));
+
+    my_mod = &mod[5];
+    // Cc 71 (filter Q) to filter Q (default resonant modulator)
+    fluid_mod_set_source1(my_mod,
+                            SOUND_CTRL2,
+                            FLUID_MOD_CC | FLUID_MOD_LINEAR | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE);
+    fluid_mod_set_source2(my_mod, FLUID_MOD_NONE, 0);
+    fluid_mod_set_dest(my_mod, GEN_FILTERQ);
+    fluid_mod_set_amount(my_mod, 250);
+    TEST_SUCCESS(fluid_synth_add_default_mod(synth, my_mod, FLUID_SYNTH_OVERWRITE));
+
+    n = count_modulator_list(synth->default_mod);
+    TEST_ASSERT(n == 11+6);
+
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_vel2att_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_vel2filter_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_at2viblfo_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_mod2viblfo_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_att_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_pan_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_expr_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_reverb_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_chorus_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &default_pitch_bend_mod));
+    TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &custom_balance_mod));
+
+    n = count_modulator_list(synth->default_mod);
+    TEST_ASSERT(n == 6);
+
+    for(n=0; n< FLUID_N_ELEMENTS(mod); n++)
+    {
+        TEST_SUCCESS(fluid_synth_remove_default_mod(synth, &mod[n]));
+    }
+
+    TEST_ASSERT(synth->default_mod == NULL);
+    n = count_modulator_list(synth->default_mod);
+    TEST_ASSERT(n == 0);
+
+    n = fluid_synth_remove_default_mod(synth, &default_pitch_bend_mod);
+    TEST_ASSERT(n == FLUID_FAILED);
+
+    TEST_SUCCESS(fluid_synth_add_default_mod(synth, &default_vel2att_mod, FLUID_SYNTH_ADD));
+
+    n = count_modulator_list(synth->default_mod);
+    TEST_ASSERT(n == 1);
+    TEST_ASSERT(fluid_mod_test_identity(synth->default_mod, &default_vel2att_mod));
+
+    n = fluid_synth_remove_default_mod(synth, &default_pitch_bend_mod);
+    TEST_ASSERT(n == FLUID_FAILED);
+
+    n = count_modulator_list(synth->default_mod);
+    TEST_ASSERT(n == 1);
+}
+
+void sfont_default_mods(fluid_sfont_t *sfont)
+{
+    int res, i;
+    fluid_mod_t mods[3] = {0};
+    fluid_mod_t *def_mod, *my_mod;
+
+    TEST_ASSERT(sfont->default_mod_list == NULL);
+    res = fluid_sfont_get_default_mod(sfont, &def_mod);
+    TEST_ASSERT(res == 0);
+    TEST_ASSERT(def_mod != NULL);
+    fluid_free(def_mod);
+    def_mod = NULL;
+
+    res = fluid_sfont_set_default_mod(sfont, NULL, 0);
+    TEST_SUCCESS(res);
+    TEST_ASSERT(sfont->default_mod_list == NULL);
+
+    my_mod = &mods[0];
+    fluid_mod_set_source1(my_mod,
+                            FLUID_MOD_VELOCITY,
+                            FLUID_MOD_GC | FLUID_MOD_CONCAVE | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE);
+    fluid_mod_set_source2(my_mod, FLUID_MOD_NONE, 0);
+    fluid_mod_set_dest(my_mod, GEN_ATTENUATION);
+    fluid_mod_set_amount(my_mod, 960 * 0.4);
+
+    my_mod = &mods[1];
+    fluid_mod_set_source1(my_mod,
+                            7,
+                            FLUID_MOD_CC | FLUID_MOD_CONCAVE | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE);
+
+    my_mod = &mods[2];
+    fluid_mod_set_source1(my_mod,
+                            11,
+                            FLUID_MOD_CC | FLUID_MOD_CONCAVE | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE);
+
+    res = fluid_sfont_set_default_mod(sfont, mods, FLUID_N_ELEMENTS(mods));
+    TEST_SUCCESS(res);
+    TEST_ASSERT(sfont->default_mod_list != NULL);
+
+    res = fluid_sfont_get_default_mod(sfont, &def_mod);
+    TEST_ASSERT(res == 3);
+    TEST_ASSERT(def_mod != NULL);
+
+    for(i=0; i<res; i++)
+    {
+        TEST_ASSERT(fluid_mod_test_identity(&def_mod[i], &mods[i]));
+    }
+
+    fluid_free(def_mod);
+    def_mod = NULL;
+
+    res = fluid_sfont_set_default_mod(sfont, (void*)0xE6AL, 0);
+    TEST_SUCCESS(res);
+    TEST_ASSERT(sfont->default_mod_list == NULL);
+}
+
+// this test should make sure that sample rate changed are handled correctly
+int main(void)
+{
+    fluid_mod_t *mod;
+    fluid_sfont_t *sfont;
+    fluid_settings_t *settings;
+    fluid_synth_t *synth;
+
+    mod = new_fluid_mod();
+    TEST_ASSERT(mod != NULL);
+
+    sfont = new_fluid_sfont_local(NULL, NULL, NULL, NULL, NULL);
+    TEST_ASSERT(sfont != NULL);
+
+    settings = new_fluid_settings();
+    TEST_ASSERT(settings != NULL);
+
+    synth = new_fluid_synth(settings);
+    TEST_ASSERT(synth != NULL);
+
+    synth_global_default_mods(synth);
+    sfont_default_mods(sfont);
+
+    delete_fluid_synth(synth);
+    delete_fluid_settings(settings);
+    delete_fluid_sfont(sfont);
+    delete_fluid_mod(mod);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
#1599 has added support SF2 specific default modulators. #1626 proposes to add DLS specific default modulators to improve accuracy of DLS synthesized audio.

Previously, fluidsynth was lacking a way to access these modulators via the API. The existing API `fluid_synth_add_default_mod()` is insufficient, as it operates on the synth's global default modulators (those given by the SF2 spec).

This stacked PR addresses this lack, by adding an API that allows a user to retrieve and manipulate Soundfont (SF2 and DLS) specific default modulators.

EDIT: This PR now includes additional code-reformatting of `fluid_dls.*`, hence you probably only want to look at the [first two commits](https://github.com/FluidSynth/fluidsynth/pull/1652/files/de3707519c77cd51bcea091dd6d001677fe67b23))