### PR TITLE
Add a unit test for modulator mappings

### DIFF
--- a/cmake_admin/FluidUnitTest.cmake
+++ b/cmake_admin/FluidUnitTest.cmake
@@ -1,5 +1,11 @@
 macro ( ADD_FLUID_TEST _test )
-    add_executable( ${_test} ${_test}.c )
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_test}.c")
+        add_executable(${_test} ${_test}.c)
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_test}.cpp")
+        add_executable(${_test} ${_test}.cpp)
+    else()
+        message(FATAL_ERROR "Neither ${_test}.c nor ${_test}.cpp found in ${CMAKE_CURRENT_SOURCE_DIR}")
+    endif()
 
     # only build this unit test when explicitly requested by "make check"
     set_target_properties(${_test} PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/include/fluidsynth/mod.h
+++ b/include/fluidsynth/mod.h
@@ -87,15 +87,16 @@ enum fluid_mod_src
  * See fluid_mod_set_custom_mapping().
  *
  * @param mod The modulator instance. The behavior is undefined if you modify @mod through any of the fluid_mod_set*() functions from within the callback.
- * @param value The input value, which will be in range [0;16383.f/16384.f] (if the input value originates from the
- * pitch wheel), or [0;127.f/128.f] otherwise.
+ * @param value The input value from the modulator source, which will be in range <code>[0;16383]</code> (if the input source value is #FLUID_MOD_PITCHWHEEL), or <code>[0;127]</code> otherwise.
+ * @param range The value-range of the modulator source, i.e. 16384, if the input source value is #FLUID_MOD_PITCHWHEEL, otherwise 128.
  * @param data Custom data pointer, as set by fluid_mod_set_custom_mapping().
  * @param is_src1 A boolean, which, if true, indicates that the mapping function is called for source1. Otherwise, it's called for source2. Only useful if two sources have been specified with the #FLUID_MOD_CUSTOM flag set.
  * @return A value mapped into range [-1.0;+1.0].
  * @note For return values that exceed the mentioned range, the behavior is unspecified
  * (i.e. it may be honored, it may be clipped, ignored, the entire modulator may be disabled, etc.).
+ * @since 2.5.0
  */
-typedef double (*fluid_mod_mapping_t)(const fluid_mod_t* mod, double value, int is_src1, void* data);
+typedef double (*fluid_mod_mapping_t)(const fluid_mod_t *mod, int value, int range, int is_src1, void *data);
 
 /** @startlifecycle{Modulator} */
 FLUIDSYNTH_API fluid_mod_t *new_fluid_mod(void);

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -315,7 +315,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
         }
         else
         {
-            val = mod->mapping_func(mod, val_norm, is_src1, mod->data);
+            val = mod->mapping_func(mod, (int)(val+0.5f), (int)(range+0.5f), is_src1, mod->data);
         }
     }
     else

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -218,14 +218,15 @@ fluid_mod_get_transform(const fluid_mod_t *mod)
 /*
  * retrieves the initial value from the given source of the modulator
  */
