### PR TITLE
Fix synth API mutex race

### DIFF
--- a/doc/recent_changes.txt
+++ b/doc/recent_changes.txt
@@ -7,6 +7,7 @@
 - fluid_mod_get_transform() now receives a <code>const</code> argument
 - fluid_version_str() now returns a <code>const</code> char array
 - An API for manipulating fluid_sfont_t specific default modulators has been added: fluid_sfont_get_default_mod() and fluid_sfont_set_default_mod()
+- In all previous versions of fluidsynth, the synth's API mutex was unlocked too early when calls to fluid_synth_unset_program() and fluid_synth_alloc_voice() had been made; this race condition has been fixed
 
 \section NewIn2_4_5 What's new in 2.4.5?
 - In order to use the sdl3 audio driver, the downstream application is responsible for calling <code>SDL_Init()</code> and <code>SDL_Quit()</code>, just like it was practice for the sdl2 audio driver. Fluidsynth may raise a warning if this isn't done, see \ref CreatingAudioDriver

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3350,8 +3350,10 @@ fluid_synth_sfont_select(fluid_synth_t *synth, int chan, int sfont_id)
 int
 fluid_synth_unset_program(fluid_synth_t *synth, int chan)
 {
+    int res;
     FLUID_API_ENTRY_CHAN(FLUID_FAILED);
-    FLUID_API_RETURN(fluid_synth_program_change(synth, chan, FLUID_UNSET_PROGRAM));
+    res = fluid_synth_program_change(synth, chan, FLUID_UNSET_PROGRAM);
+    FLUID_API_RETURN(res);
 }
 
 /**
@@ -5254,10 +5256,12 @@ fluid_voice_t *
 fluid_synth_alloc_voice(fluid_synth_t *synth, fluid_sample_t *sample,
                         int chan, int key, int vel)
 {
+    int res;
     fluid_return_val_if_fail(sample != NULL, NULL);
     fluid_return_val_if_fail(sample->data != NULL, NULL);
     FLUID_API_ENTRY_CHAN(NULL);
-    FLUID_API_RETURN(fluid_synth_alloc_voice_LOCAL(synth, sample, chan, key, vel, NULL));
+    res = fluid_synth_alloc_voice_LOCAL(synth, sample, chan, key, vel, NULL)
+    FLUID_API_RETURN(res);
 
 }
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -5256,11 +5256,11 @@ fluid_voice_t *
 fluid_synth_alloc_voice(fluid_synth_t *synth, fluid_sample_t *sample,
                         int chan, int key, int vel)
 {
-    int res;
+    fluid_voice_t *res;
     fluid_return_val_if_fail(sample != NULL, NULL);
     fluid_return_val_if_fail(sample->data != NULL, NULL);
     FLUID_API_ENTRY_CHAN(NULL);
-    res = fluid_synth_alloc_voice_LOCAL(synth, sample, chan, key, vel, NULL)
+    res = fluid_synth_alloc_voice_LOCAL(synth, sample, chan, key, vel, NULL);
     FLUID_API_RETURN(res);
 
 }


### PR DESCRIPTION
Previously, calls to `FLUID_API_RETURN` were clobbered with function calls, rather than just plain return values. This would have caused the synth's API mutex to be released before the synth's subfunction had actually been executed.

`fluid_synth_alloc_voice()` and `fluid_synth_unset_program()` were affected. For the latter, it would have only been a scheduling pessimization, since it redirects the call to  `fluid_synth_program_change()` which itself acquires the mutex.

However, for `fluid_synth_alloc_voice()` this would have ended in a true race, esp. when allocing voices from multiple threads.