### PR TITLE
fix(sfloader): move INFO chunk FLUID_LOG into the branch where item.chr is allocated

### DIFF
--- a/src/sfloader/fluid_sffile.c
+++ b/src/sfloader/fluid_sffile.c
@@ -855,6 +855,7 @@ static int process_info(SFData *sf, int size)
 
                     /* force terminate info item */
                     item.chr[chunk.size] = '\0';
+                    FLUID_LOG(FLUID_DBG, "INFO chunk %c%c%c%c (%d bytes) -> %s", p[0], p[1], p[2], p[3], chunk.size, item.chr);
                 }
             }
             else
@@ -873,7 +874,6 @@ static int process_info(SFData *sf, int size)
                     return FALSE;
                 }
             }
-            FLUID_LOG(FLUID_DBG, "INFO chunk %c%c%c%c (%d bytes) -> %s", p[0], p[1], p[2], p[3], chunk.size, item.chr);
         }
 
         size -= chunk.size;


### PR DESCRIPTION
The debug log referencing item.chr was placed at the end of the outer
else block, reachable by code paths where item.fcc was never allocated,
causing a potential NULL pointer dereference and a -Wmaybe-uninitialized
warning. Move the log to immediately after the successful fread(), where
item.chr is guaranteed to be valid.

Fixes -Wmaybe-uninitialized warning in fluid_sffile.c:685