### PR TITLE
Implement RPN 0x05 Modulation Depth Range

### DIFF
--- a/src/synth/fluid_chan.c
+++ b/src/synth/fluid_chan.c
@@ -191,6 +191,9 @@ fluid_channel_init_ctrl(fluid_channel_t *chan, int is_all_ctrl_off)
 
         chan->pitch_wheel_sensitivity = 2; /* two semi-tones */
 
+        /* Modulation depth range (GM2 RPN 0x05): default is 50 cents (half a semitone) */
+        chan->modulation_depth_range = 50.0f;
+
         /* Just like panning, a value of 64 indicates no change for sound ctrls */
         for(i = SOUND_CTRL1; i <= SOUND_CTRL10; i++)
         {

--- a/src/synth/fluid_chan.h
+++ b/src/synth/fluid_chan.h
@@ -110,6 +110,7 @@ struct _fluid_channel_t
 
     unsigned char channel_pressure;                 /**< MIDI channel pressure from [0;127] */
     float pitch_wheel_sensitivity;          /**< Current pitch wheel sensitivity */
+    float modulation_depth_range;          /**< Modulation depth range in cents (RPN 0x05) */
     short pitch_bend;                      /**< Current pitch bend value */
     /* Sostenuto order id gives the order of SostenutoOn event.
      * This value is useful to known when the sostenuto pedal is depressed
@@ -176,6 +177,10 @@ fluid_real_t fluid_channel_get_key_pitch(fluid_channel_t *chan, int key);
   ((chan)->pitch_wheel_sensitivity)
 #define fluid_channel_set_pitch_wheel_sensitivity(chan, val) \
   ((chan)->pitch_wheel_sensitivity = (val))
+#define fluid_channel_get_modulation_depth_range(chan) \
+  ((chan)->modulation_depth_range)
+#define fluid_channel_set_modulation_depth_range(chan, val) \
+  ((chan)->modulation_depth_range = (val))
 #define fluid_channel_get_num(chan)             ((chan)->channum)
 #define fluid_channel_set_interp_method(chan, new_method) \
   ((chan)->interp_method = (new_method))

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -315,7 +315,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid
      */
     unsigned char mod_src = is_src1 ? mod->src1 : mod->src2;
     unsigned char mod_flags = is_src1 ? mod->flags1 : mod->flags2;
-    unsigned char applyModulationDepth = (mod_flags & FLUID_MOD_CC) && (mod_src == MODULATION_MSB) && (mod->dest == GEN_VIBLFOTOPITCH);
+    unsigned char applyModulationDepth = (mod_flags & FLUID_MOD_CC) && (mod_src == MODULATION_MSB) && ((mod->dest == GEN_VIBLFOTOPITCH) || (mod->dest == GEN_MODLFOTOPITCH));
     mod_flags &= ~FLUID_MOD_CC;
 
     if(mod_src == FLUID_MOD_NONE)

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -301,7 +301,7 @@ fluid_mod_get_source_value(const unsigned char mod_src,
  * transforms the initial value retrieved by \c fluid_mod_get_source_value into [0.0;1.0]
  */
 fluid_real_t
-fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid_real_t range, int is_src1)
+fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid_real_t range, int is_src1, fluid_voice_t *voice)
 {
     /* normalized value, i.e. usually in the range [0;1] */
     const fluid_real_t val_norm = val / range;
@@ -315,6 +315,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid
      */
     unsigned char mod_src = is_src1 ? mod->src1 : mod->src2;
     unsigned char mod_flags = is_src1 ? mod->flags1 : mod->flags2;
+    unsigned char applyModulationDepth = (mod_flags & FLUID_MOD_CC) && (mod_src == MODULATION_MSB) && (mod->dest == GEN_VIBLFOTOPITCH);
     mod_flags &= ~FLUID_MOD_CC;
 
     if(mod_src == FLUID_MOD_NONE)
@@ -405,6 +406,11 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid
         }
     }
 
+    if(applyModulationDepth && voice != NULL && voice->channel != NULL)
+    {
+        val *= fluid_channel_get_modulation_depth_range(voice->channel) / 50.0f;
+    }
+
     return val;
 }
 
@@ -483,13 +489,13 @@ fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice)
     v1 = fluid_mod_get_source_value(mod->src1, mod->flags1, &range1, voice);
 
     /* transform the input value */
