### PR TITLE
Minor performance tweaks and profiling logs for pipewire

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -800,7 +800,7 @@ Developers:
             <desc>
                 If TRUE, creates an asynchronous PipeWire stream. This isolates synthesizer from PipeWire's synchronous processing graph, preventing system-wide audio dropouts (xruns) during heavy workload (such as high polyphones).
                 Requires PipeWire &gt;= 0.3.73.
-                <note>Enabling this automatically increases latency by exactly one period.</note>
+                <note>Enabling this automatically doubles the actual latency.</note>
             </desc>
         </setting>
         <setting>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -794,6 +794,16 @@ Developers:
             </desc>
         </setting>
         <setting>
+            <name>pipewire.async</name>
+            <type>bool</type>
+            <def>1 (TRUE)</def>
+            <desc>
+                If TRUE, creates an asynchronous PipeWire stream. This isolates synthesizer from PipeWire's synchronous processing graph, preventing system-wide audio dropouts (xruns) during heavy workload (such as high polyphones).
+                Requires PipeWire &gt;= 0.3.73.
+                <note>Enabling this automatically increases latency by exactly one period.</note>
+            </desc>
+        </setting>
+        <setting>
             <name>portaudio.device</name>
             <type>str</type>
             <def>PortAudio Default</def>

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -48,6 +48,7 @@ typedef struct
     float *lbuf, *rbuf;
 
     int buffer_period;
+    int audio_periods;
     struct spa_pod_builder *builder;
 
     struct pw_thread_loop *pw_loop;
@@ -65,6 +66,7 @@ static void fluid_pipewire_event_process(void *data)
     struct pw_buffer *pwb;
     struct spa_buffer *buf;
     float *dest;
+    uint32_t n_frames;
 #ifdef PROFILE_PIPEWIRE
     struct timespec ts_now, ts_write_start, ts_write_end;
     static struct timespec ts_last_call = {0, 0};
@@ -96,10 +98,22 @@ static void fluid_pipewire_event_process(void *data)
         return;
     }
 
+    n_frames = (uint32_t)pwb->requested; // since PW 0.3.50
+
+    if(n_frames == 0)
+    {
+        n_frames = buf->datas[0].maxsize / (uint32_t)stride;
+    }
+
+    if(n_frames == 0)
+    {
+        n_frames = (uint32_t)drv->buffer_period;
+    }
+
 #ifdef PROFILE_PIPEWIRE
     clock_gettime(CLOCK_MONOTONIC, &ts_write_start);
 #endif
-    fluid_synth_write_float(drv->data, drv->buffer_period, dest, 0, 2, dest, 1, 2);
+    fluid_synth_write_float(drv->data, (int)n_frames, dest, 0, 2, dest, 1, 2);
 #ifdef PROFILE_PIPEWIRE
     clock_gettime(CLOCK_MONOTONIC, &ts_write_end);
     {
@@ -111,7 +125,8 @@ static void fluid_pipewire_event_process(void *data)
 
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
-    buf->datas[0].chunk->size = drv->buffer_period * stride;
+    buf->datas[0].chunk->size = n_frames * stride;
+    pwb->size = n_frames;
 
     pw_stream_queue_buffer(drv->pw_stream, pwb);
 }
@@ -124,6 +139,7 @@ static void fluid_pipewire_event_process2(void *data)
     struct spa_buffer *buf;
     float *dest;
     float *channels[NUM_CHANNELS] = { drv->lbuf, drv->rbuf };
+    uint32_t n_frames;
     int i;
 
     pwb = pw_stream_dequeue_buffer(drv->pw_stream);
@@ -142,13 +158,26 @@ static void fluid_pipewire_event_process2(void *data)
         return;
     }
 
-    FLUID_MEMSET(drv->lbuf, 0, drv->buffer_period * sizeof(float));
-    FLUID_MEMSET(drv->rbuf, 0, drv->buffer_period * sizeof(float));
+    /* Determine how many frames to render (same logic as fast path) */
+    n_frames = (uint32_t)pwb->requested;
 
