### PR TITLE
Update & cleanup Android CI

### DIFF
--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -13,15 +13,6 @@ trigger:
       - '.github/workflows/*'
       - 'README.md'
 
-parameters:
-- name: UseCache
-  displayName: Use Dependency Cache
-  type: boolean
-  default: true
-  values:
-  - true
-  - false
-
 schedules:
 - cron: "0 0 * * 1"
   displayName: 'Weekly Monday Midnight build without caching'
@@ -157,14 +148,6 @@ jobs:
       displayName: 'Download Dependencies'
       workingDirectory: $(DEV)
 
-    - task: Cache@2
-      inputs:
-        key: '$(ARCH) | "$(NDK)" | $(DEV)/*.tar.* | ver1'
-        path: '$(PREFIX)'
-        cacheHitVar: 'CACHE_RESTORED'
-      displayName: 'Cache fluidsynth dependency libraries'
-      condition: and(not(in(variables['Build.Reason'], 'Schedule')), ${{ parameters.useCache }})
-
     - script: |
         set -ex
 
@@ -172,14 +155,12 @@ jobs:
         wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
         sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
       displayName: 'Use recent CMake Version'
-      condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
       enabled: 'false'
 
     - script: |
         set -ex
         sudo -E apt-get -y --no-install-suggests --no-install-recommends install cmake zlib1g-dev autogen automake autoconf libtool pkg-config autotools-dev build-essential meson ninja-build python3-distutils
       displayName: 'apt-get install build-tools'
-      condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
 
     - script: |
         set -e
@@ -274,7 +255,6 @@ jobs:
 
       displayName: 'Create fake oboe.pc'
       workingDirectory: $(DEV)
-      condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
 
     # finally, compile fluidsynth
     - template: cmake-android.yml

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -31,9 +31,6 @@ schedules:
   always: true
 
 variables:
-  ICONV_VERSION: '1.17'
-  # libffi 3.4.4 fails due to https://github.com/libffi/libffi/issues/760
-  FFI_VERSION: 'ce077e5565366171aa1b4438749b0922fce887a4'
   OBOE_VERSION: '1.9.0'
   SNDFILE_VERSION: '1.2.2'
   VORBIS_VERSION: '1.3.7'
@@ -141,9 +138,6 @@ jobs:
     - script: |
         set -ex
 
-        wget -O libffi-${FFI_VERSION}.tar.gz https://github.com/libffi/libffi/archive/${FFI_VERSION}.tar.gz # https://github.com/libffi/libffi/releases/download/v${FFI_VERSION}/libffi-${FFI_VERSION}.tar.gz
-        tar zxf libffi-${FFI_VERSION}.tar.gz
-
         wget -O oboe-${OBOE_VERSION}.tar.gz https://github.com/google/oboe/archive/${OBOE_VERSION}.tar.gz
         tar zxf oboe-${OBOE_VERSION}.tar.gz
 
@@ -235,22 +229,6 @@ jobs:
         echo "##vso[task.setvariable variable=RANLIB]$RANLIB"
 
       displayName: 'Set environment variables'
-
-    - script: |
-        set -ex
-
-        pushd libffi-${FFI_VERSION}
-        NOCONFIGURE=true autoreconf -v -i
-        # install headers into the conventional ${PREFIX}/include rather than ${PREFIX}/lib/libffi-3.2.1/include.
-        #sed -e '/^includesdir/ s/$(libdir).*$/$(includedir)/' -i include/Makefile.in
-        #sed -e '/^includedir/ s/=.*$/=@includedir@/' -e 's/^Cflags: -I${includedir}/Cflags:/' -i libffi.pc.in
-        ./configure --host=${AUTOTOOLS_TARGET} --prefix=${PREFIX} --libdir=${LIBPATH0} --enable-static --disable-shared
-        make -j$((`nproc`+1))
-        make install
-        popd
-      displayName: 'Compile libffi-$(FFI_VERSION)'
-      workingDirectory: $(DEV)
-      condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
 
     - template: cmake-android.yml
       parameters:

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -27,7 +27,7 @@ variables:
   VORBIS_VERSION: '1.3.7'
   OGG_VERSION: '1.3.6'
   OPUS_VERSION: '1.5.2'