-    v1 = fluid_mod_transform_source_value(mod, v1, range1, TRUE);
+    v1 = fluid_mod_transform_source_value(mod, v1, range1, TRUE, voice);
 
     /* get the second input source */
     v2 = fluid_mod_get_source_value(mod->src2, mod->flags2, &range2, voice);
 
     /* transform the second input value */
-    v2 = fluid_mod_transform_source_value(mod, v2, range2, FALSE);
+    v2 = fluid_mod_transform_source_value(mod, v2, range2, FALSE, voice);
 
     /* it indeed is as simple as that: */
     final_value = (fluid_real_t) mod->amount * v1 * v2;

--- a/src/synth/fluid_mod.c
+++ b/src/synth/fluid_mod.c
@@ -315,7 +315,7 @@ fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid
      */
     unsigned char mod_src = is_src1 ? mod->src1 : mod->src2;
     unsigned char mod_flags = is_src1 ? mod->flags1 : mod->flags2;
-    unsigned char applyModulationDepth = (mod_flags & FLUID_MOD_CC) && (mod_src == MODULATION_MSB) && ((mod->dest == GEN_VIBLFOTOPITCH) || (mod->dest == GEN_MODLFOTOPITCH));
+    unsigned char applyModulationDepth = is_src1 && (mod_flags & FLUID_MOD_CC) && (mod_src == MODULATION_MSB) && ((mod->dest == GEN_VIBLFOTOPITCH) || (mod->dest == GEN_MODLFOTOPITCH));
     mod_flags &= ~FLUID_MOD_CC;
 
     if(mod_src == FLUID_MOD_NONE)

--- a/src/synth/fluid_mod.h
+++ b/src/synth/fluid_mod.h
@@ -60,7 +60,7 @@ fluid_real_t fluid_mod_get_value(fluid_mod_t *mod, fluid_voice_t *voice);
 int fluid_mod_check_sources(const fluid_mod_t *mod, char *name);
 
 fluid_real_t fluid_mod_get_source_value(const unsigned char mod_src, const unsigned char mod_flags, fluid_real_t *range, const fluid_voice_t *voice);
-fluid_real_t fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid_real_t range, int is_src1);
+fluid_real_t fluid_mod_transform_source_value(fluid_mod_t* mod, fluid_real_t val, const fluid_real_t range, int is_src1, fluid_voice_t *voice);
 
 void delete_fluid_list_mod(fluid_mod_t *mod);
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -3227,21 +3227,7 @@ fluid_synth_update_pitch_wheel_sens_LOCAL(fluid_synth_t *synth, int chan)
 static int
 fluid_synth_update_modulation_depth_range_LOCAL(fluid_synth_t *synth, int chan)
 {
-    fluid_voice_t *voice;
-    int i;
-
-    for(i = 0; i < synth->polyphony; i++)
-    {
-        voice = synth->voice[i];
-
-        if(fluid_voice_get_channel(voice) == chan && fluid_voice_is_playing(voice))
-        {
-            fluid_voice_update_param(voice, GEN_VIBLFOTOPITCH);
-            fluid_voice_update_param(voice, GEN_MODLFOTOPITCH);
-        }
-    }
-
-    return FLUID_OK;
+    return fluid_synth_modulate_voices_LOCAL(synth, chan, 1, MODULATION_MSB);
 }
 
 /**
@@ -7964,7 +7950,7 @@ static void fluid_synth_process_awe32_nrpn_LOCAL(fluid_synth_t *synth, int chan,
         case GEN_REVERBSEND:
             fluid_clip(data, 0, 255);
             /* transform the input value */
-            converted_sf2_generator_value = fluid_mod_transform_source_value(&default_reverb_mod, data, 256, TRUE);
+            converted_sf2_generator_value = fluid_mod_transform_source_value(&default_reverb_mod, data, 256, TRUE, NULL);
             FLUID_LOG(FLUID_DBG, "AWE32 Reverb: %f", converted_sf2_generator_value);
             converted_sf2_generator_value*= fluid_mod_get_amount(&default_reverb_mod);
             break;
