### PR TITLE
fix(midi): replace deprecated API calls in fluid_player_set_bpm

### DIFF
--- a/src/midi/fluid_midi.c
+++ b/src/midi/fluid_midi.c
@@ -2574,7 +2574,7 @@ int fluid_player_set_bpm(fluid_player_t *player, int bpm)
         return FLUID_FAILED; /* to avoid a division by 0 */
     }
 
-    return fluid_player_set_midi_tempo(player, 60000000L / bpm);
+    return fluid_player_set_tempo(player, FLUID_PLAYER_TEMPO_EXTERNAL_BPM, (double)bpm);
 }
 
 /**


### PR DESCRIPTION
fluid_player_set_bpm is deprecated in favour of fluid_player_set_tempo, as is fluid_player_set_midi_tempo which it called internally. Replace the internal call with fluid_player_set_tempo() using FLUID_PLAYER_TEMPO_EXTERNAL_BPM to suppress the -Wdeprecated-declarations warning without introducing internal workarounds.