-    (*drv->user_callback)(drv->data, drv->buffer_period, 0, NULL, NUM_CHANNELS, channels);
+    if(n_frames == 0)
+    {
+        n_frames = buf->datas[0].maxsize / (uint32_t)stride;
+    }
+
+    if(n_frames == 0)
+    {
+        n_frames = (uint32_t)drv->buffer_period;
+    }
+
+    FLUID_MEMSET(drv->lbuf, 0, n_frames * sizeof(float));
+    FLUID_MEMSET(drv->rbuf, 0, n_frames * sizeof(float));
+
+    (*drv->user_callback)(drv->data, (int)n_frames, 0, NULL, NUM_CHANNELS, channels);
 
     /* Interleave the floating point data */
-    for(i = 0; i < drv->buffer_period; i++)
+    for(i = 0; i < (int)n_frames; i++)
     {
         dest[i * 2] = drv->lbuf[i];
         dest[i * 2 + 1] = drv->rbuf[i];
@@ -156,7 +185,8 @@ static void fluid_pipewire_event_process2(void *data)
 
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
-    buf->datas[0].chunk->size = drv->buffer_period * stride;
+    buf->datas[0].chunk->size = n_frames * stride;
+    pwb->size = n_frames;
 
     pw_stream_queue_buffer(drv->pw_stream, pwb);
 }
