### PR TITLE
Fix several minor build issues

### DIFF
--- a/cmake_admin/FindSndFileLegacy.cmake
+++ b/cmake_admin/FindSndFileLegacy.cmake
@@ -87,50 +87,58 @@ elseif(_sndfile_library)
   find_package(mpg123 QUIET)
 
   if(NOT CMAKE_CROSSCOMPILING)
-    include(CheckSourceRuns)
-    set(_backup_includes ${CMAKE_REQUIRED_INCLUDES})
-    set(_backup_libraries ${CMAKE_REQUIRED_LIBRARIES})
-    set(CMAKE_REQUIRED_INCLUDES "${SndFile_INCLUDE_DIR}")
-    set(CMAKE_REQUIRED_LIBRARIES "${_sndfile_library}")
+    if(${CMAKE_VERSION} VERSION_LESS "3.19")
+      message(STATUS
+        "Your CMake version (${CMAKE_VERSION}) is less than 3.19 - cannot check for external sndfile libraries."
+      )
+      set(SndFile_WITH_EXTERNAL_LIBS FALSE)
+      set(SndFile_WITH_MPEG FALSE)
+    else()
+      include(CheckSourceRuns)
+      set(_backup_includes ${CMAKE_REQUIRED_INCLUDES})
+      set(_backup_libraries ${CMAKE_REQUIRED_LIBRARIES})
+      set(CMAKE_REQUIRED_INCLUDES "${SndFile_INCLUDE_DIR}")
+      set(CMAKE_REQUIRED_LIBRARIES "${_sndfile_library}")
 
-    set(_optional_libs "MPG123::libmpg123" "mp3lame::mp3lame" "FLAC::FLAC"
-                       "Opus::opus" "Vorbis::vorbisenc" "Ogg::ogg")
-    foreach(_target ${_optional_libs})
-      if(TARGET "${_target}")
-        list(APPEND CMAKE_REQUIRED_LIBRARIES "${_target}")
-      endif()
-    endforeach()
+      set(_optional_libs "MPG123::libmpg123" "mp3lame::mp3lame" "FLAC::FLAC"
+                        "Opus::opus" "Vorbis::vorbisenc" "Ogg::ogg")
+      foreach(_target ${_optional_libs})
+        if(TARGET "${_target}")
+          list(APPEND CMAKE_REQUIRED_LIBRARIES "${_target}")
+        endif()
+      endforeach()
 
-    check_source_runs(
-      C
-      "#include <stdlib.h>
+      check_source_runs(
+        C
+        "#include <stdlib.h>
 #include <sndfile.h>
 int main() {
   SF_FORMAT_INFO info = {SF_FORMAT_VORBIS};
   sf_command(NULL, SFC_GET_FORMAT_INFO, &info, sizeof info);
   return info.name != NULL ? EXIT_SUCCESS : EXIT_FAILURE;
 }"
-      SNDFILE_SUPPORTS_VORBIS)
+        SNDFILE_SUPPORTS_VORBIS)
 
-    check_source_runs(
-      C
-      "#include <stdlib.h>
+      check_source_runs(
+        C
+        "#include <stdlib.h>
 #include <sndfile.h>
 int main() {
   SF_FORMAT_INFO info = {SF_FORMAT_MPEG_LAYER_III};
   sf_command(NULL, SFC_GET_FORMAT_INFO, &info, sizeof info);
   return info.name != NULL ? EXIT_SUCCESS : EXIT_FAILURE;
 }"
-      SNDFILE_SUPPORTS_MPEG)
+        SNDFILE_SUPPORTS_MPEG)
 
-    set(SndFile_WITH_EXTERNAL_LIBS ${SNDFILE_SUPPORTS_VORBIS})
-    set(SndFile_WITH_MPEG ${SNDFILE_SUPPORTS_MPEG})
-    set(CMAKE_REQUIRED_INCLUDES ${_backup_includes})
-    set(CMAKE_REQUIRED_LIBRARIES ${_backup_libraries})
+      set(SndFile_WITH_EXTERNAL_LIBS ${SNDFILE_SUPPORTS_VORBIS})
+      set(SndFile_WITH_MPEG ${SNDFILE_SUPPORTS_MPEG})
+      set(CMAKE_REQUIRED_INCLUDES ${_backup_includes})
+      set(CMAKE_REQUIRED_LIBRARIES ${_backup_libraries})
+    endif()
   else()
     message(
       STATUS
-        "Cross-compiling without pkg-config - cannot check for external libraries."
+        "Cross-compiling without pkg-config - cannot check for external sndfile libraries."
         "If you have the upstream CMake config set CMAKE_FIND_PACKAGE_PREFER_CONFIG to true for accurate results."
     )
     set(SndFile_WITH_EXTERNAL_LIBS FALSE)

--- a/cmake_admin/PkgConfigHelpers.cmake
+++ b/cmake_admin/PkgConfigHelpers.cmake
@@ -27,7 +27,7 @@ macro ( generate_pkgconfig_spec template outfile target )
     if (TARGET ${target})
         # retrieve all the private libs we depend on
         get_target_property (_libs ${target} INTERFACE_LINK_LIBRARIES)
-        set(_cleanlibs)
+        set(_cleanlibs "")
         foreach(_lib IN LISTS _libs)
             if (TARGET ${_lib})
                 # All the imported PkgConfig target are explicitly added to PC_REQUIRES_PRIV.

--- a/contrib/fluidsynth.spec
+++ b/contrib/fluidsynth.spec
@@ -24,7 +24,7 @@
 %endif
 
 Name:           fluidsynth
-Version:        2.2.2
+Version:        2.5.0
 Release:        0
 Summary:        A Real-Time Software Synthesizer That Uses Soundfont(tm)
 License:        LGPL-2.1-or-later

--- a/contrib/fluidsynth.spec
+++ b/contrib/fluidsynth.spec
@@ -122,7 +122,7 @@ ln -s %{_sbindir}/service %{buildroot}%{_sbindir}/rc%{name}
 
 %files
 %license LICENSE
-%doc AUTHORS ChangeLog README.md THANKS TODO
+%doc AUTHORS ChangeLog.old README.md THANKS TODO
 %{_mandir}/man?/*
 %{_bindir}/*
 %if 0%{?suse_version}

--- a/contrib/fluidsynth.spec
+++ b/contrib/fluidsynth.spec
@@ -129,6 +129,7 @@ ln -s %{_sbindir}/service %{buildroot}%{_sbindir}/rc%{name}
 %{_unitdir}/%{name}.service
 %{_sbindir}/rc%{name}
 %{_fillupdir}/sysconfig.%{name}
+%{_tmpfilesdir}/%{name}.conf
 %endif
 
 %files devel


### PR DESCRIPTION
This fixes several issues when compiling and packaging fluidsynth:

* Fixes build on RPM-based distros, due to previously unpackaged `ChangeLog.old` and `fluidsynth.tmpfiles` files
* Fixes two build issues on Debian-based distros, which compile and package libsndfile with the autotools build system, causing our `FindSndFileLegacy.cmake` module to be used:
  * Failure if variable  `_cleanlibs` was empty
  * Failure when compiling with CMake < 3.19 due to missing `include(CheckSourceRuns)`