-static fluid_real_t
+fluid_real_t
 fluid_mod_get_source_value(const unsigned char mod_src,
                            const unsigned char mod_flags,
                            fluid_real_t *range,
                            const fluid_voice_t *voice
                           )
 {
-    const fluid_channel_t *chan = voice->channel;
+    // voice might be NULL in case of unit testing
+    const fluid_channel_t *chan = voice != NULL ? voice->channel : NULL;
     fluid_real_t val;
 
     if(mod_flags & FLUID_MOD_CC)

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -55,6 +55,12 @@ fluid_mod_clone(fluid_mod_t *mod, const fluid_mod_t *src)
 void
 fluid_mod_set_source1(fluid_mod_t *mod, int src, int flags)
 {
+    if ((flags & FLUID_MOD_MAP_MASK) == FLUID_MOD_SIN)
+    {
+        FLUID_LOG(FLUID_ERR, "This version of fluidsynth no longer supports FLUID_MOD_SIN, pls. use fluid_mod_set_custom_mapping() instead. Disabling source.");
+        src = FLUID_MOD_NONE;
+    }
+
     mod->src1 = src;
     mod->flags1 = flags;
 }
@@ -71,6 +77,12 @@ fluid_mod_set_source1(fluid_mod_t *mod, int src, int flags)
 void
 fluid_mod_set_source2(fluid_mod_t *mod, int src, int flags)
 {
+    if ((flags & FLUID_MOD_MAP_MASK) == FLUID_MOD_SIN)
+    {
+        FLUID_LOG(FLUID_ERR, "This version of fluidsynth no longer supports FLUID_MOD_SIN, pls. use fluid_mod_set_custom_mapping() instead. Disabling source.");
+        src = FLUID_MOD_NONE;
+    }
+
     mod->src2 = src;
     mod->flags2 = flags;
 }
@@ -328,11 +340,6 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid
     }
     else
     {
-        if ((mod_flags & FLUID_MOD_MAP_MASK) == FLUID_MOD_SIN)
-        {
-            FLUID_LOG(FLUID_ERR, "This version of fluidsynth no longer supports FLUID_MOD_SIN, pls. use fluid_mod_set_custom_mapping() instead.");
-        }
-
         if ((mod_flags & FLUID_MOD_POLAR_MASK) == FLUID_MOD_UNIPOLAR)
         {
             if ((mod_flags & FLUID_MOD_SIGN_MASK) == FLUID_MOD_NEGATIVE)

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -290,12 +290,6 @@ fluid_mod_get_source_value(const unsigned char mod_src,
 fluid_real_t
 fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned char mod_flags, const fluid_real_t range, int is_src1)
 {
-    enum
-    {
-        FLUID_MOD_POLAR_MASK = FLUID_MOD_BIPOLAR | FLUID_MOD_UNIPOLAR,
-        FLUID_MOD_MAP_MASK = FLUID_MOD_LINEAR | FLUID_MOD_CONCAVE | FLUID_MOD_CONVEX | FLUID_MOD_SWITCH | FLUID_MOD_SIN,
-        FLUID_MOD_SIGN_MASK = FLUID_MOD_POSITIVE | FLUID_MOD_NEGATIVE,
-    };
     /* normalized value, i.e. usually in the range [0;1] */
     const fluid_real_t val_norm = val / range;
     /* inverted value used for negative mapping functions */

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -292,6 +292,8 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
 {
     /* normalized value, i.e. usually in the range [0;1] */
     const fluid_real_t val_norm = val / range;
+    /* inverted value used for negative mapping functions */
+    const fluid_real_t inv_norm = 1.0f - val_norm;
 
     /* we could also only switch case the lower nibble of mod_flags, however
      * this would keep us from adding further mod types in the future
@@ -325,7 +327,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_LINEAR | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* =1 */
-                val = 1.0f - val_norm;
+                val = inv_norm;
                 break;
 
             case FLUID_MOD_LINEAR | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* =2 */
@@ -333,7 +335,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_LINEAR | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* =3 */
-                val = 1.0f - 2.0f * val_norm;
+                val = -1.0f + 2.0f * inv_norm;
                 break;
 
             case FLUID_MOD_CONCAVE | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE: /* =4 */
@@ -341,7 +343,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_CONCAVE | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* =5 */
-                val = fluid_concave(127 * (1.0f - val_norm));
+                val = fluid_concave(127 * (inv_norm));
                 break;
 
             case FLUID_MOD_CONCAVE | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* =6 */
@@ -350,8 +352,8 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_CONCAVE | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* =7 */
-                val = (val_norm > 0.5f) ? -fluid_concave(127 * 2 * (val_norm - 0.5f))
-                        :  fluid_concave(127 * 2 * (0.5f - val_norm));
+                val = (inv_norm > 0.5f) ?  fluid_concave(127 * 2 * (inv_norm - 0.5f))
+                        : -fluid_concave(127 * 2 * (0.5f - inv_norm));
                 break;
 
             case FLUID_MOD_CONVEX | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE: /* =8 */
@@ -359,7 +361,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_CONVEX | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* =9 */
-                val = fluid_convex(127 * (1.0f - val_norm));
+                val = fluid_convex(127 * (inv_norm));
                 break;
 
             case FLUID_MOD_CONVEX | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* =10 */
@@ -368,8 +370,8 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_CONVEX | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* =11 */
-                val = (val_norm > 0.5f) ? -fluid_convex(127 * 2 * (val_norm - 0.5f))
-                        :  fluid_convex(127 * 2 * (0.5f - val_norm));
+                val = (inv_norm > 0.5f) ?  fluid_convex(127 * 2 * (inv_norm - 0.5f))
+                        : -fluid_convex(127 * 2 * (0.5f - inv_norm));
                 break;
 
             case FLUID_MOD_SWITCH | FLUID_MOD_UNIPOLAR | FLUID_MOD_POSITIVE: /* =12 */
@@ -377,7 +379,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_SWITCH | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* =13 */
-                val = (val_norm >= 0.5f) ? 0.0f : 1.0f;
+                val = (inv_norm >= 0.5f) ? 1.0f : 0.0f;
                 break;
 
             case FLUID_MOD_SWITCH | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* =14 */
@@ -385,7 +387,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_SWITCH | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* =15 */
-                val = (val_norm >= 0.5f) ? -1.0f : 1.0f;
+                val = (inv_norm >= 0.5f) ? 1.0f : -1.0f;
                 break;
 
             /*
@@ -401,7 +403,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_SIN | FLUID_MOD_UNIPOLAR | FLUID_MOD_NEGATIVE: /* custom */
-                val = FLUID_SIN((FLUID_M_PI / 2.0f * 0.87f) * (1.0f - val_norm));
+                val = FLUID_SIN((FLUID_M_PI / 2.0f * 0.87f) * (inv_norm));
                 break;
 
             case FLUID_MOD_SIN | FLUID_MOD_BIPOLAR | FLUID_MOD_POSITIVE: /* custom */
@@ -410,8 +412,8 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
                 break;
 
             case FLUID_MOD_SIN | FLUID_MOD_BIPOLAR | FLUID_MOD_NEGATIVE: /* custom */
-                val = (val_norm > 0.5f) ? -FLUID_SIN(FLUID_M_PI * (val_norm - 0.5f))
-                        :  FLUID_SIN(FLUID_M_PI * (0.5f - val_norm));
+                val = (inv_norm > 0.5f) ?  FLUID_SIN(FLUID_M_PI * (inv_norm - 0.5f))
+                        : -FLUID_SIN(FLUID_M_PI * (0.5f - inv_norm));
                 break;
 
             default:

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -293,7 +293,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned ch
     /* normalized value, i.e. usually in the range [0;1] */
     const fluid_real_t val_norm = val / range;
     /* inverted value used for negative mapping functions */
-    const fluid_real_t inv_norm = 1.0f - val_norm;
+    const fluid_real_t inv_norm = 1.0f - 1.0f / range - val_norm;
 
     /* we could also only switch case the lower nibble of mod_flags, however
      * this would keep us from adding further mod types in the future

--- a/src/synth/fluid_mod.h
+++ b/src/synth/fluid_mod.h
@@ -47,6 +47,8 @@ struct _fluid_mod_t
 
 fluid_real_t fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice);
 int fluid_mod_check_sources(const fluid_mod_t *mod, char *name);
+
+fluid_real_t fluid_mod_get_source_value(const unsigned char mod_src, const unsigned char mod_flags, fluid_real_t *range, const fluid_voice_t *voice);
 fluid_real_t fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned char mod_flags, const fluid_real_t range, int is_src1);
 
 

--- a/src/synth/fluid_mod.h
+++ b/src/synth/fluid_mod.h
@@ -56,7 +56,7 @@ fluid_real_t fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice);
 int fluid_mod_check_sources(const fluid_mod_t *mod, char *name);
 
 fluid_real_t fluid_mod_get_source_value(const unsigned char mod_src, const unsigned char mod_flags, fluid_real_t *range, const fluid_voice_t *voice);
-fluid_real_t fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, unsigned char mod_flags, const fluid_real_t range, int is_src1);
+fluid_real_t fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid_real_t range, int is_src1);
 
 
 #ifdef DEBUG

--- a/src/synth/fluid_mod.h
+++ b/src/synth/fluid_mod.h
@@ -23,6 +23,9 @@
 #include "fluidsynth_priv.h"
 #include "fluid_conv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /*
  * Modulator structure.  See SoundFont 2.04 PDF section 8.2.
  */
@@ -63,5 +66,7 @@ fluid_real_t fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val
 void fluid_dump_modulator(fluid_mod_t *mod);
 #endif
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* _FLUID_MOD_H */

--- a/src/synth/fluid_mod.h
+++ b/src/synth/fluid_mod.h
@@ -45,6 +45,13 @@ struct _fluid_mod_t
     fluid_mod_t *next;
 };
 
+enum
+{
+    FLUID_MOD_POLAR_MASK = FLUID_MOD_BIPOLAR | FLUID_MOD_UNIPOLAR,
+    FLUID_MOD_MAP_MASK = FLUID_MOD_LINEAR | FLUID_MOD_CONCAVE | FLUID_MOD_CONVEX | FLUID_MOD_SWITCH | FLUID_MOD_SIN,
+    FLUID_MOD_SIGN_MASK = FLUID_MOD_POSITIVE | FLUID_MOD_NEGATIVE,
+};
+
 fluid_real_t fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice);
 int fluid_mod_check_sources(const fluid_mod_t *mod, char *name);
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -7843,7 +7843,7 @@ static void fluid_synth_process_awe32_nrpn_LOCAL(fluid_synth_t *synth, int chan,
         case GEN_REVERBSEND:
             fluid_clip(data, 0, 255);
             /* transform the input value */
-            converted_sf2_generator_value = fluid_mod_transform_source_value(NULL, data, default_reverb_mod.flags1, 256, TRUE);
+            converted_sf2_generator_value = fluid_mod_transform_source_value(NULL, data, 256, TRUE);
             FLUID_LOG(FLUID_DBG, "AWE32 Reverb: %f", converted_sf2_generator_value);
             converted_sf2_generator_value*= fluid_mod_get_amount(&default_reverb_mod);
             break;
@@ -7851,7 +7851,7 @@ static void fluid_synth_process_awe32_nrpn_LOCAL(fluid_synth_t *synth, int chan,
         case GEN_CHORUSSEND:
             fluid_clip(data, 0, 255);
             /* transform the input value */
-            converted_sf2_generator_value = fluid_mod_transform_source_value(NULL, data, default_chorus_mod.flags1, 256, TRUE);
+            converted_sf2_generator_value = fluid_mod_transform_source_value(NULL, data, 256, TRUE);
             FLUID_LOG(FLUID_DBG, "AWE32 Chorus: %f", converted_sf2_generator_value);
             converted_sf2_generator_value*= fluid_mod_get_amount(&default_chorus_mod);
             break;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ ADD_FLUID_TEST(test_seq_evt_order)
 ADD_FLUID_TEST(test_seq_event_queue_remove)
 ADD_FLUID_TEST(test_jack_obtaining_synth)
 ADD_FLUID_TEST(test_utf8_open)
+ADD_FLUID_TEST(test_modulator)
 
 if ( GLIB_SUPPORT AND GLib2_VERSION VERSION_GREATER_EQUAL 2.33.12 )
     # Earlier versions of GLib had broken comment handling and should not be compared to

--- a/test/test_fast_render.c
+++ b/test/test_fast_render.c
@@ -12,6 +12,7 @@ int main(void)
     fluid_synth_t *synth;
     fluid_player_t *player;
     fluid_file_renderer_t *renderer;
+    FILE *file;
 
     settings = new_fluid_settings();
     synth = new_fluid_synth(settings);
@@ -51,7 +52,6 @@ int main(void)
     delete_fluid_synth(synth);
     delete_fluid_settings(settings);
     
-    FILE *file;
     file = FLUID_FOPEN(TEST_WAV_UTF8, "rb");
     TEST_ASSERT(file != NULL);
     TEST_ASSERT(FLUID_FCLOSE(file) == 0);

--- a/test/test_modulator.c
+++ b/test/test_modulator.c
@@ -38,18 +38,18 @@ static void test_mod_source_mapping(fluid_mod_t *mod)
                             | FLUID_MOD_POSITIVE
                             );
 
-            v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
+            v1 = fluid_mod_transform_source_value(mod, 0, Range, TRUE);
             TEST_ASSERT(v1 == 0.0f);
 
             // skip midpoint validation for concave and convex since we're not checking correctness of concave and convex implementations here
             if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, TRUE);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
 
-            v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
+            v1 = fluid_mod_transform_source_value(mod, 127, Range, TRUE);
             tmp = get_mod_max(mod);
             TEST_ASSERT(v1 == tmp);
         }
@@ -64,17 +64,17 @@ static void test_mod_source_mapping(fluid_mod_t *mod)
                             | FLUID_MOD_NEGATIVE
                             );
 