-  FLAC_VERSION: '1.5.0'
+  FLAC_VERSION: '1.4.3'
 
   # Android NDK sources and standalone toolchain is put here
   DEV: '$(System.DefaultWorkingDirectory)/android-build-root'

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -142,9 +142,6 @@ jobs:
     - script: |
         set -ex
 
-        wget http://ftpmirror.gnu.org/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz
-        tar zxf libiconv-${ICONV_VERSION}.tar.gz
-
         wget -O libffi-${FFI_VERSION}.tar.gz https://github.com/libffi/libffi/archive/${FFI_VERSION}.tar.gz # https://github.com/libffi/libffi/releases/download/v${FFI_VERSION}/libffi-${FFI_VERSION}.tar.gz
         tar zxf libffi-${FFI_VERSION}.tar.gz
 
@@ -242,39 +239,6 @@ jobs:
         echo "##vso[task.setvariable variable=RANLIB]$RANLIB"
 
       displayName: 'Set environment variables'
-
-    - script: |
-        set -ex
-
-        pushd libiconv-${ICONV_VERSION}
-        ./configure \
-          --host=${AUTOTOOLS_TARGET} \
-          --prefix=${PREFIX} \
-          --libdir=${LIBPATH0} \
-          --disable-rpath \
-          --enable-static \
-          --disable-shared \
-          --with-pic \
-          --disable-maintainer-mode \
-          --disable-silent-rules \
-          --disable-gtk-doc \
-          --disable-introspection \
-          --disable-nls
-        make -j$((`nproc`+1))
-        make install
-        popd
-
-      displayName: 'Compile libiconv-$(ICONV_VERSION)'
-      workingDirectory: $(DEV)
-      condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
-
-    - script: |
-        set -ex
-        pushd libiconv-${ICONV_VERSION}
-        cat config.log
-      displayName: 'libiconv config.log'
-      workingDirectory: $(DEV)
-      condition: and(failed(), ne(variables.CACHE_RESTORED, 'true'))
 
     - script: |
         set -ex

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -37,7 +37,6 @@ variables:
   OGG_VERSION: '1.3.5'
   OPUS_VERSION: '1.5.2'
   FLAC_VERSION: '1.4.3'
-  PCRE_VERSION: '8.45'
 
   # Android NDK sources and standalone toolchain is put here
   DEV: '$(System.DefaultWorkingDirectory)/android-build-root'
@@ -155,14 +154,6 @@ jobs:
 
         wget -O opus-${OPUS_VERSION}.tar.gz https://github.com/xiph/opus/archive/refs/tags/v${OPUS_VERSION}.tar.gz
         tar xf opus-${OPUS_VERSION}.tar.gz
-
-        wget -O pcre-${PCRE_VERSION}.tar.bz2 https://sourceforge.net/projects/pcre/files/pcre/${PCRE_VERSION}/pcre-${PCRE_VERSION}.tar.bz2/download
-        tar jxf pcre-${PCRE_VERSION}.tar.bz2
-        cd pcre-${PCRE_VERSION}
-        # CMake checks for the existence of strtoq() using the C compiler - and yes, it does exist!
-        # Later on, it's actually used by the C++ compiler, where it does not exist.
-        # Rename the function so CMake won't find it.
-        sed -i 's/strtoq/strtoqqqq/g' CMakeLists.txt
       displayName: 'Download Dependencies'
       workingDirectory: $(DEV)
 
@@ -229,11 +220,6 @@ jobs:
         echo "##vso[task.setvariable variable=RANLIB]$RANLIB"
 
       displayName: 'Set environment variables'
-
-    - template: cmake-android.yml
-      parameters:
-        sourceDir: 'pcre-$(PCRE_VERSION)'
-        cmakeArgs: '-DPCRE_SUPPORT_UNICODE_PROPERTIES=1 -DPCRE_SUPPORT_UTF=1 -DPCRE_BUILD_PCRECPP=0 -DPCRE_BUILD_TESTS=0'
 
     - template: cmake-android.yml
       parameters:
@@ -355,8 +341,6 @@ jobs:
         ls libvorbis.so
         ls libvorbisenc.so
         ls libvorbisfile.so