@@ -7972,7 +7958,7 @@ static void fluid_synth_process_awe32_nrpn_LOCAL(fluid_synth_t *synth, int chan,
         case GEN_CHORUSSEND:
             fluid_clip(data, 0, 255);
             /* transform the input value */
-            converted_sf2_generator_value = fluid_mod_transform_source_value(&default_chorus_mod, data, 256, TRUE);
+            converted_sf2_generator_value = fluid_mod_transform_source_value(&default_chorus_mod, data, 256, TRUE, NULL);
             FLUID_LOG(FLUID_DBG, "AWE32 Chorus: %f", converted_sf2_generator_value);
             converted_sf2_generator_value*= fluid_mod_get_amount(&default_chorus_mod);
             break;

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -87,6 +87,7 @@ static int fluid_synth_update_channel_pressure_LOCAL(fluid_synth_t *synth, int c
 static int fluid_synth_update_key_pressure_LOCAL(fluid_synth_t *synth, int chan, int key);
 static int fluid_synth_update_pitch_bend_LOCAL(fluid_synth_t *synth, int chan);
 static int fluid_synth_update_pitch_wheel_sens_LOCAL(fluid_synth_t *synth, int chan);
+static int fluid_synth_update_modulation_depth_range_LOCAL(fluid_synth_t *synth, int chan);
 static int fluid_synth_set_preset(fluid_synth_t *synth, int chan,
                                   fluid_preset_t *preset);
 static int fluid_synth_reverb_get_param(fluid_synth_t *synth, int fx_group,
@@ -2072,6 +2073,11 @@ fluid_synth_cc_LOCAL(fluid_synth_t *synth, int channum, int num)
                 break;
 
             case RPN_MODULATION_DEPTH_RANGE:
+                /* MSB = semitones, LSB = 1/128 semitones (cent fraction)
+                 * Default per GM2: 0 semitones + 64/128 = 50 cents */
+                fluid_channel_set_modulation_depth_range(chan,
+                    msb_value * 100.0f + lsb_value * 100.0f / 128.0f);
+                fluid_synth_update_modulation_depth_range_LOCAL(synth, channum);
                 break;
             }
         }
@@ -3177,6 +3183,28 @@ static int
 fluid_synth_update_pitch_wheel_sens_LOCAL(fluid_synth_t *synth, int chan)
 {
     return fluid_synth_modulate_voices_LOCAL(synth, chan, 0, FLUID_MOD_PITCHWHEELSENS);
+}
+
+/* Local synthesis thread variant: update voices after modulation depth range RPN change.
+ * Re-applies GEN_VIBLFOTOPITCH and GEN_MODLFOTOPITCH with the new channel multiplier. */
+static int
+fluid_synth_update_modulation_depth_range_LOCAL(fluid_synth_t *synth, int chan)
+{
+    fluid_voice_t *voice;
+    int i;
+
+    for(i = 0; i < synth->polyphony; i++)
+    {
+        voice = synth->voice[i];
+
+        if(fluid_voice_get_channel(voice) == chan && fluid_voice_is_playing(voice))
+        {
+            fluid_voice_update_param(voice, GEN_VIBLFOTOPITCH);
+            fluid_voice_update_param(voice, GEN_MODLFOTOPITCH);
+        }
+    }
+
+    return FLUID_OK;
 }
 
 /**

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -2109,10 +2109,14 @@ fluid_synth_cc_LOCAL(fluid_synth_t *synth, int channum, int num)
 
             case RPN_MODULATION_DEPTH_RANGE:
                 /* MSB = semitones, LSB = 1/128 semitones (cent fraction)
-                 * Default per GM2: 0 semitones + 64/128 = 50 cents */
-                fluid_channel_set_modulation_depth_range(chan,
-                    msb_value * 100.0f + lsb_value * 100.0f / 128.0f);
-                fluid_synth_update_modulation_depth_range_LOCAL(synth, channum);
+                 * Default per GM2: 0 semitones + 64/128 = 50 cents
+                 * Ignored for "rhythm channels" */
+                if(chan->channel_type == CHANNEL_TYPE_MELODIC)
+                {
+                    fluid_channel_set_modulation_depth_range(chan,
+                        msb_value * 100.0f + lsb_value * 100.0f / 128.0f);
+                    fluid_synth_update_modulation_depth_range_LOCAL(synth, channum);
+                }
                 break;
             }
         }

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -879,6 +879,7 @@ fluid_voice_update_param(fluid_voice_t *voice, int gen)
         break;
 
     case GEN_MODLFOTOPITCH:
