### PR TITLE
Some optimizations for PipeWire audio driver

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -800,7 +800,7 @@ Developers:
             <desc>
                 If TRUE, creates an asynchronous PipeWire stream. This isolates synthesizer from PipeWire's synchronous processing graph, preventing system-wide audio dropouts (xruns) during heavy workload (such as high polyphones).
                 Requires PipeWire &gt;= 0.3.73.
-                <note>Enabling this automatically increases latency by exactly one period.</note>
+                <note>Enabling this automatically doubles the actual latency.</note>
             </desc>
         </setting>
         <setting>

--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -794,6 +794,16 @@ Developers:
             </desc>
         </setting>
         <setting>
+            <name>pipewire.async</name>
+            <type>bool</type>
+            <def>1 (TRUE)</def>
+            <desc>
+                If TRUE, creates an asynchronous PipeWire stream. This isolates synthesizer from PipeWire's synchronous processing graph, preventing system-wide audio dropouts (xruns) during heavy workload (such as high polyphones).
+                Requires PipeWire &gt;= 0.3.73.
+                <note>Enabling this automatically increases latency by exactly one period.</note>
+            </desc>
+        </setting>
+        <setting>
             <name>portaudio.device</name>
             <type>str</type>
             <def>PortAudio Default</def>

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -48,6 +48,7 @@ typedef struct
     float *lbuf, *rbuf;
 
     int buffer_period;
+    int audio_periods;
     struct spa_pod_builder *builder;
 
     struct pw_thread_loop *pw_loop;
@@ -65,6 +66,7 @@ static void fluid_pipewire_event_process(void *data)
     struct pw_buffer *pwb;
     struct spa_buffer *buf;
     float *dest;
+    uint32_t n_frames;
 #ifdef PROFILE_PIPEWIRE
     struct timespec ts_now, ts_write_start, ts_write_end;
     static struct timespec ts_last_call = {0, 0};
@@ -96,10 +98,22 @@ static void fluid_pipewire_event_process(void *data)
         return;
     }
 
+    n_frames = (uint32_t)pwb->requested; // since PW 0.3.50
+
+    if(n_frames == 0)
+    {
+        n_frames = buf->datas[0].maxsize / (uint32_t)stride;
+    }
+
+    if(n_frames == 0)
+    {
+        n_frames = (uint32_t)drv->buffer_period;
+    }
+
 #ifdef PROFILE_PIPEWIRE
     clock_gettime(CLOCK_MONOTONIC, &ts_write_start);
 #endif
-    fluid_synth_write_float(drv->data, drv->buffer_period, dest, 0, 2, dest, 1, 2);
+    fluid_synth_write_float(drv->data, (int)n_frames, dest, 0, 2, dest, 1, 2);
 #ifdef PROFILE_PIPEWIRE
     clock_gettime(CLOCK_MONOTONIC, &ts_write_end);
     {
@@ -111,7 +125,8 @@ static void fluid_pipewire_event_process(void *data)
 
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
-    buf->datas[0].chunk->size = drv->buffer_period * stride;
+    buf->datas[0].chunk->size = n_frames * stride;
+    pwb->size = n_frames;
 
     pw_stream_queue_buffer(drv->pw_stream, pwb);
 }
@@ -124,6 +139,7 @@ static void fluid_pipewire_event_process2(void *data)
     struct spa_buffer *buf;
     float *dest;
     float *channels[NUM_CHANNELS] = { drv->lbuf, drv->rbuf };
+    uint32_t n_frames;
     int i;
 
     pwb = pw_stream_dequeue_buffer(drv->pw_stream);
@@ -142,13 +158,26 @@ static void fluid_pipewire_event_process2(void *data)
         return;
     }
 
-    FLUID_MEMSET(drv->lbuf, 0, drv->buffer_period * sizeof(float));
-    FLUID_MEMSET(drv->rbuf, 0, drv->buffer_period * sizeof(float));
+    /* Determine how many frames to render (same logic as fast path) */
+    n_frames = (uint32_t)pwb->requested;
 