@@ -171,6 +201,8 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
 {
     fluid_pipewire_audio_driver_t *drv;
     int period_size;
+    int periods;
+    int max_latency_frames;
     int buffer_length;
     int res;
     int pw_flags;
@@ -194,15 +226,19 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     FLUID_MEMSET(drv, 0, sizeof(*drv));
 
     fluid_settings_getint(settings, "audio.period-size", &period_size);
+    fluid_settings_getint(settings, "audio.periods", &periods);
     fluid_settings_getint(settings, "audio.realtime-prio", &realtime_prio);
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
     fluid_settings_dupstr(settings, "audio.pipewire.media-role", &media_role);
     fluid_settings_dupstr(settings, "audio.pipewire.media-type", &media_type);
     fluid_settings_dupstr(settings, "audio.pipewire.media-category", &media_category);
 
+    max_latency_frames = period_size * periods;
+
     drv->data = data;
     drv->user_callback = func;
     drv->buffer_period = period_size;
+    drv->audio_periods = periods;
 
     drv->events = FLUID_NEW(struct pw_stream_events);
 
@@ -227,6 +263,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, NULL);
 
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", period_size, (int) sample_rate);
+    pw_properties_setf(props, PW_KEY_NODE_MAX_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
 
     drv->pw_stream = pw_stream_new_simple(
@@ -266,8 +303,8 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
 
     if(func)
     {
-        drv->lbuf = FLUID_ARRAY(float, period_size);
-        drv->rbuf = FLUID_ARRAY(float, period_size);
+        drv->lbuf = FLUID_ARRAY(float, max_latency_frames);
+        drv->rbuf = FLUID_ARRAY(float, max_latency_frames);
 
         if(!drv->lbuf || !drv->rbuf)
         {

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -27,6 +27,7 @@
 #include "fluid_synth.h"
 #include "fluid_adriver.h"
 #include "fluid_settings.h"
+#include <time.h>
 
 #if PIPEWIRE_SUPPORT
 
@@ -55,6 +56,7 @@ typedef struct
 
 } fluid_pipewire_audio_driver_t;
 
+// #define PROFILE_PIPEWIRE 1
 
 /* Fast-path rendering routine with no user processing callbacks */
 static void fluid_pipewire_event_process(void *data)
@@ -63,7 +65,21 @@ static void fluid_pipewire_event_process(void *data)
     struct pw_buffer *pwb;
     struct spa_buffer *buf;
     float *dest;
+#ifdef PROFILE_PIPEWIRE
+    struct timespec ts_now, ts_write_start, ts_write_end;
+    static struct timespec ts_last_call = {0, 0};
 
+    clock_gettime(CLOCK_MONOTONIC, &ts_now);
+
+    if(ts_last_call.tv_sec != 0 || ts_last_call.tv_nsec != 0)
+    {
+        double interval_ms = (ts_now.tv_sec - ts_last_call.tv_sec) * 1000.0
+                             + (ts_now.tv_nsec - ts_last_call.tv_nsec) / 1.0e6;
+        FLUID_LOG(FLUID_INFO, "pipewire process: interval since last call: %.3f ms", interval_ms);
+    }
+
+    ts_last_call = ts_now;
+#endif
     pwb = pw_stream_dequeue_buffer(drv->pw_stream);
 
     if(!pwb)
@@ -80,7 +96,19 @@ static void fluid_pipewire_event_process(void *data)
         return;
     }
 
+#ifdef PROFILE_PIPEWIRE
+    clock_gettime(CLOCK_MONOTONIC, &ts_write_start);
+#endif
     fluid_synth_write_float(drv->data, drv->buffer_period, dest, 0, 2, dest, 1, 2);
+#ifdef PROFILE_PIPEWIRE
+    clock_gettime(CLOCK_MONOTONIC, &ts_write_end);
+    {
+        double write_ms = (ts_write_end.tv_sec - ts_write_start.tv_sec) * 1000.0
+                          + (ts_write_end.tv_nsec - ts_write_start.tv_nsec) / 1.0e6;
+        FLUID_LOG(FLUID_INFO, "pipewire process: fluid_synth_write_float took: %.3f ms", write_ms);
+    }
+#endif
+
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
     buf->datas[0].chunk->size = drv->buffer_period * stride;

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -52,12 +52,29 @@ typedef struct
     struct spa_pod_builder *builder;
 
     struct pw_thread_loop *pw_loop;
+    struct pw_context *pw_context;
+    struct pw_core *pw_core;
     struct pw_stream *pw_stream;
     struct pw_stream_events *events;
+    struct spa_hook stream_listener;
+    struct spa_hook core_listener;
 
 } fluid_pipewire_audio_driver_t;
 
 // #define PROFILE_PIPEWIRE 1
+
+static void on_core_error(void *data, uint32_t id, int seq, int res, const char *message)
+{
+    FLUID_LOG(FLUID_ERR, "PipeWire error: id=%u seq=%d res=%d (%s): %s",
+              id, seq, res, strerror(res), message ? message : "(null)");
+
+    (void)data;
+}
+
+static const struct pw_core_events core_events = {
+    .version = PW_VERSION_CORE_EVENTS,
+    .error = on_core_error,
+};
 
 /* Fast-path rendering routine with no user processing callbacks */
 static void fluid_pipewire_event_process(void *data)
@@ -66,7 +83,6 @@ static void fluid_pipewire_event_process(void *data)
     struct pw_buffer *pwb;
     struct spa_buffer *buf;
     float *dest;
-    uint32_t n_frames;
 #ifdef PROFILE_PIPEWIRE
     struct timespec ts_now, ts_write_start, ts_write_end;
     static struct timespec ts_last_call = {0, 0};
@@ -98,35 +114,23 @@ static void fluid_pipewire_event_process(void *data)
         return;
     }
 
-    n_frames = (uint32_t)pwb->requested; // since PW 0.3.50
-
-    if(n_frames == 0)
-    {
-        n_frames = buf->datas[0].maxsize / (uint32_t)stride;
-    }
-
-    if(n_frames == 0)
-    {
-        n_frames = (uint32_t)drv->buffer_period;
-    }
-
 #ifdef PROFILE_PIPEWIRE
     clock_gettime(CLOCK_MONOTONIC, &ts_write_start);
 #endif