-            v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
+            v1 = fluid_mod_transform_source_value(mod, 127, Range, TRUE);
             TEST_ASSERT(v1 == 0.0f);
 
             if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, TRUE);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 0.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
             
-            v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
+            v1 = fluid_mod_transform_source_value(mod, 0, Range, TRUE);
             tmp = get_mod_max(mod);
             TEST_ASSERT(v1 == tmp);
         }
@@ -89,17 +89,17 @@ static void test_mod_source_mapping(fluid_mod_t *mod)
                             | FLUID_MOD_POSITIVE
                             );
 
-            v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
+            v1 = fluid_mod_transform_source_value(mod, 0, Range, TRUE);
             TEST_ASSERT(v1 == -1.0f);
 
             if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, TRUE);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
 
-            v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
+            v1 = fluid_mod_transform_source_value(mod, 127, Range, TRUE);
             tmp = get_mod_max(mod);
             TEST_ASSERT(v1 == tmp);
         }
@@ -114,17 +114,17 @@ static void test_mod_source_mapping(fluid_mod_t *mod)
                             | FLUID_MOD_NEGATIVE
                             );
 
-            v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
+            v1 = fluid_mod_transform_source_value(mod, 127, Range, TRUE);
             TEST_ASSERT(v1 == -1.0f);
 
             if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, TRUE);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? -1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
 