-    (*drv->user_callback)(drv->data, drv->buffer_period, 0, NULL, NUM_CHANNELS, channels);
+    if(n_frames == 0)
+    {
+        n_frames = buf->datas[0].maxsize / (uint32_t)stride;
+    }
+
+    if(n_frames == 0)
+    {
+        n_frames = (uint32_t)drv->buffer_period;
+    }
+
+    FLUID_MEMSET(drv->lbuf, 0, n_frames * sizeof(float));
+    FLUID_MEMSET(drv->rbuf, 0, n_frames * sizeof(float));
+
+    (*drv->user_callback)(drv->data, (int)n_frames, 0, NULL, NUM_CHANNELS, channels);
 
     /* Interleave the floating point data */
-    for(i = 0; i < drv->buffer_period; i++)
+    for(i = 0; i < (int)n_frames; i++)
     {
         dest[i * 2] = drv->lbuf[i];
         dest[i * 2 + 1] = drv->rbuf[i];
@@ -156,7 +185,8 @@ static void fluid_pipewire_event_process2(void *data)
 
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
-    buf->datas[0].chunk->size = drv->buffer_period * stride;
+    buf->datas[0].chunk->size = n_frames * stride;
+    pwb->size = n_frames;
 
     pw_stream_queue_buffer(drv->pw_stream, pwb);
 }
@@ -171,6 +201,8 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
 {
     fluid_pipewire_audio_driver_t *drv;
     int period_size;
+    int periods;
+    int max_latency_frames;
     int buffer_length;
     int res;
     int pw_flags;
@@ -194,15 +226,19 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     FLUID_MEMSET(drv, 0, sizeof(*drv));
 
     fluid_settings_getint(settings, "audio.period-size", &period_size);
+    fluid_settings_getint(settings, "audio.periods", &periods);
     fluid_settings_getint(settings, "audio.realtime-prio", &realtime_prio);
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
     fluid_settings_dupstr(settings, "audio.pipewire.media-role", &media_role);
     fluid_settings_dupstr(settings, "audio.pipewire.media-type", &media_type);
     fluid_settings_dupstr(settings, "audio.pipewire.media-category", &media_category);
 
+    max_latency_frames = period_size * periods;
+
     drv->data = data;
     drv->user_callback = func;
     drv->buffer_period = period_size;
+    drv->audio_periods = periods;
 
     drv->events = FLUID_NEW(struct pw_stream_events);
 
@@ -227,6 +263,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, NULL);
 
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", period_size, (int) sample_rate);
+    pw_properties_setf(props, PW_KEY_NODE_MAX_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
 
     drv->pw_stream = pw_stream_new_simple(
@@ -266,8 +303,8 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
 
     if(func)
     {
-        drv->lbuf = FLUID_ARRAY(float, period_size);
-        drv->rbuf = FLUID_ARRAY(float, period_size);
+        drv->lbuf = FLUID_ARRAY(float, max_latency_frames);
+        drv->rbuf = FLUID_ARRAY(float, max_latency_frames);
 
         if(!drv->lbuf || !drv->rbuf)
         {

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -52,12 +52,29 @@ typedef struct
     struct spa_pod_builder *builder;
 
     struct pw_thread_loop *pw_loop;
+    struct pw_context *pw_context;
+    struct pw_core *pw_core;
     struct pw_stream *pw_stream;
     struct pw_stream_events *events;
+    struct spa_hook stream_listener;
+    struct spa_hook core_listener;
 
 } fluid_pipewire_audio_driver_t;
 
 // #define PROFILE_PIPEWIRE 1
+
+static void on_core_error(void *data, uint32_t id, int seq, int res, const char *message)
+{
+    FLUID_LOG(FLUID_ERR, "PipeWire error: id=%u seq=%d res=%d (%s): %s",
+              id, seq, res, strerror(res), message ? message : "(null)");
+
+    (void)data;
+}
+
+static const struct pw_core_events core_events = {
+    .version = PW_VERSION_CORE_EVENTS,
+    .error = on_core_error,
+};
 
 /* Fast-path rendering routine with no user processing callbacks */
 static void fluid_pipewire_event_process(void *data)
@@ -66,7 +83,6 @@ static void fluid_pipewire_event_process(void *data)
     struct pw_buffer *pwb;
     struct spa_buffer *buf;
     float *dest;
-    uint32_t n_frames;
 #ifdef PROFILE_PIPEWIRE
     struct timespec ts_now, ts_write_start, ts_write_end;
     static struct timespec ts_last_call = {0, 0};
@@ -98,35 +114,23 @@ static void fluid_pipewire_event_process(void *data)
         return;
     }
 
-    n_frames = (uint32_t)pwb->requested; // since PW 0.3.50
-
-    if(n_frames == 0)
-    {
-        n_frames = buf->datas[0].maxsize / (uint32_t)stride;
-    }
-
-    if(n_frames == 0)
-    {
-        n_frames = (uint32_t)drv->buffer_period;
-    }
-
 #ifdef PROFILE_PIPEWIRE
     clock_gettime(CLOCK_MONOTONIC, &ts_write_start);
 #endif
-    fluid_synth_write_float(drv->data, (int)n_frames, dest, 0, 2, dest, 1, 2);
+    fluid_synth_write_float(drv->data, drv->buffer_period, dest, 0, 2, dest, 1, 2);
 #ifdef PROFILE_PIPEWIRE
     clock_gettime(CLOCK_MONOTONIC, &ts_write_end);
     {
         double write_ms = (ts_write_end.tv_sec - ts_write_start.tv_sec) * 1000.0
                           + (ts_write_end.tv_nsec - ts_write_start.tv_nsec) / 1.0e6;
-        FLUID_LOG(FLUID_INFO, "pipewire process: fluid_synth_write_float took: %.3f ms", write_ms);
+        FLUID_LOG(FLUID_INFO, "pipewire process: fluid_synth_write_float took: %.3f ms for %d frames", write_ms, drv->buffer_period);
     }
 #endif
 
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
-    buf->datas[0].chunk->size = n_frames * stride;
-    pwb->size = n_frames;
+    buf->datas[0].chunk->size = drv->buffer_period * stride;
+    pwb->size = drv->buffer_period;
 
     pw_stream_queue_buffer(drv->pw_stream, pwb);
 }
@@ -139,7 +143,6 @@ static void fluid_pipewire_event_process2(void *data)
     struct spa_buffer *buf;
     float *dest;
     float *channels[NUM_CHANNELS] = { drv->lbuf, drv->rbuf };
-    uint32_t n_frames;
     int i;
 
     pwb = pw_stream_dequeue_buffer(drv->pw_stream);
@@ -158,26 +161,13 @@ static void fluid_pipewire_event_process2(void *data)
         return;
     }
 
