### PR TITLE
Change the log level of stub functions

### DIFF
--- a/src/utils/fluid_stub_functions.h
+++ b/src/utils/fluid_stub_functions.h
@@ -30,18 +30,24 @@
 #include "fluidsynth_priv.h"
 
 
+#ifdef NDEBUG
+#define STUB_FUNCTION_LOG_LEVEL FLUID_DBG
+#else
+#define STUB_FUNCTION_LOG_LEVEL FLUID_ERR
+#endif
+
 #define STUB_FUNCTION_VOID(function, args) \
     static FLUID_INLINE void \
     function args \
     { \
-        FLUID_LOG(FLUID_ERR, "function " # function " is a stub"); \
+        FLUID_LOG(STUB_FUNCTION_LOG_LEVEL, "function " # function " is a stub"); \
     }
 
 #define STUB_FUNCTION(function, type, result, args) \
     static FLUID_INLINE type \
     function args \
     { \
-        FLUID_LOG(FLUID_ERR, "function " # function " is a stub, always returning " # result); \
+        FLUID_LOG(STUB_FUNCTION_LOG_LEVEL, "function " # function " is a stub, always returning " # result); \
         return result; \
     }
 


### PR DESCRIPTION
We're having problems at https://github.com/mkxp-z/mkxp-z/pull/321 with the "function is a stub" log messages sometimes emitted by FluidSynth when configured with `-Dosal=cpp11` or `-Dosal=embedded` being annoying to end users. Given that they don't indicate an error that occurred within FluidSynth, maybe they shouldn't be error messages?