-            v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
+            v1 = fluid_mod_transform_source_value(mod, 0, Range, TRUE);
             tmp = get_mod_max(mod);
             TEST_ASSERT(v1 == tmp);
         }
@@ -148,7 +148,7 @@ static void test_mod_no_source(fluid_mod_t *mod)
         v1 = fluid_mod_get_source_value(mod->src2, mod->flags2, &tmp, NULL);
         TEST_ASSERT(tmp == Range);
         TEST_ASSERT(v1 == Range);
-        v1 = fluid_mod_transform_source_value(mod, v1, mod->flags2, Range, TRUE);
+        v1 = fluid_mod_transform_source_value(mod, v1, Range, !TRUE);
         TEST_ASSERT(v1 == 1.0f);
     }
 }

--- a/test/test_modulator.c
+++ b/test/test_modulator.c
@@ -151,6 +151,15 @@ static void test_mod_no_source(fluid_mod_t *mod)
         v1 = fluid_mod_transform_source_value(mod, v1, Range, !TRUE);
         TEST_ASSERT(v1 == 1.0f);
     }
+
+    fluid_mod_set_source2(mod, FLUID_MOD_VELOCITY, FLUID_MOD_GC | FLUID_MOD_SIN);
+    // No secondary source given, result must be one
+    tmp = Range;
+    v1 = fluid_mod_get_source_value(mod->src2, mod->flags2, &tmp, NULL);
+    TEST_ASSERT(tmp == Range);
+    TEST_ASSERT(v1 == Range);
+    v1 = fluid_mod_transform_source_value(mod, v1, Range, !TRUE);
+    TEST_ASSERT(v1 == 1.0f);
 }
 
 // this tests ensures that samples with invalid SfSampleType flag combinations are rejected