-    fluid_synth_write_float(drv->data, (int)n_frames, dest, 0, 2, dest, 1, 2);
+    fluid_synth_write_float(drv->data, drv->buffer_period, dest, 0, 2, dest, 1, 2);
 #ifdef PROFILE_PIPEWIRE
     clock_gettime(CLOCK_MONOTONIC, &ts_write_end);
     {
         double write_ms = (ts_write_end.tv_sec - ts_write_start.tv_sec) * 1000.0
                           + (ts_write_end.tv_nsec - ts_write_start.tv_nsec) / 1.0e6;
-        FLUID_LOG(FLUID_INFO, "pipewire process: fluid_synth_write_float took: %.3f ms", write_ms);
+        FLUID_LOG(FLUID_INFO, "pipewire process: fluid_synth_write_float took: %.3f ms for %d frames", write_ms, drv->buffer_period);
     }
 #endif
 
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
-    buf->datas[0].chunk->size = n_frames * stride;
-    pwb->size = n_frames;
+    buf->datas[0].chunk->size = drv->buffer_period * stride;
+    pwb->size = drv->buffer_period;
 
     pw_stream_queue_buffer(drv->pw_stream, pwb);
 }
@@ -139,7 +143,6 @@ static void fluid_pipewire_event_process2(void *data)
     struct spa_buffer *buf;
     float *dest;
     float *channels[NUM_CHANNELS] = { drv->lbuf, drv->rbuf };
-    uint32_t n_frames;
     int i;
 
     pwb = pw_stream_dequeue_buffer(drv->pw_stream);
@@ -158,26 +161,13 @@ static void fluid_pipewire_event_process2(void *data)
         return;
     }
 
-    /* Determine how many frames to render (same logic as fast path) */
-    n_frames = (uint32_t)pwb->requested;
+    FLUID_MEMSET(drv->lbuf, 0, drv->buffer_period * sizeof(float));
+    FLUID_MEMSET(drv->rbuf, 0, drv->buffer_period * sizeof(float));
 
-    if(n_frames == 0)
-    {
-        n_frames = buf->datas[0].maxsize / (uint32_t)stride;
-    }
-
-    if(n_frames == 0)
-    {
-        n_frames = (uint32_t)drv->buffer_period;
-    }
-
-    FLUID_MEMSET(drv->lbuf, 0, n_frames * sizeof(float));
-    FLUID_MEMSET(drv->rbuf, 0, n_frames * sizeof(float));
-
-    (*drv->user_callback)(drv->data, (int)n_frames, 0, NULL, NUM_CHANNELS, channels);
+    (*drv->user_callback)(drv->data, drv->buffer_period, 0, NULL, NUM_CHANNELS, channels);
 
     /* Interleave the floating point data */
-    for(i = 0; i < (int)n_frames; i++)
+    for(i = 0; i < drv->buffer_period; i++)
     {
         dest[i * 2] = drv->lbuf[i];
         dest[i * 2 + 1] = drv->rbuf[i];
@@ -185,8 +175,8 @@ static void fluid_pipewire_event_process2(void *data)
 
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
-    buf->datas[0].chunk->size = n_frames * stride;
-    pwb->size = n_frames;
+    buf->datas[0].chunk->size = drv->buffer_period * stride;
+    pwb->size = drv->buffer_period;
 
     pw_stream_queue_buffer(drv->pw_stream, pwb);
 }
@@ -262,29 +252,46 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
         goto driver_cleanup;
     }
 
+    drv->pw_context = pw_context_new(pw_thread_loop_get_loop(drv->pw_loop),
+                                         NULL, 0);
+
+    if(!drv->pw_context)
+    {
+        FLUID_LOG(FLUID_ERR, "Failed to allocate PipeWire context");
+        goto driver_cleanup;
+    }
+
+    drv->pw_core = pw_context_connect(drv->pw_context, NULL, 0);
+
+    if(!drv->pw_core)
+    {
+        FLUID_LOG(FLUID_ERR, "Failed to connect to PipeWire");
+        goto driver_cleanup;
+    }
+    
+    spa_zero(drv->core_listener);
+    pw_core_add_listener(drv->pw_core, &drv->core_listener,
+                            &core_events, NULL);
+
     props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, NULL);