-    /* Determine how many frames to render (same logic as fast path) */
-    n_frames = (uint32_t)pwb->requested;
+    FLUID_MEMSET(drv->lbuf, 0, drv->buffer_period * sizeof(float));
+    FLUID_MEMSET(drv->rbuf, 0, drv->buffer_period * sizeof(float));
 
-    if(n_frames == 0)
-    {
-        n_frames = buf->datas[0].maxsize / (uint32_t)stride;
-    }
-
-    if(n_frames == 0)
-    {
-        n_frames = (uint32_t)drv->buffer_period;
-    }
-
-    FLUID_MEMSET(drv->lbuf, 0, n_frames * sizeof(float));
-    FLUID_MEMSET(drv->rbuf, 0, n_frames * sizeof(float));
-
-    (*drv->user_callback)(drv->data, (int)n_frames, 0, NULL, NUM_CHANNELS, channels);
+    (*drv->user_callback)(drv->data, drv->buffer_period, 0, NULL, NUM_CHANNELS, channels);
 
     /* Interleave the floating point data */
-    for(i = 0; i < (int)n_frames; i++)
+    for(i = 0; i < drv->buffer_period; i++)
     {
         dest[i * 2] = drv->lbuf[i];
         dest[i * 2 + 1] = drv->rbuf[i];
@@ -185,8 +175,8 @@ static void fluid_pipewire_event_process2(void *data)
 
     buf->datas[0].chunk->offset = 0;
     buf->datas[0].chunk->stride = stride;
-    buf->datas[0].chunk->size = n_frames * stride;
-    pwb->size = n_frames;
+    buf->datas[0].chunk->size = drv->buffer_period * stride;
+    pwb->size = drv->buffer_period;
 
     pw_stream_queue_buffer(drv->pw_stream, pwb);
 }
@@ -262,29 +252,46 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
         goto driver_cleanup;
     }
 