+        x *= fluid_channel_get_modulation_depth_range(voice->channel) / 50.0f;
         fluid_clip(x, -12000.f, 12000.f);
         UPDATE_RVOICE_R1(fluid_rvoice_set_modlfo_to_pitch, x);
         break;
@@ -926,6 +927,7 @@ fluid_voice_update_param(fluid_voice_t *voice, int gen)
         break;
 
     case GEN_VIBLFOTOPITCH:
+        x *= fluid_channel_get_modulation_depth_range(voice->channel) / 50.0f;
         fluid_clip(x, -12000.f, 12000.f);
         UPDATE_RVOICE_R1(fluid_rvoice_set_viblfo_to_pitch, x);
         break;

--- a/src/synth/fluid_voice.c
+++ b/src/synth/fluid_voice.c
@@ -865,7 +865,6 @@ fluid_voice_update_param(fluid_voice_t *voice, int gen)
         break;
 
     case GEN_MODLFOTOPITCH:
-        x *= fluid_channel_get_modulation_depth_range(voice->channel) / 50.0f;
         fluid_clip(x, -12000.f, 12000.f);
         UPDATE_RVOICE_R1(fluid_rvoice_set_modlfo_to_pitch, x);
         break;
@@ -913,7 +912,6 @@ fluid_voice_update_param(fluid_voice_t *voice, int gen)
         break;
 
     case GEN_VIBLFOTOPITCH:
-        x *= fluid_channel_get_modulation_depth_range(voice->channel) / 50.0f;
         fluid_clip(x, -12000.f, 12000.f);
         UPDATE_RVOICE_R1(fluid_rvoice_set_viblfo_to_pitch, x);
         break;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -473,11 +473,19 @@ add_custom_target(renderDMOD
 )
 
 add_custom_target(renderRPN
-    COMMAND ${MANUAL_TEST_FLUIDSYNTH} -R 0 -C 0 -g 1.1 -F "${RPN_RENDER_DIR}/SA2 - Prison Lane -- MIDIMan - FluidSynth Test.mid.${FEXT}" ${GENERAL_USER_GS2} "FluidSynth.pitch.bend.fine.tuning.bug.demonstration/SA2 - Prison Lane -- MIDIMan - FluidSynth Test.mid"
     COMMENT "Rendering Test MIDI for RPNs"
     DEPENDS ${MANUAL_TEST_DEPENDS} create_out_dir
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/manual/rpn/"
-    VERBATIM
+)
+set_target_properties(renderRPN PROPERTIES
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/manual/rpn"
+)
+add_render_job(renderRPN
+    "${RPN_RENDER_DIR}/SA2 - Prison Lane -- MIDIMan - FluidSynth Test.${FEXT}"
+    -R 0 -C 0 -g 1.1 ${GENERAL_USER_GS2} "FluidSynth.pitch.bend.fine.tuning.bug.demonstration/SA2 - Prison Lane -- MIDIMan - FluidSynth Test.mid"
+)
+add_render_job(renderRPN
+    "${RPN_RENDER_DIR}/test-rpn-00-05-modulation-depth-range.${FEXT}"
+    -R 0 -C 0 -g 1.9 ${GENERAL_USER_GS2} "test-rpn-00-05-modulation-depth-range.mid"
 )
 
 set(_gsdt1_demos

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -484,8 +484,12 @@ add_render_job(renderRPN
     -R 0 -C 0 -g 1.1 ${GENERAL_USER_GS2} "FluidSynth.pitch.bend.fine.tuning.bug.demonstration/SA2 - Prison Lane -- MIDIMan - FluidSynth Test.mid"
 )
 add_render_job(renderRPN
-    "${RPN_RENDER_DIR}/test-rpn-00-05-modulation-depth-range.${FEXT}"
-    -R 0 -C 0 -g 1.9 ${GENERAL_USER_GS2} "test-rpn-00-05-modulation-depth-range.mid"
+    "${RPN_RENDER_DIR}/modulation-range/test-rpn-00-05-modulation-depth-range.${FEXT}"
+    -R 0 -C 0 -g 1.9 ${GENERAL_USER_GS2} "modulation-range/test-rpn-00-05-modulation-depth-range.mid"
+)
+add_render_job(renderRPN
+    "${RPN_RENDER_DIR}/modulation-range/mod-rpn-no-mod-wheel.${FEXT}"
+    -R 0 -C 0 -g 1.4 modulation-range/vib.sf2 "modulation-range/mod-rpn-no-mod-wheel.mid"
 )
 
 set(_gsdt1_demos

--- a/test/test_modulator.cpp
+++ b/test/test_modulator.cpp
@@ -43,28 +43,28 @@ static void test_mod_source_mapping(fluid_mod_t *mod)
                             | FLUID_MOD_POSITIVE
                             );
 
-            v1 = fluid_mod_transform_source_value(mod, 0, Range, true);
+            v1 = fluid_mod_transform_source_value(mod, 0, Range, true, nullptr);
             TEST_ASSERT(v1 == 0.0f);
 
             // skip midpoint validation for concave and convex since we're not checking correctness of concave and convex implementations here
             if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, true, nullptr);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
             else if(Mapping[i] == FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, true, nullptr);
                 TEST_ASSERT(std::fabs(v1 - UnipolarConvexMid) <= 1e-6);
             }
             else if(Mapping[i] == FLUID_MOD_CONCAVE)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, true, nullptr);
                 TEST_ASSERT(std::fabs(v1 - UnipolarConcaveMid) <= 1e-6);
             }
 
