### PR TITLE
Fix DLS sample validation

### DIFF
--- a/src/sfloader/fluid_dls.cpp
+++ b/src/sfloader/fluid_dls.cpp
@@ -1707,7 +1707,7 @@ fluid_dls_font::fluid_dls_font(fluid_synth_t *synth,
     bool invalid_loops_were_sanitized = false;
     for(auto &sample : samples)
     {
-        fluid_sample_t fluid{};
+        auto& fluid = samples_fluid.emplace_back();
         fluid.start = sample.start;
         fluid.end = sample.end - 1;
         fluid.samplerate = sample.samplerate;
@@ -1735,9 +1735,10 @@ fluid_dls_font::fluid_dls_font(fluid_synth_t *synth,
         fluid.sampletype = FLUID_SAMPLETYPE_MONO;
         fluid.default_modulators = this->sfont->default_mod_list;
 
-        if(fluid_sample_validate(&fluid, sampledata.size() * sizeof(decltype(sampledata)::value_type)) == FLUID_OK)
+        if(fluid_sample_validate(&fluid, sampledata.size() * sizeof(decltype(sampledata)::value_type)) != FLUID_OK)
         {
-            samples_fluid.push_back(std::move(fluid));
+            FLUID_LOG(FLUID_WARN, "Sample '%s' is invalid, purging", sample.name.c_str());
+            fluid = {};
         }
     }
 


### PR DESCRIPTION
2354c2a9acdb26de7cdcd37c903ee108f46c0a7d introduces validation of DLS samples, but when a sample is invalid, it won't be add into samples_fluid, causing mismatch between array index and sample ID to following samples.

This can cause out-of-bound reading beyond the samples_fluid (a std::vector)'s length, but not beyond its capacity.