--- a/test/test_modulator.c
+++ b/test/test_modulator.c
@@ -1,0 +1,147 @@
+
+#include "test.h"
+#include "fluidsynth.h"
+#include "fluid_mod.h"
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+// Range shall be set to 7bit resolution, i.e. 128
+static const fluid_real_t Range = 128.0
+
+fluid_real_t get_mod_max(const fluid_mod_t *mod)
+{
+    // The maximum mapped position is always 127/128, see section 9.5.3 of SF2.4
+    // For switches however, we keep sticking to fluidsynth historical limits of +-1.0
+    return ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? 1.0f : (Range-1)/Range;
+}
+
+// this tests ensures that samples with invalid SfSampleType flag combinations are rejected
+int main(void)
+{
+    static const int mapping[] = {FLUID_MOD_SWITCH, FLUID_MOD_LINEAR, FLUID_MOD_CONCAVE, FLUID_MOD_CONVEX};
+    unsigned int i;
+    fluid_real_t v1, tmp;
+
+    fluid_mod_t* mod = new_fluid_mod();
+    fluid_mod_set_source2(mod, 0, 0);
+    fluid_mod_set_dest(mod, GEN_ATTENUATION);
+    fluid_mod_set_amount(mod, 1);
+
+    // No secondary source given, result must be one
+    tmp = Range;
+    v1 = fluid_mod_get_source_value(mod->src2, mod->flags2, &tmp, NULL);
+    TEST_ASSERT(tmp == Range);
+    TEST_ASSERT(v1 == Range);
+    v1 = fluid_mod_transform_source_value(mod, v1, mod->flags2, Range, TRUE);
+    TEST_ASSERT(v1 == 1.0f);
+
+    for(i = 0; i < FLUID_N_ELEMENTS(mapping); i++)
+    {
+        {
+            static const fluid_real_t mid = 64.0/128.0;
+            fluid_mod_set_source1(mod,
+                            FLUID_MOD_VELOCITY,
+                            FLUID_MOD_GC
+                            | mapping[i]
+                            | FLUID_MOD_UNIPOLAR
+                            | FLUID_MOD_POSITIVE
+                            );
+
+            v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
+            TEST_ASSERT(v1 == 0.0f);
+
+            // skip midpoint validation for concave and convex since we're not checking correctness of concave and convex implementations here
+            if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
+            {
+                v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
+                tmp = ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? 1.0f : mid;
+                TEST_ASSERT(v1 == tmp);
+            }
+
+            v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
+            tmp = get_mod_max(mod);
+            TEST_ASSERT(v1 == tmp);
+        }
+
+        {
+            static const fluid_real_t mid = (64-1)/128.0;
+            fluid_mod_set_source1(mod,
+                            FLUID_MOD_VELOCITY,
+                            FLUID_MOD_GC
+                            | mapping[i]
+                            | FLUID_MOD_UNIPOLAR
+                            | FLUID_MOD_NEGATIVE
+                            );
+
+            v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
+            TEST_ASSERT(v1 == 0.0f);
+
+            if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
+            {
+                v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
+                tmp = ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? 0.0f : mid;
+                TEST_ASSERT(v1 == tmp);
+            }
+            
+            v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
+            tmp = get_mod_max(mod);
+            TEST_ASSERT(v1 == tmp);
+        }
+
+        {
+            static const fluid_real_t mid = 0;
+            fluid_mod_set_source1(mod,
+                            FLUID_MOD_VELOCITY,
+                            FLUID_MOD_GC
+                            | mapping[i]
+                            | FLUID_MOD_BIPOLAR
+                            | FLUID_MOD_POSITIVE
+                            );
+
+            v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
+            TEST_ASSERT(v1 == -1.0f);
+
+            if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
+            {
+                v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
+                tmp = ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? 1.0f : mid;
+                TEST_ASSERT(v1 == tmp);
+            }
+
+            v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
+            tmp = get_mod_max(mod);
+            TEST_ASSERT(v1 == tmp);
+        }
+
+        {
+            static const fluid_real_t mid = -1/64.0;
+            fluid_mod_set_source1(mod,
+                            FLUID_MOD_VELOCITY,
+                            FLUID_MOD_GC
+                            | mapping[i]
+                            | FLUID_MOD_BIPOLAR
+                            | FLUID_MOD_NEGATIVE
+                            );
+
+            v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
+            TEST_ASSERT(v1 == -1.0f);
+
+            if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
+            {
+                v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
+                tmp = ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? -1.0f : mid;
+                TEST_ASSERT(v1 == tmp);
+            }
+
+            v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
+            tmp = get_mod_max(mod);
+            TEST_ASSERT(v1 == tmp);
+        }
+    }
+
+    delete_fluid_mod(mod);
+
+    return EXIT_SUCCESS;
+}

