### PR TITLE
Prevent deletion of DLS font while being in use

### DIFF
--- a/src/sfloader/fluid_dls.cpp
+++ b/src/sfloader/fluid_dls.cpp
@@ -3139,10 +3139,8 @@ static int fluid_dls_sfont_delete(fluid_sfont_t *sfont) noexcept
     auto *dlsfont = static_cast<fluid_dls_font *>(fluid_sfont_get_data(sfont));
 
     /* Check that no samples are currently used */
-    for (auto it = dlsfont->samples_fluid.begin(); it != dlsfont->samples_fluid.end(); ++it)
+    for (const auto& sample : dlsfont->samples_fluid)
     {
-        auto& sample = *it;
-
         if (sample.refcount != 0)
         {
             return FLUID_FAILED;


### PR DESCRIPTION
Resolves #1717

Repro:

1. `fluidsynth some.dls`
2. `noteon 0 60 127`
3. `unload 1`

ASAN Report:
```
==2157==ERROR: AddressSanitizer: heap-use-after-free on address 0x7e8f577f96c0 at pc 0x0000005dd2c2 bp 0x7b8f52a40440 sp 0x7b8f52a40438
READ of size 8 at 0x7e8f577f96c0 thread T4
>     #0 0x0000005dd2c1 in int dsp_invoker<Interpolate4thOrder>(_fluid_rvoice_t*, double*, int) /fluidsynth/src/rvoice/fluid_rvoice_dsp.cpp:777
    #1 0x0000005dd2c1 in fluid_rvoice_dsp_interpolate /fluidsynth/src/rvoice/fluid_rvoice_dsp.cpp:823
    #2 0x0000005958c0 in fluid_rvoice_write /fluidsynth/src/rvoice/fluid_rvoice.c:474
    #3 0x0000005e5c9f in fluid_mixer_buffers_render_one /fluidsynth/src/rvoice/fluid_rvoice_mixer.c:523
    #4 0x0000005e5c9f in fluid_render_loop_singlethread /fluidsynth/src/rvoice/fluid_rvoice_mixer.c:679
    #5 0x0000005eceea in fluid_rvoice_mixer_render /fluidsynth/src/rvoice/fluid_rvoice_mixer.c:1712
    #6 0x00000044f9c9 in fluid_synth_write_float_channels_LOCAL /fluidsynth/src/synth/fluid_synth.c:4650
    #7 0x0000004510b6 in fluid_synth_write_float_channels /fluidsynth/src/synth/fluid_synth.c:4570
    #8 0x0000004510b6 in fluid_synth_write_float /fluidsynth/src/synth/fluid_synth.c:4530
    #9 0x0000004b34dd in fluid_file_renderer_process_block /fluidsynth/src/bindings/fluid_filerenderer.c:432
    #10 0x0000004bcd31 in fluid_file_audio_run /fluidsynth/src/drivers/fluid_aufile.c:129
    #11 0x00000041e279 in fluid_timer_run /fluidsynth/src/utils/fluid_sys.c:1002
    #12 0x00000041f2bd in fluid_thread_high_prio /fluidsynth/src/utils/fluid_sys.c:979
    #13 0x7f8f59fdb3ac  (/lib64/libglib-2.0.so.0+0x943ac) (BuildId: a1baf80bf47a8b0e99823b0b876b51fed88de515)
    #14 0x7f8f5a103c75  (/lib64/libasan.so.8+0x63c75) (BuildId: cbfe49f3b7600c4f194d4c54774c977296e9d98a)
    #15 0x7f8f58dcbdf0 in start_thread (/lib64/libc.so.6+0x9bdf0) (BuildId: 8523b213e7586a93ab00f6dd476418b1e521e62c)
    #16 0x7f8f58e50a63 in __GI___clone (/lib64/libc.so.6+0x120a63) (BuildId: 8523b213e7586a93ab00f6dd476418b1e521e62c)

0x7e8f577f96c0 is located 37568 bytes inside of 63360-byte region [0x7e8f577f0400,0x7e8f577ffb80)
freed by thread T0 here:
    #0 0x7f8f5a1c369b in operator delete(void*, unsigned long) (/lib64/libasan.so.8+0x12369b) (BuildId: cbfe49f3b7600c4f194d4c54774c977296e9d98a)
    #1 0x0000004e1a7f in std::__new_allocator<_fluid_sample_t>::deallocate(_fluid_sample_t*, unsigned long) /usr/include/c++/15/bits/new_allocator.h:172
    #2 0x0000004e1a7f in std::allocator_traits<std::allocator<_fluid_sample_t> >::deallocate(std::allocator<_fluid_sample_t>&, _fluid_sample_t*, unsigned long) /usr/include/c++/15/bits/alloc_traits.h:649
    #3 0x0000004e1a7f in std::_Vector_base<_fluid_sample_t, std::allocator<_fluid_sample_t> >::_M_deallocate(_fluid_sample_t*, unsigned long) /usr/include/c++/15/bits/stl_vector.h:396
    #4 0x0000004e1a7f in std::_Vector_base<_fluid_sample_t, std::allocator<_fluid_sample_t> >::~_Vector_base() /usr/include/c++/15/bits/stl_vector.h:375
    #5 0x0000004e1a7f in std::vector<_fluid_sample_t, std::allocator<_fluid_sample_t> >::~vector() /usr/include/c++/15/bits/stl_vector.h:805
    #6 0x0000004e1a7f in fluid_dls_font::~fluid_dls_font() /fluidsynth/src/sfloader/fluid_dls.cpp:438
    #7 0x0000004e1a7f in delete_fluid_dls_font /fluidsynth/src/sfloader/fluid_dls.cpp:523
    #8 0x0000004e1a7f in fluid_dls_sfont_delete /fluidsynth/src/sfloader/fluid_dls.cpp:3141

previously allocated by thread T0 here:
    #0 0x7f8f5a1c273b in operator new(unsigned long) (/lib64/libasan.so.8+0x12273b) (BuildId: cbfe49f3b7600c4f194d4c54774c977296e9d98a)
    #1 0x0000004ffda0 in std::__new_allocator<_fluid_sample_t>::allocate(unsigned long, void const*) /usr/include/c++/15/bits/new_allocator.h:151
    #2 0x0000004ffda0 in std::allocator_traits<std::allocator<_fluid_sample_t> >::allocate(std::allocator<_fluid_sample_t>&, unsigned long) /usr/include/c++/15/bits/alloc_traits.h:614
    #3 0x0000004ffda0 in std::_Vector_base<_fluid_sample_t, std::allocator<_fluid_sample_t> >::_M_allocate(unsigned long) /usr/include/c++/15/bits/stl_vector.h:387
    #4 0x0000004ffda0 in std::_Vector_base<_fluid_sample_t, std::allocator<_fluid_sample_t> >::_M_allocate(unsigned long) /usr/include/c++/15/bits/stl_vector.h:384
    #5 0x0000004ffda0 in std::vector<_fluid_sample_t, std::allocator<_fluid_sample_t> >::reserve(unsigned long) /usr/include/c++/15/bits/vector.tcc:79

Thread T4 created by T0 here:
    #0 0x7f8f5a1b9192 in pthread_create (/lib64/libasan.so.8+0x119192) (BuildId: cbfe49f3b7600c4f194d4c54774c977296e9d98a)
    #1 0x7f8f59fda004  (/lib64/libglib-2.0.so.0+0x93004) (BuildId: a1baf80bf47a8b0e99823b0b876b51fed88de515)

SUMMARY: AddressSanitizer: heap-use-after-free /fluidsynth/src/rvoice/fluid_rvoice_dsp.cpp:777 in int dsp_invoker<Interpolate4thOrder>(_fluid_rvoice_t*, double*, int)
Shadow bytes around the buggy address:
  0x7e8f577f9400: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e8f577f9480: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e8f577f9500: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e8f577f9580: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e8f577f9600: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x7e8f577f9680: fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd
  0x7e8f577f9700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e8f577f9780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e8f577f9800: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e8f577f9880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e8f577f9900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==2157==ABORTING
```