### PR TITLE
Fix drum kits not being selected after SysEx GS Rythm Part

### DIFF
--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -2606,15 +2606,15 @@ fluid_synth_sysex_gs_dt1(fluid_synth_t *synth, const char *data, int len,
             // used in the selected mode. This behavior is not replicated here.
             // Issue 1579: The preset selected for the channel needs to be forcibly changed. Therefore it is not sufficient
             // to send a prog change, as the old bank is still active in the channel.
-            // Also, do not explicitly send a prog change here. It must be sent by the user, see note on site 60:
+            // MSGS selects the standard drum kit right after this message (which is equivalent to sending a prog change 0).
+            // However, this behavior is insonsistent with the note on site 60:
             // "To select a drum set after setting the part mode, transmit a program change [...]"
+            fluid_synth_cc_LOCAL(synth, chan, ALL_CTRL_OFF);
             fluid_channel_set_sfont_bank_prog(synth->channel[chan],
                                               -1,
                                               type == CHANNEL_TYPE_DRUM ? DRUM_INST_BANK : 0,
                                               -1);
-            fluid_synth_cc_LOCAL(synth, chan, ALL_CTRL_OFF);
-            // Unset the currently selected program, so that this channel remains silent, in case the user doesn't send a progchange afterwards
-            fluid_synth_unset_program(synth, chan);
+            fluid_synth_program_change(synth, chan, 0);
         }
         return FLUID_OK;
     }

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -2198,10 +2198,6 @@ fluid_synth_sysex(fluid_synth_t *synth, const char *data, int len,
         result = fluid_synth_sysex_gs_dt1(synth, data, len, response,
                                           response_len, avail_response,
                                           handled, dryrun);
-        if(synth->verbose)
-        {
-            FLUID_LOG(FLUID_INFO, "Processed SysEX GS DT1 message, bank selection mode might have been changed.");
-        }
         FLUID_API_RETURN(result);
     }
 
