### PR TITLE
Correct wiki links to the new wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: "📖 Fluidsynth Wiki"
-    url: "https://github.com/FluidSynth/fluidsynth/wiki"
+    url: "https://www.fluidsynth.org/wiki"
     about: "Looking for documentation or developer resources?"
   - name: "⁉️ GitHub Community Support"
     url: "https://github.com/FluidSynth/fluidsynth/discussions"

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,5 @@ install_manifest.txt
 # Built docs
 /.zensical/
 /.cache/
-/site/
 _codeql_build_dir/
 _codeql_detected_source_root

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,6 @@ install_manifest.txt
 # Built docs
 /.zensical/
 /.cache/
+/site/
 _codeql_build_dir/
 _codeql_detected_source_root

--- a/ChangeLog.old
+++ b/ChangeLog.old
@@ -1,7 +1,7 @@
 This file is no longer used. For detailed Changelog information, please refer to the 
 version control system's commits. For an overview of differences between versions,
 see:
-https://github.com/FluidSynth/fluidsynth/wiki/ChangeLog
+https://www.fluidsynth.org/wiki/ChangeLog
 
 For developer related "What's new"-information,
 https://www.fluidsynth.org/api/RecentChanges.html

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -2,7 +2,7 @@
 
 The latest information on how to compile FluidSynth using the cmake build system can be found in our wiki:
 
-https://github.com/FluidSynth/fluidsynth/wiki/BuildingWithCMake
+https://www.fluidsynth.org/wiki/BuildingWithCMake
 
 ## For developers - how to add a new feature to the CMake build system
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 #### FluidSynth is a cross-platform, real-time software synthesizer based on the Soundfont 2 specification.
 
-FluidSynth generates audio by reading and handling MIDI events from MIDI input devices by using a [SoundFont](https://github.com/FluidSynth/fluidsynth/wiki/SoundFont). It is the software analogue of a MIDI synthesizer. FluidSynth can also play MIDI files.
+FluidSynth generates audio by reading and handling MIDI events from MIDI input devices by using a [SoundFont](https://www.fluidsynth.org/wiki/SoundFont). It is the software analogue of a MIDI synthesizer. FluidSynth can also play MIDI files.
 
 [![SonarQube Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=FluidSynth_fluidsynth&metric=alert_status)](https://sonarcloud.io/dashboard?id=FluidSynth_fluidsynth) [![OHLOH Project Stats](https://www.openhub.net/p/fluidsynth/widgets/project_thin_badge?format=gif)](https://www.openhub.net/p/fluidsynth)
 
@@ -23,7 +23,7 @@ FluidSynth generates audio by reading and handling MIDI events from MIDI input d
 
 The central place for documentation and further links is our **wiki** here at GitHub:
 
-#### https://github.com/FluidSynth/fluidsynth/wiki
+#### https://www.fluidsynth.org/wiki
 
 If you are missing parts of the documentation, let us know by writing to our mailing list.
 Of course, you are welcome to edit and improve the wiki yourself. All you need is an account at GitHub. Alternatively, you may send an EMail to our mailing list along with your suggested changes. Further information about the mailing list is available in the wiki as well.
@@ -32,17 +32,17 @@ Latest information about FluidSynth is also available on the web site at https:/
 
 ## License
 
-The source code for FluidSynth is distributed under the terms of the [GNU Lesser General Public License](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html), see the [LICENSE](https://github.com/FluidSynth/fluidsynth/blob/master/LICENSE) file. To better understand the conditions how FluidSynth can be used in e.g. commercial or closed-source projects, please refer to the [LicensingFAQ in our wiki](https://github.com/FluidSynth/fluidsynth/wiki/LicensingFAQ).
+The source code for FluidSynth is distributed under the terms of the [GNU Lesser General Public License](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html), see the [LICENSE](https://github.com/FluidSynth/fluidsynth/blob/master/LICENSE) file. To better understand the conditions how FluidSynth can be used in e.g. commercial or closed-source projects, please refer to the [LicensingFAQ in our wiki](https://www.fluidsynth.org/wiki/LicensingFAQ).
 
 ## Building from source
 
-For information on how to build FluidSynth from source, please [refer to our wiki](https://github.com/FluidSynth/fluidsynth/wiki/BuildingWithCMake).
+For information on how to build FluidSynth from source, please [refer to our wiki](https://www.fluidsynth.org/wiki/BuildingWithCMake).
 
 ## Links
 
 - FluidSynth's Home Page, https://www.fluidsynth.org
 
-- FluidSynth's wiki, https://github.com/FluidSynth/fluidsynth/wiki
+- FluidSynth's wiki, https://www.fluidsynth.org/wiki
 
 - FluidSynth's API documentation, https://www.fluidsynth.org/api/
 

--- a/doc/README
+++ b/doc/README
@@ -10,4 +10,4 @@ The latest generated API HTML docs can also be found at:
 https://www.fluidsynth.org/api/
 
 Even more documentation references are provided on our wiki page:
-https://github.com/FluidSynth/fluidsynth/wiki/Documentation
+https://www.fluidsynth.org/wiki/Documentation

--- a/doc/android/README.md
+++ b/doc/android/README.md
@@ -33,7 +33,7 @@ There is [an example source code](https://github.com/atsushieno/fluidsynth-midi-
 
 ## Building
 
-In this directory the Cerbero build system is (ab)used for cross-compiling Fluidsynth's dependencies for Android. The entrypoint is `Makefile.android`. If you are looking for a step by step introduction guide for cross-compiling Fluidsynth, [you'll find it in the wiki](https://github.com/FluidSynth/fluidsynth/wiki/BuildingForAndroid).
+In this directory the Cerbero build system is (ab)used for cross-compiling Fluidsynth's dependencies for Android. The entrypoint is `Makefile.android`. If you are looking for a step by step introduction guide for cross-compiling Fluidsynth, [you'll find it in the wiki](https://www.fluidsynth.org/wiki/BuildingForAndroid).
 
 By default, you are supposed to provide `PKG_CONFIG_PATH` to glib etc. as well as oboe. There is nothing special.
 

--- a/include/fluidsynth/shell.h
+++ b/include/fluidsynth/shell.h
@@ -38,7 +38,7 @@ extern "C" {
  * For a full list of available commands, type \c help in the
  * \ref command_shell or send the same command via a command handler.
  * Further documentation can be found at
- * https://github.com/FluidSynth/fluidsynth/wiki/UserManual#shell-commands
+ * https://www.fluidsynth.org/wiki/UserManual#shell-commands
  *
  * @{
  */

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -1731,7 +1731,7 @@ fluid_synth_remove_default_mod(fluid_synth_t *synth, const fluid_mod_t *mod)
  * Send a MIDI controller event on a MIDI channel.
  *
  * Most CCs are 7-bits wide in FluidSynth. There are a few exceptions which may be 14-bits wide as are documented here:
- * https://github.com/FluidSynth/fluidsynth/wiki/FluidFeatures#midi-control-change-implementation-chart
+ * https://www.fluidsynth.org/wiki/FluidFeatures#midi-control-change-implementation-chart
  *
  * @param synth FluidSynth instance
  * @param chan MIDI channel number (0 to MIDI channel count - 1)


### PR DESCRIPTION
This small PR changes all links that still point to the GH wiki to the new wiki
Also adds the output generated `site` dir to `.gitignore` because it forgot to add it before and we don't want to accidentally commit the generated files :-]