+    drv->pw_context = pw_context_new(pw_thread_loop_get_loop(drv->pw_loop),
+                                         NULL, 0);
+
+    if(!drv->pw_context)
+    {
+        FLUID_LOG(FLUID_ERR, "Failed to allocate PipeWire context");
+        goto driver_cleanup;
+    }
+
+    drv->pw_core = pw_context_connect(drv->pw_context, NULL, 0);
+
+    if(!drv->pw_core)
+    {
+        FLUID_LOG(FLUID_ERR, "Failed to connect to PipeWire");
+        goto driver_cleanup;
+    }
+    
+    spa_zero(drv->core_listener);
+    pw_core_add_listener(drv->pw_core, &drv->core_listener,
+                            &core_events, NULL);
+
     props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, NULL);
-
-    pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", period_size, (int) sample_rate);
-    pw_properties_setf(props, PW_KEY_NODE_MAX_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
+    pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
-
     if(async)
     {
         pw_properties_set(props, PW_KEY_NODE_ASYNC, "true");
     }
 
-    drv->pw_stream = pw_stream_new_simple(
-                         pw_thread_loop_get_loop(drv->pw_loop),
-                         "FluidSynth",
-                         props,
-                         drv->events,
-                         drv);
+    drv->pw_stream = pw_stream_new(drv->pw_core, "FluidSynth", props);
 
     if(!drv->pw_stream)
     {
         FLUID_LOG(FLUID_ERR, "Failed to allocate PipeWire stream");
         goto driver_cleanup;
     }
+
+    spa_zero(drv->stream_listener);
+    pw_stream_add_listener(drv->pw_stream, &drv->stream_listener,
+                            drv->events, drv);
 
     buffer = FLUID_ARRAY(float, NUM_CHANNELS * period_size);
 
@@ -310,8 +317,8 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
 
     if(func)
     {
-        drv->lbuf = FLUID_ARRAY(float, max_latency_frames);
-        drv->rbuf = FLUID_ARRAY(float, max_latency_frames);
+        drv->lbuf = FLUID_ARRAY(float, period_size);
+        drv->rbuf = FLUID_ARRAY(float, period_size);
 
         if(!drv->lbuf || !drv->rbuf)
         {
@@ -374,6 +381,16 @@ void delete_fluid_pipewire_audio_driver(fluid_audio_driver_t *p)
     if(drv->pw_stream)
     {
         pw_stream_destroy(drv->pw_stream);
+    }
+
+    if(drv->pw_core)
+    {
+        pw_core_disconnect(drv->pw_core);
+    }
+
+    if(drv->pw_context)
+    {
+        pw_context_destroy(drv->pw_context);
     }
 
     if(drv->pw_loop)

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -207,6 +207,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     int res;
     int pw_flags;
     int realtime_prio = 0;
+    int async = 0;
     double sample_rate;
     char *media_role = NULL;
     char *media_type = NULL;
@@ -228,6 +229,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     fluid_settings_getint(settings, "audio.period-size", &period_size);
     fluid_settings_getint(settings, "audio.periods", &periods);
     fluid_settings_getint(settings, "audio.realtime-prio", &realtime_prio);
+    fluid_settings_getint(settings, "audio.pipewire.async", &async);
     fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
     fluid_settings_dupstr(settings, "audio.pipewire.media-role", &media_role);
     fluid_settings_dupstr(settings, "audio.pipewire.media-type", &media_type);
@@ -265,6 +267,11 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", period_size, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_MAX_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
+
+    if(async)
+    {
+        pw_properties_set(props, PW_KEY_NODE_ASYNC, "true");
+    }
 
     drv->pw_stream = pw_stream_new_simple(
                          pw_thread_loop_get_loop(drv->pw_loop),
@@ -395,6 +402,7 @@ void fluid_pipewire_audio_driver_settings(fluid_settings_t *settings)
     fluid_settings_register_str(settings, "audio.pipewire.media-role", "Music", 0);
     fluid_settings_register_str(settings, "audio.pipewire.media-type", "Audio", 0);
     fluid_settings_register_str(settings, "audio.pipewire.media-category", "Playback", 0);
+    fluid_settings_register_int(settings, "audio.pipewire.async", 1, 0, 1, 0);
 }
 
 #endif


### PR DESCRIPTION
* Support audio.periods
* Async node support (default on): 
  > If TRUE, creates an asynchronous PipeWire stream. This isolates synthesizer from PipeWire's synchronous processing graph, preventing system-wide audio dropouts (xruns) during heavy workload (such as high polyphones).
  > Requires PipeWire >= 0.3.73.
  > Enabling this automatically doubles the actual latency.