-
-    pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", period_size, (int) sample_rate);
-    pw_properties_setf(props, PW_KEY_NODE_MAX_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
+    pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
-
     if(async)
     {
         pw_properties_set(props, PW_KEY_NODE_ASYNC, "true");
     }
 
-    drv->pw_stream = pw_stream_new_simple(
-                         pw_thread_loop_get_loop(drv->pw_loop),
-                         "FluidSynth",
-                         props,
-                         drv->events,
-                         drv);
+    drv->pw_stream = pw_stream_new(drv->pw_core, "FluidSynth", props);
 
     if(!drv->pw_stream)
     {
         FLUID_LOG(FLUID_ERR, "Failed to allocate PipeWire stream");
         goto driver_cleanup;
     }
+
+    spa_zero(drv->stream_listener);
+    pw_stream_add_listener(drv->pw_stream, &drv->stream_listener,
+                            drv->events, drv);
 
     buffer = FLUID_ARRAY(float, NUM_CHANNELS * period_size);
 
@@ -310,8 +317,8 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
 
     if(func)
     {
-        drv->lbuf = FLUID_ARRAY(float, max_latency_frames);
-        drv->rbuf = FLUID_ARRAY(float, max_latency_frames);
+        drv->lbuf = FLUID_ARRAY(float, period_size);
+        drv->rbuf = FLUID_ARRAY(float, period_size);
 
         if(!drv->lbuf || !drv->rbuf)
         {
@@ -374,6 +381,16 @@ void delete_fluid_pipewire_audio_driver(fluid_audio_driver_t *p)
     if(drv->pw_stream)
     {
         pw_stream_destroy(drv->pw_stream);
+    }
+
+    if(drv->pw_core)
+    {
+        pw_core_disconnect(drv->pw_core);
+    }
+
+    if(drv->pw_context)
+    {
+        pw_context_destroy(drv->pw_context);
     }
 
     if(drv->pw_loop)

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -207,6 +207,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     int res;
     int pw_flags;
     int realtime_prio = 0;
+    int async = 0;
     double sample_rate;
     char *media_role = NULL;
     char *media_type = NULL;
@@ -228,6 +229,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     fluid_settings_getint(settings, "audio.period-size", &period_size);
     fluid_settings_getint(settings, "audio.periods", &periods);
     fluid_settings_getint(settings, "audio.realtime-prio", &realtime_prio);
+    fluid_settings_getint(settings, "audio.pipewire.async", &async);
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
     fluid_settings_dupstr(settings, "audio.pipewire.media-role", &media_role);
     fluid_settings_dupstr(settings, "audio.pipewire.media-type", &media_type);
@@ -265,6 +267,11 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", period_size, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_MAX_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
+
+    if(async)
+    {
+        pw_properties_set(props, PW_KEY_NODE_ASYNC, "true");
+    }
 
     drv->pw_stream = pw_stream_new_simple(
                          pw_thread_loop_get_loop(drv->pw_loop),
@@ -395,6 +402,7 @@ void fluid_pipewire_audio_driver_settings(fluid_settings_t *settings)
     fluid_settings_register_str(settings, "audio.pipewire.media-role", "Music", 0);
     fluid_settings_register_str(settings, "audio.pipewire.media-type", "Audio", 0);
     fluid_settings_register_str(settings, "audio.pipewire.media-category", "Playback", 0);
+    fluid_settings_register_int(settings, "audio.pipewire.async", 1, 0, 1, 0);
 }
 
 #endif

--- a/src/rvoice/fluid_iir_filter.h
+++ b/src/rvoice/fluid_iir_filter.h
@@ -105,7 +105,7 @@ void fluid_iir_filter_init_table(fluid_iir_sincos_t *sincos_table, fluid_real_t 
 void fluid_iir_filter_reset(fluid_iir_filter_t *iir_filter);
 
 void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
-                           fluid_real_t output_rate, fluid_real_t fres_mod);
+                           fluid_real_t max_fres_ct, fluid_real_t fres_mod);
 
 void fluid_iir_filter_apply(fluid_iir_filter_t *iir_filter,
                             fluid_iir_filter_t *custom_filter,

--- a/src/rvoice/fluid_iir_filter_impl.cpp
+++ b/src/rvoice/fluid_iir_filter_impl.cpp
@@ -307,7 +307,7 @@ extern "C" void fluid_iir_filter_apply(fluid_iir_filter_t *resonant_filter,
 }
 
 void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
-                           fluid_real_t output_rate,
+                           fluid_real_t max_fres_ct,
                            fluid_real_t fres_mod)
 {
     bool calc_coeff_flag = false;
@@ -318,10 +318,11 @@ void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
         return;
     }
 
-    /* calculate the frequency of the resonant filter in Hz */
-    fres = fluid_ct2hz(iir_filter->fres + fres_mod);
-
-    /* I removed the optimization of turning the filter off when the
+    /* Calculate the filter cutoff in absolute cents and clip it.
+     * The upper bound (max_fres_ct) was precomputed as fluid_hz2ct(0.45 * output_rate)
+     * so that the expensive hz<->cents round-trip for clipping fres is avoided on every voice render call.
+     *
+     * I removed the optimization of turning the filter off when the
      * resonance frequency is above the maximum frequency. Instead, the
      * filter frequency is set to a maximum of 0.45 times the sampling
      * rate. For a 44100 kHz sampling rate, this amounts to 19845
@@ -331,18 +332,18 @@ void fluid_iir_filter_calc(fluid_iir_filter_t *iir_filter,
      * clipping the maximum filter frequency at 0.45*srate, the filter
      * is used as an anti-aliasing filter. */
 
-    if(fres > 0.45f * output_rate)
+    static const fluid_real_t min_fres_ct = fluid_hz2ct(5.f);
+    fres = iir_filter->fres + fres_mod;
+    if(fres > max_fres_ct)
     {
-        fres = 0.45f * output_rate;
+        fres = max_fres_ct;
     }
-    else if(fres < 5.f)
+    else if(fres < min_fres_ct)
     {
-        fres = 5.f;
+        fres = min_fres_ct;
     }
 
-    LOG_FILTER("%f + %f = %f cents = %f Hz | Q: %f", iir_filter->fres, fres_mod, iir_filter->fres + fres_mod, fres, iir_filter->last_q);
-    
-    fres = fluid_hz2ct(fres);
+    LOG_FILTER("%f + %f = %f cents | Q: %f", iir_filter->fres, fres_mod, fres, iir_filter->last_q);
     
     /* if filter enabled and there is a significant frequency change.. */
     fres_diff = fres - iir_filter->last_fres;

--- a/src/rvoice/fluid_rvoice.c
+++ b/src/rvoice/fluid_rvoice.c
@@ -441,11 +441,11 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
     // Applying the filter after applying the gain from the volEnv might cause audible clicks for when turning off
     // voices that are filtered by a high Q, see https://github.com/FluidSynth/fluidsynth/issues/1427
     //
-    // Note that at this point we are using voice->dsp.output_rate which is set to the synth's output rate, because
+    // Note that at this point we are using voice->dsp.max_filter_fres_ct which is precomputed from the synth's output rate, because
     // the filter will receive the interpolated waveform.
 
     fmod = fluid_lfo_get_val(&voice->envlfo.modlfo) * voice->envlfo.modlfo_to_fc + modenv_val * voice->envlfo.modenv_to_fc;
-    fluid_iir_filter_calc(&voice->resonant_filter, voice->dsp.output_rate, fmod);
+    fluid_iir_filter_calc(&voice->resonant_filter, voice->dsp.max_filter_fres_ct, fmod);
 
     fluid_check_fpe("voice_write IIR coefficients");
 
@@ -453,7 +453,7 @@ fluid_rvoice_write(fluid_rvoice_t *voice, fluid_real_t *dsp_buf)
     fmod = voice->resonant_custom_filter.flags & FLUID_IIR_BEANLAND
          ? (voice->dsp.pitch + voice->dsp.pitchoffset) - (voice->dsp.sample->origpitch * 100 + voice->dsp.sample->pitchadj)
          : 0;
-    fluid_iir_filter_calc(&voice->resonant_custom_filter, voice->dsp.output_rate, fmod);
+    fluid_iir_filter_calc(&voice->resonant_custom_filter, voice->dsp.max_filter_fres_ct, fmod);
 
     fluid_check_fpe("voice_write IIR (custom) coefficients");
 
@@ -770,7 +770,7 @@ DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_output_rate)
     fluid_rvoice_t *voice = obj;
     fluid_real_t value = param[0].real;
 
-    voice->dsp.output_rate = value;
+    voice->dsp.max_filter_fres_ct = fluid_hz2ct(0.45f * value);
 }
 
 DECLARE_FLUID_RVOICE_FUNCTION(fluid_rvoice_set_interp_method)