-            v1 = fluid_mod_transform_source_value(mod, 127, Range, true);
+            v1 = fluid_mod_transform_source_value(mod, 127, Range, true, nullptr);
             tmp = get_mod_max(mod);
             TEST_ASSERT(v1 == tmp);
         }
@@ -80,27 +80,27 @@ static void test_mod_source_mapping(fluid_mod_t *mod)
                             | FLUID_MOD_NEGATIVE
                             );
 
-            v1 = fluid_mod_transform_source_value(mod, 127, Range, true);
+            v1 = fluid_mod_transform_source_value(mod, 127, Range, true, nullptr);
             TEST_ASSERT(v1 == 0.0f);
 
             if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, true, nullptr);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 0.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
             else if(Mapping[i] == FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64-1, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64-1, Range, true, nullptr);
                 TEST_ASSERT(std::fabs(v1 - UnipolarConvexMid) <= 1e-6);
             }
             else if(Mapping[i] == FLUID_MOD_CONCAVE)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64-1, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64-1, Range, true, nullptr);
                 TEST_ASSERT(std::fabs(v1 - UnipolarConcaveMid) <= 1e-6);
             }
             
-            v1 = fluid_mod_transform_source_value(mod, 0, Range, true);
+            v1 = fluid_mod_transform_source_value(mod, 0, Range, true, nullptr);
             tmp = get_mod_max(mod);
             TEST_ASSERT(v1 == tmp);
         }
@@ -116,29 +116,29 @@ static void test_mod_source_mapping(fluid_mod_t *mod)
                             | FLUID_MOD_POSITIVE
                             );
 
-            v1 = fluid_mod_transform_source_value(mod, 0, Range, true);
+            v1 = fluid_mod_transform_source_value(mod, 0, Range, true, nullptr);
             TEST_ASSERT(v1 == -1.0f);
 
             if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, true, nullptr);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? 1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
             else if(Mapping[i] == FLUID_MOD_CONVEX)
             {
                 // v1 should be zero exactly
-                v1 = fluid_mod_transform_source_value(mod, 64, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, true, nullptr);
                 TEST_ASSERT(v1 == BipolarConvexMid);
             }
             else if(Mapping[i] == FLUID_MOD_CONCAVE)
             {
                 // v1 should be zero exactly
-                v1 = fluid_mod_transform_source_value(mod, 64, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, true, nullptr);
                 TEST_ASSERT(v1 == BipolarConcaveMid);
             }
 
-            v1 = fluid_mod_transform_source_value(mod, 127, Range, true);
+            v1 = fluid_mod_transform_source_value(mod, 127, Range, true, nullptr);
             tmp = get_mod_max(mod);
             TEST_ASSERT(v1 == tmp);
         }
@@ -154,29 +154,29 @@ static void test_mod_source_mapping(fluid_mod_t *mod)
                             | FLUID_MOD_NEGATIVE
                             );
 