--- a/test/test_modulator.c
+++ b/test/test_modulator.c
@@ -10,41 +10,30 @@
 // Range shall be set to 7bit resolution, i.e. 128
 static const fluid_real_t Range = 128.0;
 
-fluid_real_t get_mod_max(const fluid_mod_t *mod)
+static const int Mapping[] = {FLUID_MOD_SWITCH, FLUID_MOD_LINEAR, FLUID_MOD_CONCAVE, FLUID_MOD_CONVEX};
+static const int Polar[] = {FLUID_MOD_UNIPOLAR, FLUID_MOD_BIPOLAR};
+static const int Direction[] = {FLUID_MOD_POSITIVE, FLUID_MOD_NEGATIVE};
+
+static fluid_real_t get_mod_max(const fluid_mod_t *mod)
 {
     // The maximum mapped position is always 127/128, see section 9.5.3 of SF2.4
     // For switches however, we keep sticking to fluidsynth historical limits of +-1.0
     return ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : (Range-1)/Range;
 }
 
-// this tests ensures that samples with invalid SfSampleType flag combinations are rejected
-int main(void)
+static void test_mod_source_mapping(fluid_mod_t *mod)
 {
-    static const int mapping[] = {FLUID_MOD_SWITCH, FLUID_MOD_LINEAR, FLUID_MOD_CONCAVE, FLUID_MOD_CONVEX};
     unsigned int i;
     fluid_real_t v1, tmp;
 
-    fluid_mod_t* mod = new_fluid_mod();
-    fluid_mod_set_source2(mod, 0, 0);
-    fluid_mod_set_dest(mod, GEN_ATTENUATION);
-    fluid_mod_set_amount(mod, 1);
-
-    // No secondary source given, result must be one
-    tmp = Range;
-    v1 = fluid_mod_get_source_value(mod->src2, mod->flags2, &tmp, NULL);
-    TEST_ASSERT(tmp == Range);
-    TEST_ASSERT(v1 == Range);
-    v1 = fluid_mod_transform_source_value(mod, v1, mod->flags2, Range, TRUE);
-    TEST_ASSERT(v1 == 1.0f);
-
-    for(i = 0; i < FLUID_N_ELEMENTS(mapping); i++)
+    for(i = 0; i < FLUID_N_ELEMENTS(Mapping); i++)
     {
         {
             static const fluid_real_t mid = 64.0/128.0;
             fluid_mod_set_source1(mod,
                             FLUID_MOD_VELOCITY,
                             FLUID_MOD_GC
-                            | mapping[i]
+                            | Mapping[i]
                             | FLUID_MOD_UNIPOLAR
                             | FLUID_MOD_POSITIVE
                             );
@@ -53,7 +42,7 @@ int main(void)
             TEST_ASSERT(v1 == 0.0f);
 
             // skip midpoint validation for concave and convex since we're not checking correctness of concave and convex implementations here
-            if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
+            if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
                 v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : mid;
@@ -70,7 +59,7 @@ int main(void)
             fluid_mod_set_source1(mod,
                             FLUID_MOD_VELOCITY,
                             FLUID_MOD_GC
-                            | mapping[i]
+                            | Mapping[i]
                             | FLUID_MOD_UNIPOLAR
                             | FLUID_MOD_NEGATIVE
                             );
@@ -78,7 +67,7 @@ int main(void)
             v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
             TEST_ASSERT(v1 == 0.0f);
 
-            if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
+            if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
                 v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 0.0f : mid;
@@ -95,7 +84,7 @@ int main(void)
             fluid_mod_set_source1(mod,
                             FLUID_MOD_VELOCITY,
                             FLUID_MOD_GC
-                            | mapping[i]
+                            | Mapping[i]
                             | FLUID_MOD_BIPOLAR
                             | FLUID_MOD_POSITIVE
                             );
@@ -103,7 +92,7 @@ int main(void)
             v1 = fluid_mod_transform_source_value(mod, 0, mod->flags1, Range, TRUE);
             TEST_ASSERT(v1 == -1.0f);
 
-            if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
+            if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
                 v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : mid;
@@ -120,7 +109,7 @@ int main(void)
             fluid_mod_set_source1(mod,
                             FLUID_MOD_VELOCITY,
                             FLUID_MOD_GC
-                            | mapping[i]
+                            | Mapping[i]
                             | FLUID_MOD_BIPOLAR
                             | FLUID_MOD_NEGATIVE
                             );
@@ -128,7 +117,7 @@ int main(void)
             v1 = fluid_mod_transform_source_value(mod, 127, mod->flags1, Range, TRUE);
             TEST_ASSERT(v1 == -1.0f);
 
-            if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
+            if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
                 v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? -1.0f : mid;
@@ -140,6 +129,38 @@ int main(void)
             TEST_ASSERT(v1 == tmp);
         }
     }
+}
+
+static void test_mod_no_source(fluid_mod_t *mod)
+{
+    unsigned int i,j,k;
+    fluid_real_t v1, tmp;
+    fluid_mod_set_dest(mod, GEN_ATTENUATION);
+    fluid_mod_set_amount(mod, 1);
+
+    for(i = 0; i < FLUID_N_ELEMENTS(Mapping); i++)
+    for(j = 0; j < FLUID_N_ELEMENTS(Polar); j++)
+    for(k = 0; k < FLUID_N_ELEMENTS(Direction); k++)
+    {
+        fluid_mod_set_source2(mod, FLUID_MOD_NONE, Mapping[i] | Polar[j] | Direction[k]);
+        // No secondary source given, result must be one
+        tmp = Range;
+        v1 = fluid_mod_get_source_value(mod->src2, mod->flags2, &tmp, NULL);
+        TEST_ASSERT(tmp == Range);
+        TEST_ASSERT(v1 == Range);
+        v1 = fluid_mod_transform_source_value(mod, v1, mod->flags2, Range, TRUE);
+        TEST_ASSERT(v1 == 1.0f);
+    }
+}
+
+// this tests ensures that samples with invalid SfSampleType flag combinations are rejected
+int main(void)
+{
+    fluid_mod_t* mod = new_fluid_mod();
+
+    test_mod_no_source(mod);
+
+    test_mod_source_mapping(mod);
 
     delete_fluid_mod(mod);
 

--- a/test/test_modulator.c
+++ b/test/test_modulator.c
@@ -8,13 +8,13 @@
 #endif
 
 // Range shall be set to 7bit resolution, i.e. 128
-static const fluid_real_t Range = 128.0
+static const fluid_real_t Range = 128.0;
 
 fluid_real_t get_mod_max(const fluid_mod_t *mod)
 {
     // The maximum mapped position is always 127/128, see section 9.5.3 of SF2.4
     // For switches however, we keep sticking to fluidsynth historical limits of +-1.0
-    return ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? 1.0f : (Range-1)/Range;
+    return ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : (Range-1)/Range;
 }
 
 // this tests ensures that samples with invalid SfSampleType flag combinations are rejected
@@ -56,7 +56,7 @@ int main(void)
             if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
             {
                 v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
-                tmp = ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? 1.0f : mid;
+                tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
 
@@ -81,7 +81,7 @@ int main(void)
             if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
             {
                 v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
-                tmp = ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? 0.0f : mid;
+                tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 0.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
             
@@ -106,7 +106,7 @@ int main(void)
             if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
             {
                 v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
-                tmp = ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? 1.0f : mid;
+                tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
 
@@ -131,7 +131,7 @@ int main(void)
             if(mapping[i] != FLUID_MOD_CONCAVE && mapping[i] != FLUID_MOD_CONVEX)
             {
                 v1 = fluid_mod_transform_source_value(mod, 64, mod->flags1, Range, TRUE);
-                tmp = ((mod->flags1 & FLUID_MOD_SWITCH) == FLUID_MOD_SWITCH) ? -1.0f : mid;
+                tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? -1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
 


### PR DESCRIPTION
This adds a unit test to verify that issue #1651 has been fixed properly. The test itself is expected to fail, just like the CI builds are.

Next, it merges  #1653, which fixes the newly added unit test. Particularly, the following modulator mappings have been changed:
* negative unipolar
* bipolar
* concave
* convex

That means, only positive unipolar and switch mappings remain unchanged. Switch mappings keep their `+/-1.0` (bipolar) and `[0;+1]` (unipolar mapping). All other mappings now use `127/128` as their maximum mapped value and 0 (-1.0 for bipolar resp.) as their minimum mapping.

Lastly it makes necessary adjustments to the newly added API `fluid_mod_set_custom_mapping()`.

Resolves #1651