@@ -2529,7 +2525,7 @@ fluid_synth_sysex_gs_dt1(fluid_synth_t *synth, const char *data, int len,
 
     if(len < 9) // at least one byte of data should be transmitted
     {
-        FLUID_LOG(FLUID_INFO, "SysEx DT1: message too short, dropping it.");
+        FLUID_LOG(FLUID_INFO, "SysEx GS DT1: message too short, dropping it.");
         return FLUID_FAILED;
     }
     len_data = len - 8;
@@ -2543,7 +2539,7 @@ fluid_synth_sysex_gs_dt1(fluid_synth_t *synth, const char *data, int len,
     // An intermediate checksum of 0x80 must be treated as zero! #1578
     if ((checksum & 0x7F) != data[len - 1])
     {
-        FLUID_LOG(FLUID_INFO, "SysEx DT1: dropping message on addr 0x%x due to incorrect checksum 0x%x. Correct checksum: 0x%x", addr, (int)data[len - 1], checksum);
+        FLUID_LOG(FLUID_INFO, "SysEx GS DT1: dropping message on addr 0x%x due to incorrect checksum 0x%x. Correct checksum: 0x%x", addr, (int)data[len - 1], checksum);
         return FLUID_FAILED;
     }
 
@@ -2551,16 +2547,18 @@ fluid_synth_sysex_gs_dt1(fluid_synth_t *synth, const char *data, int len,
     {
         if (len_data > 1 || (data[7] != 0 && data[7] != 0x7f))
         {
-            FLUID_LOG(FLUID_INFO, "SysEx DT1: dropping invalid mode set message");
+            FLUID_LOG(FLUID_INFO, "SysEx GS DT1: dropping invalid mode set message");
             return FLUID_FAILED;
         }
         if (handled)
         {
             *handled = TRUE;
         }
+
+        i = data[7];
         if (!dryrun)
         {
-            if (data[7] == 0)
+            if (i == 0)
             {
                 synth->bank_select = FLUID_BANK_STYLE_GS;
             }
@@ -2569,6 +2567,12 @@ fluid_synth_sysex_gs_dt1(fluid_synth_t *synth, const char *data, int len,
                 synth->bank_select = FLUID_BANK_STYLE_GM;
             }
             return fluid_synth_system_reset_LOCAL(synth);
+        }
+        if(synth->verbose)
+        {
+            FLUID_LOG(FLUID_INFO, "%sSysEX GS DT1: bank selection mode is now %s",
+            dryrun ? "[DRYRUN] " : "",
+            i == 0 ? "GS" : "GM");
         }
         return FLUID_OK;
     }
@@ -2582,7 +2586,7 @@ fluid_synth_sysex_gs_dt1(fluid_synth_t *synth, const char *data, int len,
     {
         if (len_data > 1 || data[7] > 0x02)
         {
-            FLUID_LOG(FLUID_INFO, "SysEx DT1: dropping invalid rhythm part message");
+            FLUID_LOG(FLUID_INFO, "SysEx GS DT1: dropping invalid rhythm part message");
             return FLUID_FAILED;
         }
         if (handled)
@@ -2597,7 +2601,7 @@ fluid_synth_sysex_gs_dt1(fluid_synth_t *synth, const char *data, int len,
             type = data[7] == 0x00 ? CHANNEL_TYPE_MELODIC : CHANNEL_TYPE_DRUM;
             synth->channel[chan]->channel_type = type;
 
-            FLUID_LOG(FLUID_DBG, "SysEx DT1: setting MIDI channel %d to type %d", chan, (int)synth->channel[chan]->channel_type);
+            FLUID_LOG(FLUID_DBG, "SysEx GS DT1: setting MIDI channel %d to type %d", chan, (int)synth->channel[chan]->channel_type);
             // Roland synths seem to "remember" the last instrument a channel
             // used in the selected mode. This behavior is not replicated here.
             // Issue 1579: The preset selected for the channel needs to be forcibly changed. Therefore it is not sufficient

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -2613,6 +2613,8 @@ fluid_synth_sysex_gs_dt1(fluid_synth_t *synth, const char *data, int len,
                                               type == CHANNEL_TYPE_DRUM ? DRUM_INST_BANK : 0,
                                               -1);
             fluid_synth_cc_LOCAL(synth, chan, ALL_CTRL_OFF);
+            // Unset the currently selected program, so that this channel remains silent, in case the user doesn't send a progchange afterwards
+            fluid_synth_unset_program(synth, chan);
         }
         return FLUID_OK;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set(DYNSAM_RENDER_DIR "${CMAKE_CURRENT_BINARY_DIR}/manual/dynamic-sample-loading
 set(BANKSELECT_RENDER_DIR "${CMAKE_CURRENT_BINARY_DIR}/manual/midi-bank-select")
 set(STACKEDSF_RENDER_DIR "${CMAKE_CURRENT_BINARY_DIR}/manual/stacked_sf2")
 set(SFE_RENDER_DIR "${CMAKE_CURRENT_BINARY_DIR}/manual/sfe")
+set(SYSEX_GS_DT1 "${CMAKE_CURRENT_BINARY_DIR}/manual/sysex/gs_dt1")
 
 if(LIBSNDFILE_SUPPORT)
     set(FEXT "wav")
@@ -84,7 +85,7 @@ endif()
 add_custom_target(check_manual)
 
 add_custom_target(create_iir_dir
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IIR_FILTER_RENDER_DIR} ${AWE32_NRPN_RENDER_DIR} ${SFSPEC_RENDER_DIR} ${PORTAMENTO_RENDER_DIR} ${REVERB_RENDER_DIR} ${EXCL_RENDER_DIR} ${DSPINTERP_RENDER_DIR} ${DYNSAM_RENDER_DIR} ${STACKEDSF_RENDER_DIR} ${GUGDEMO_RENDER_DIR} ${BANKSELECT_RENDER_DIR} ${SFE_RENDER_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${IIR_FILTER_RENDER_DIR} ${AWE32_NRPN_RENDER_DIR} ${SFSPEC_RENDER_DIR} ${PORTAMENTO_RENDER_DIR} ${REVERB_RENDER_DIR} ${EXCL_RENDER_DIR} ${DSPINTERP_RENDER_DIR} ${DYNSAM_RENDER_DIR} ${STACKEDSF_RENDER_DIR} ${GUGDEMO_RENDER_DIR} ${BANKSELECT_RENDER_DIR} ${SFE_RENDER_DIR} ${SYSEX_GS_DT1}
     VERBATIM)
 
 add_custom_target(render1415
@@ -322,6 +323,15 @@ add_custom_target(renderDMOD
     COMMENT "Rendering Test MIDI for DMOD SF2"
     DEPENDS fluidsynth create_iir_dir
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/manual/sfe/dmod"
+    VERBATIM
+)
+
+add_custom_target(renderGSDT1
+    COMMAND fluidsynth -R 0 -C 0 -g 0.6 -F "${SYSEX_GS_DT1}/wikipedia_MIDI_sample_gstest.${FEXT}" ${GENERAL_USER_GS2} "wikipedia_MIDI_sample_gstest.mid"
+    COMMAND fluidsynth -R 0 -C 0 -g 0.6 -F "${SYSEX_GS_DT1}/D_DM2TTL - GS Drums.${FEXT}" ${GENERAL_USER_GS2} "D_DM2TTL - GS Drums.mid"
+    COMMENT "Rendering Test MIDIs for SysEx GS DT1"
+    DEPENDS fluidsynth create_iir_dir
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/manual/sysex/gs_dt1"
     VERBATIM
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -329,6 +329,7 @@ add_custom_target(renderDMOD
 add_custom_target(renderGSDT1
     COMMAND fluidsynth -R 0 -C 0 -g 0.6 -F "${SYSEX_GS_DT1}/wikipedia_MIDI_sample_gstest.${FEXT}" ${GENERAL_USER_GS2} "wikipedia_MIDI_sample_gstest.mid"
     COMMAND fluidsynth -R 0 -C 0 -g 0.6 -F "${SYSEX_GS_DT1}/D_DM2TTL - GS Drums.${FEXT}" ${GENERAL_USER_GS2} "D_DM2TTL - GS Drums.mid"
+    COMMAND fluidsynth -R 0 -C 0 -g 0.6 -F "${SYSEX_GS_DT1}/GS Drums Bank Select and Program Change interaction on MSGS.${FEXT}" ${GENERAL_USER_GS2} "GS Drums Bank Select and Program Change interaction on MSGS.mid"
     COMMENT "Rendering Test MIDIs for SysEx GS DT1"
     DEPENDS fluidsynth create_iir_dir
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/manual/sysex/gs_dt1"


### PR DESCRIPTION
Previously, fluidsynth changed the channel type and sent a progchange. This was not sufficient to switch to the drum bank, as the previously selected bank was still cached. This PR now explicitly resets the bank, causing a subsequent progchange to select the correct preset from the Soundfont.

Note that this "subsequent progchange" is expected to be sent by the user, cf. SC-88Pro/8850 owner's manual, site 60:

> "To select a drum set after setting the part mode, transmit a program change [...]"

Fixes #1579.