--- a/src/rvoice/fluid_rvoice.h
+++ b/src/rvoice/fluid_rvoice.h
@@ -111,7 +111,7 @@ struct _fluid_rvoice_dsp_t
 
     fluid_real_t pitch;              /* the pitch in midicents */
     fluid_real_t root_pitch_hz;      /* the base note of the note in hz */
-    fluid_real_t output_rate;
+    fluid_real_t max_filter_fres_ct; /* the maximum IIR filter cutoff frequency in absolute cents (= fluid_hz2ct(0.45 * output_rate)) */
 
     /* Stuff needed for amplitude calculations */
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -5327,7 +5327,6 @@ fluid_synth_free_voice_by_kill_LOCAL(fluid_synth_t *synth)
 
     for(i = 0; i < synth->polyphony; i++)
     {
-
         voice = synth->voice[i];
 
         /* safeguard against an available voice. */
@@ -5349,11 +5348,12 @@ fluid_synth_free_voice_by_kill_LOCAL(fluid_synth_t *synth)
 
     if(best_voice_index < 0)
     {
+        FLUID_LOG(FLUID_DBG, "Polyphony exceeded, failed to find a suitable voice to kill");
         return NULL;
     }
 
     voice = synth->voice[best_voice_index];
-    FLUID_LOG(FLUID_DBG, "Killing voice %d, index %d, chan %d, key %d ",
+    FLUID_LOG(FLUID_DBG, "Polyphony exceeded, killing voice %d, index %d, chan %d, key %d ",
               fluid_voice_get_id(voice), best_voice_index, fluid_voice_get_channel(voice), fluid_voice_get_key(voice));
     fluid_voice_off(voice);
 
@@ -5398,22 +5398,8 @@ fluid_synth_alloc_voice_LOCAL(fluid_synth_t *synth, fluid_sample_t *sample, int 
     fluid_channel_t *channel = NULL;
     unsigned int ticks;
 
-    /* check if there's an available synthesis process */
-    for(i = 0; i < synth->polyphony; i++)
-    {
-        if(_AVAILABLE(synth->voice[i]))
-        {
-            voice = synth->voice[i];
-            break;
-        }
-    }
-
-    /* No success yet? Then stop a running voice. */
-    if(voice == NULL)
-    {
-        FLUID_LOG(FLUID_DBG, "Polyphony exceeded, trying to kill a voice");
-        voice = fluid_synth_free_voice_by_kill_LOCAL(synth);
-    }
+    /* check if there's an available voice or kill one */
+    voice = fluid_synth_free_voice_by_kill_LOCAL(synth);
 
     if(voice == NULL)
     {

--- a/src/synth/fluid_voice.h
+++ b/src/synth/fluid_voice.h
@@ -65,22 +65,17 @@ enum fluid_voice_status
  */
 struct _fluid_voice_t
 {
-    unsigned int id;                /* the id is incremented for every new noteon.
-					   it's used for noteoff's  */
     unsigned char status;
+    unsigned char can_access_rvoice; /* False if rvoice is being rendered in separate thread */
+    unsigned char can_access_overflow_rvoice; /* False if overflow_rvoice is being rendered in separate thread */
     unsigned char chan;             /* the channel number, quick access for channel messages */
     unsigned char key;              /* the key of the noteon event, quick access for noteoff */
     unsigned char vel;              /* the velocity of the noteon event */
-    fluid_channel_t *channel;
-    fluid_rvoice_eventhandler_t *eventhandler;
-    fluid_zone_range_t *zone_range;  /* instrument zone range*/
-    fluid_sample_t *sample;          /* Pointer to sample (dupe in rvoice) */
-    fluid_sample_t *overflow_sample; /* Pointer to sample (dupe in overflow_rvoice) */
-
+    unsigned char has_noteoff; /* Flag set when noteoff has been sent */
+    unsigned int id;                /* the id is incremented for every new noteon.
+					   it's used for noteoff's  */
     unsigned int start_time;
-    int mod_count;
-    fluid_mod_t mod[FLUID_NUM_MOD];
-    fluid_gen_t gen[GEN_LAST];
+    fluid_channel_t *channel;
 
     /* basic parameters */
     fluid_real_t output_rate;        /* the sample rate of the synthesizer (dupe in rvoice) */
@@ -108,9 +103,15 @@ struct _fluid_voice_t
     /* rvoice control */
     fluid_rvoice_t *rvoice;
     fluid_rvoice_t *overflow_rvoice; /* Used temporarily and only in overflow situations */
-    char can_access_rvoice; /* False if rvoice is being rendered in separate thread */
-    char can_access_overflow_rvoice; /* False if overflow_rvoice is being rendered in separate thread */
-    char has_noteoff; /* Flag set when noteoff has been sent */
+
+    fluid_rvoice_eventhandler_t *eventhandler;
+    fluid_zone_range_t *zone_range;  /* instrument zone range*/
+    fluid_sample_t *sample;          /* Pointer to sample (dupe in rvoice) */
+    fluid_sample_t *overflow_sample; /* Pointer to sample (dupe in overflow_rvoice) */
+
+    int mod_count;
+    fluid_mod_t mod[FLUID_NUM_MOD];
+    fluid_gen_t gen[GEN_LAST];
 
     /* user callback */
     fluid_voice_callback_t callback;
@@ -192,8 +193,7 @@ fluid_voice_unlock_rvoice(fluid_voice_t *voice)
     voice->can_access_rvoice = 1;
 }
 
-#define _AVAILABLE(voice)  ((voice)->can_access_rvoice && \
- (((voice)->status == FLUID_VOICE_CLEAN) || ((voice)->status == FLUID_VOICE_OFF)))
+#define _AVAILABLE(voice)  ((((voice)->status == FLUID_VOICE_CLEAN) || ((voice)->status == FLUID_VOICE_OFF)) && (voice)->can_access_rvoice)
 //#define _RELEASED(voice)  ((voice)->chan == NO_CHANNEL)
 #define _SAMPLEMODE(voice) ((int)(voice)->gen[GEN_SAMPLEMODE].val)
 


### PR DESCRIPTION
This PR implements some minor performance tweaks found while digging into #1808. After these changes, the MIDI file of the reference issue renders about 8 seconds faster for me (when using the fast file renderer). So a step in the right direction. Yet the big (but known) problems remain to be `fluid_rvoice_dsp_interpolate()` and `fluid_iir_filter_apply()`. These functions use inherently scalar arithmetics according to Intel VTune (see below) while dealing with lots of data, making them very slow.

<img width="2690" height="1166" alt="Bildschirmfoto_20260719_175050" src="https://github.com/user-attachments/assets/964c3499-e4dd-4e0e-a09c-633044de2468" />

Apparently, due to the tiny arithmetic change in the IIR filter, MIDI that make use of the filter are now rendered slightly differently, causing some of our regression tests to hit the threshold and fail. This is expected though.
