### PR TITLE
Hide private CXX and inline symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ endif ( NOT CMAKE_POSITION_INDEPENDENT_CODE )
 if ( NOT OS2 )
     set ( CMAKE_C_VISIBILITY_PRESET hidden )
     set ( CMAKE_CXX_VISIBILITY_PRESET hidden )
+    set ( CMAKE_VISIBILITY_INLINES_HIDDEN yes )
 endif ( NOT OS2 )
 
 # enforce visibility control for all types of cmake targets


### PR DESCRIPTION
It was discovered that unfortunately, all C++ source files were compiled with the default and incorrect visibility settings, causing all (private) C++ symbols to be exposed by the shared library. This PR sets the correct visibility for CXX, causing those private symbols to be removed from the public ABI again.

Since all the symbols in question were never part of any public API spec, I will refrain from bumping the major SOVERSION. Doing so would just unnecessarily confuse downstream, enforcing a rebuild of everything, even though no existing public interfaces were changed, removed, or otherwise broken.

Fixes #1676 