### PR TITLE
fix: add channel bounds check in pitch_bend_range to prevent OOB access

### DIFF
--- a/src/bindings/fluid_cmd.c
+++ b/src/bindings/fluid_cmd.c
@@ -748,6 +748,11 @@ fluid_handle_pitch_bend_range(void *data, int ac, char **av, fluid_ostream_t out
 
     channum = atoi(av[0]);
     value = atoi(av[1]);
+    if(channum < 0 || channum >= fluid_synth_count_midi_channels(handler->synth))
+    {
+        fluid_ostream_printf(out, "pitch_bend_range: invalid channel number\n");
+        return FLUID_FAILED;
+    }
     fluid_channel_set_pitch_wheel_sensitivity(handler->synth->channel[channum], value);
     return FLUID_OK;
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  fluid_handle_pitch_bend_range() in src/bindings/fluid_cmd.c uses the user-supplied channel number from the TCP shell command directly as an array index into handler->synth->channel[] without any range validation. An attacker connected to the TCP shell (fluidsynth -s) can send "pitch_bend_range 999 100" to trigger an out-of-bounds write, causing a segfault confirmed by AddressSanitizer.                      
                                                                                                                                                                                                                        ## Fix          

  Add a bounds check using fluid_synth_count_midi_channels() before indexing the channel array. Invalid channel numbers return FLUID_FAILED with an error message.                                                 
  
                                                                                                                                                                                                                        ## Affected code                                                                                                                                                                                                 
                                                                                                                                                                                                                   
  src/bindings/fluid_cmd.c — fluid_handle_pitch_bend_range()