### PR TITLE
More stable workaround for MinGW fseek() workaround

### DIFF
--- a/src/utils/fluid_sys.c
+++ b/src/utils/fluid_sys.c
@@ -39,10 +39,6 @@
 #include <android/log.h>
 #endif
 
-#ifdef __MINGW32__
-#include <_mingw.h>
-#endif
-
 /* WIN32 HACK - Flag used to differentiate between a file descriptor and a socket.
  * Should work, so long as no SOCKET or file descriptor ends up with this bit set. - JG */
 #ifdef _WIN32
@@ -1672,8 +1668,7 @@ int fluid_file_read(void *buf, fluid_long_long_t count, FILE *fd)
 
 int fluid_file_seek(FILE *fd, fluid_long_long_t ofs, int whence)
 {
-// See here for the macro definitions: https://github.com/mingw-w64/mingw-w64/blob/a125b9ec1d96ff282155f2344f7d6eb50bf43c02/mingw-w64-headers/crt/_mingw_mac.h#L50-L61
-#if defined(__MINGW32__) && defined(_M_IX86)
+#if defined(__MINGW32__) && defined(__i386__)
     // Some older versions of MinGW i686 report incorrect values for _ftelli64(). This is problematic,
     // because _fseeki64() below would use these incorrect values when seeking with SEEK_CUR,
     // resulting in incorrect file positions. So we need to work around this by doing the SEEK_CUR


### PR DESCRIPTION
This makes the `fseek()` workaround for MinGW more stable, as per [related discussion](https://github.com/FluidSynth/fluidsynth/pull/1756#pullrequestreview-3802078613).

Addresses #1755