### PR TITLE
GitHub Actions: Run acceptance-test on multiple Windows versions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -566,7 +566,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:  # https://github.com/actions/runner-images#available-images
-        os: [windows-2022, windows-2025-vs2026, windows-latest, windows-11-arm]
+        os: [windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
     name: 🧪 Acceptance Test
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -563,7 +563,11 @@ jobs:
     - msvc-build
     - msys2-build
     - mingw-build
-    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:  # https://github.com/actions/runner-images#available-images
+        os: [windows-2022, windows-2025-vs2026, windows-latest, windows-11-arm]
+    runs-on: ${{ matrix.os }}
     name: 🧪 Acceptance Test
     steps:
     - name: Download all artifacts


### PR DESCRIPTION
https://github.com/actions/runner-images#available-images
```
os: [windows-2022, windows-2025-vs2026, windows-latest, windows-11-arm]
runs-on: ${{ matrix.os }}
```
`windows-11-arm` is from https://github.com/actions/partner-runner-images