-            v1 = fluid_mod_transform_source_value(mod, 127, Range, true);
+            v1 = fluid_mod_transform_source_value(mod, 127, Range, true, nullptr);
             TEST_ASSERT(v1 == -1.0f);
 
             if(Mapping[i] != FLUID_MOD_CONCAVE && Mapping[i] != FLUID_MOD_CONVEX)
             {
-                v1 = fluid_mod_transform_source_value(mod, 64, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64, Range, true, nullptr);
                 tmp = ((mod->flags1 & FLUID_MOD_MAP_MASK) == FLUID_MOD_SWITCH) ? -1.0f : mid;
                 TEST_ASSERT(v1 == tmp);
             }
             else if(Mapping[i] == FLUID_MOD_CONVEX)
             {
                 // v1 should be zero exactly
-                v1 = fluid_mod_transform_source_value(mod, 64-1, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64-1, Range, true, nullptr);
                 TEST_ASSERT(v1 == BipolarConvexMid);
             }
             else if(Mapping[i] == FLUID_MOD_CONCAVE)
             {
                 // v1 should be zero exactly
-                v1 = fluid_mod_transform_source_value(mod, 64-1, Range, true);
+                v1 = fluid_mod_transform_source_value(mod, 64-1, Range, true, nullptr);
                 TEST_ASSERT(v1 == BipolarConcaveMid);
             }
 
-            v1 = fluid_mod_transform_source_value(mod, 0, Range, true);
+            v1 = fluid_mod_transform_source_value(mod, 0, Range, true, nullptr);
             tmp = get_mod_max(mod);
             TEST_ASSERT(v1 == tmp);
         }
@@ -201,7 +201,7 @@ static void test_mod_no_source(fluid_mod_t *mod)
                 v1 = fluid_mod_get_source_value(mod->src2, mod->flags2, &tmp, nullptr);
                 TEST_ASSERT(tmp == Range);
                 TEST_ASSERT(v1 == Range);
-                v1 = fluid_mod_transform_source_value(mod, v1, Range, false);
+                v1 = fluid_mod_transform_source_value(mod, v1, Range, false, nullptr);
                 TEST_ASSERT(v1 == 1.0f);
             }
         }
@@ -212,7 +212,7 @@ static void test_mod_no_source(fluid_mod_t *mod)
     v1 = fluid_mod_get_source_value(mod->src2, mod->flags2, &tmp, nullptr);
     TEST_ASSERT(tmp == Range);
     TEST_ASSERT(v1 == Range);
-    v1 = fluid_mod_transform_source_value(mod, v1, Range, false);
+    v1 = fluid_mod_transform_source_value(mod, v1, Range, false, nullptr);
     TEST_ASSERT(v1 == 1.0f);
 }
 
@@ -234,7 +234,7 @@ static void test_custom_mapping(fluid_mod_t *mod)
     for(int i = 0; i <= Range; i++)
     {
         v = i;
-        v = fluid_mod_transform_source_value(mod, v, Range, false);
+        v = fluid_mod_transform_source_value(mod, v, Range, false, nullptr);
         TEST_ASSERT(-1. <= v && v <= 1. && v == (i*1.)/Range);
     }
 }


### PR DESCRIPTION
Following @spessasus proposal in #1355, this PR implements GM2 RPN 0x5 by using a modulation multiplier: 

*    Implemented RPN 0x05 handler to store and update the current modulation depth range in cents (default: 50 cents per GM2 spec)
*   When processing modulators targeting `GEN_VIBLFOTOPITCH` or `GEN_MODLFOTOPITCH` AND source1 is set to the modulation wheel, the modulator output is scaled by `modulation_depth_range / 50.0`
*    RPN 0x05 is ignored for drum/rhythm channels, following GM2 spec
*    Added test MIDI files and soundfonts to verify the implementation.

### Why This Approach?

Rather than replacing SoundFont-defined vibrato depths with absolute values, this implementation uses a modulation multiplier to preserve the composer's original instrument voice characteristics. This means if a SoundFont defines a subtle 25-cent vibrato and the MIDI composer sets RPN 0x05 to 100 cents (double the default), the result is 50 cents—a proper doubling of the original depth—instead of overriding it to 100 cents. This maintains artistic intent across different instruments and SoundFonts. It also maintains backward compatibility for Soundfonts that override / disable the [default mod2viblfo modulator](https://github.com/derselbst/fluidsynth/blob/cd045d6719fc3e7d8006ae98cc3787d655e8e55c/src/synth/fluid_synth.c#L409-L417) and choose to use `GEN_MODLFOTOPITCH` instead.

Resolves #1355 