-        ls libpcre.so
-        ls libpcreposix.so
       displayName: 'Verify all libs exist'
       workingDirectory: '$(PREFIX)/lib'
 

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -34,7 +34,6 @@ variables:
   ICONV_VERSION: '1.17'
   # libffi 3.4.4 fails due to https://github.com/libffi/libffi/issues/760
   FFI_VERSION: 'ce077e5565366171aa1b4438749b0922fce887a4'
-  GETTEXT_VERSION: '0.22.5'
   OBOE_VERSION: '1.9.0'
   SNDFILE_VERSION: '1.2.2'
   VORBIS_VERSION: '1.3.7'
@@ -145,9 +144,6 @@ jobs:
         wget -O libffi-${FFI_VERSION}.tar.gz https://github.com/libffi/libffi/archive/${FFI_VERSION}.tar.gz # https://github.com/libffi/libffi/releases/download/v${FFI_VERSION}/libffi-${FFI_VERSION}.tar.gz
         tar zxf libffi-${FFI_VERSION}.tar.gz
 
-        wget http://ftpmirror.gnu.org/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.gz
-        tar zxf gettext-${GETTEXT_VERSION}.tar.gz
-
         wget -O oboe-${OBOE_VERSION}.tar.gz https://github.com/google/oboe/archive/${OBOE_VERSION}.tar.gz
         tar zxf oboe-${OBOE_VERSION}.tar.gz
 
@@ -196,7 +192,7 @@ jobs:
 
     - script: |
         set -ex
-        sudo -E apt-get -y --no-install-suggests --no-install-recommends install gettext cmake zlib1g-dev autogen automake autoconf libtool pkg-config autotools-dev build-essential meson ninja-build python3-distutils
+        sudo -E apt-get -y --no-install-suggests --no-install-recommends install cmake zlib1g-dev autogen automake autoconf libtool pkg-config autotools-dev build-essential meson ninja-build python3-distutils
       displayName: 'apt-get install build-tools'
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
 
@@ -253,34 +249,6 @@ jobs:
         make install
         popd
       displayName: 'Compile libffi-$(FFI_VERSION)'
-      workingDirectory: $(DEV)
-      condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
-
-    - script: |
-        set -ex
-
-        pushd gettext-${GETTEXT_VERSION}
-        ./configure \
-          --host=${AUTOTOOLS_TARGET} \
-          --prefix=${PREFIX} \
-          --libdir=${LIBPATH0} \
-          --disable-rpath \
-          --disable-libasprintf \
-          --disable-java \
-          --disable-native-java \
-          --disable-openmp \
-          --disable-curses \
-          --enable-static \
-          --disable-shared \
-          --with-pic  \
-          --disable-maintainer-mode \
-          --disable-silent-rules \
-          --disable-gtk-doc \
-          --disable-introspection
-        make -j$((`nproc`+1))
-        make install
-        popd
-      displayName: 'Compile gettext-$(GETTEXT_VERSION)'
       workingDirectory: $(DEV)
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
 

--- a/.azure/azure-pipelines-android.yml
+++ b/.azure/azure-pipelines-android.yml
@@ -22,12 +22,12 @@ schedules:
   always: true
 
 variables:
-  OBOE_VERSION: '1.9.0'
+  OBOE_VERSION: '1.10.0'
   SNDFILE_VERSION: '1.2.2'
   VORBIS_VERSION: '1.3.7'
-  OGG_VERSION: '1.3.5'
+  OGG_VERSION: '1.3.6'
   OPUS_VERSION: '1.5.2'
-  FLAC_VERSION: '1.4.3'
+  FLAC_VERSION: '1.5.0'
 
   # Android NDK sources and standalone toolchain is put here
   DEV: '$(System.DefaultWorkingDirectory)/android-build-root'

--- a/.azure/cmake-android.yml
+++ b/.azure/cmake-android.yml
@@ -11,7 +11,7 @@ parameters:
   default: $(DEV)
 - name: condition
   type: string
-  default: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
+  default: succeeded()
 - name: installCommand
   type: string
   default: 'make install'


### PR DESCRIPTION
After removal of GLIB several dependency libs can be removed from the Android CI pipeline. Remaining libs were updated, if possible. The pipeline cache is no longer needed and was removed.