### PR TITLE
Fix interpolation bug and implement Kaiser window for testing

### DIFF
--- a/src/rvoice/fluid_rvoice_dsp.cpp
+++ b/src/rvoice/fluid_rvoice_dsp.cpp
@@ -516,6 +516,7 @@ fluid_rvoice_dsp_interpolate_sinc_local(fluid_rvoice_t *rvoice, fluid_real_t *FL
     fluid_phase_t dsp_phase_incr;
     const short int *FLUID_RESTRICT dsp_data = voice->sample->data;
     const char *FLUID_RESTRICT dsp_data24 = voice->sample->data24;
+    const unsigned int loop_len = voice->loopend - voice->loopstart;
     unsigned short dsp_i = 0;
     unsigned int dsp_phase_index;
     unsigned int start_index, end_index;
@@ -539,16 +540,16 @@ fluid_rvoice_dsp_interpolate_sinc_local(fluid_rvoice_t *rvoice, fluid_real_t *FL
     if(voice->has_looped)   /* set start_index and start points if looped or not */
     {
         start_index = voice->loopstart;
-
         for(int j = 0; j < half; j++)
         {
-            start_points[j] = fluid_rvoice_get_float_sample<IS_24BIT>(dsp_data, dsp_data24, voice->loopend - 1 - j);
+            /* wrap index into the loop in case half >= loop_len */
+            unsigned int idx = voice->loopend - 1 - (j % loop_len);
+            start_points[j] = fluid_rvoice_get_float_sample<IS_24BIT>(dsp_data, dsp_data24, idx);
         }
     }
     else
     {
         start_index = voice->start;
-
         /* duplicate the start point for all left guard positions */
         for(int j = 0; j < half; j++)
         {
@@ -561,7 +562,9 @@ fluid_rvoice_dsp_interpolate_sinc_local(fluid_rvoice_t *rvoice, fluid_real_t *FL
     {
         for(int j = 0; j < right_guard; j++)
         {
-            end_points[j] = fluid_rvoice_get_float_sample<IS_24BIT>(dsp_data, dsp_data24, voice->loopstart + j);
+            /* wrap index into the loop in case right_guard >= loop_len */
+            unsigned int idx = voice->loopstart + (j % loop_len);
+            end_points[j] = fluid_rvoice_get_float_sample<IS_24BIT>(dsp_data, dsp_data24, idx);
         }
     }
     else
@@ -677,16 +680,17 @@ fluid_rvoice_dsp_interpolate_sinc_local(fluid_rvoice_t *rvoice, fluid_real_t *FL
         /* go back to loop start */
         if(dsp_phase_index > end_index + right_guard)
         {
-            fluid_phase_sub_int(dsp_phase, voice->loopend - voice->loopstart);
+            fluid_phase_sub_int(dsp_phase, loop_len);
 
             if(!voice->has_looped)
             {
                 voice->has_looped = 1;
                 start_index = voice->loopstart;
-
-                for(int j = 0; j < half; j++)
+                for (int j = 0; j < half; j++)
                 {
-                    start_points[j] = fluid_rvoice_get_float_sample<IS_24BIT>(dsp_data, dsp_data24, voice->loopend - 1 - j);
+                    /* wrap index into the loop in case half >= loop_len */
+                    unsigned int idx = voice->loopend - 1 - (j % loop_len);
+                    start_points[j] = fluid_rvoice_get_float_sample<IS_24BIT>(dsp_data, dsp_data24, idx);
                 }
             }
         }

--- a/src/rvoice/fluid_rvoice_dsp.cpp
+++ b/src/rvoice/fluid_rvoice_dsp.cpp
@@ -813,6 +813,8 @@ fluid_rvoice_dsp_interpolate(fluid_rvoice_t *rvoice, fluid_real_t *FLUID_RESTRIC
         return dsp_invoker<InterpolateSinc<11>>(rvoice, dsp_buf, looping);
 
     case FLUID_INTERP_HIGH:
+        return dsp_invoker<InterpolateSinc<17>>(rvoice, dsp_buf, looping);
+
     case FLUID_INTERP_HIGHEST:
         return dsp_invoker<InterpolateSinc<25>>(rvoice, dsp_buf, looping);
     }

--- a/src/rvoice/fluid_rvoice_dsp_sinc.hpp
+++ b/src/rvoice/fluid_rvoice_dsp_sinc.hpp
@@ -24,9 +24,18 @@
 #include <array>
 #include <cmath>
 
+/* 0 = Hann window (default)
+ * 1 = Custom Kaiser window (sfizz-derived, uses std::cyl_bessel_i)
+ * 2 = Signalsmith Kaiser window (requires signalsmith-dsp headers)
+ *
+ * In case of 2 adding
+    target_include_directories ( libfluidsynth-OBJ PRIVATE
+        $<TARGET_PROPERTY:signalsmith-dsp,INTERFACE_INCLUDE_DIRECTORIES> )
+ * to src/CMakeLists.txt will be required
+ */
 #define USE_KAISER_WINDOW 0
 
-#if USE_KAISER_WINDOW
+#if USE_KAISER_WINDOW == 1
 // Code borrowed from sfizz: https://github.com/sfztools/sfizz/blob/f5c6e29f23b8057867c08e88f5f6ac6738baa30b/src/sfizz/Interpolators.hpp#L146-L157
 constexpr fluid_real_t get_beta(int sinc_order)
 {
@@ -69,7 +78,31 @@ static inline fluid_real_t kaiser(fluid_real_t i_shifted)
 
     return w;
 }
-#endif // USE_KAISER_WINDOW
+#endif // USE_KAISER_WINDOW == 1
+
+#if USE_KAISER_WINDOW == 2
+#include "signalsmith-dsp/windows.h"
+
+template<int SINC_ORDER>
+static inline fluid_real_t kaiser_signalsmith(fluid_real_t i_shifted)
+{
+    /* Bandwidth scaled to SINC_ORDER, targeting the expected range [8, 72].
+     * bw = 4.0 at order 8  → beta ≈ 5.4  (matches sfizz BetaMin ≈ 5.66)
+     * bw = 7.0 at order 72 → beta ≈ 9.3  (approaches sfizz BetaMax = 10.0)
+     * heuristicOptimal=true further tunes beta for minimal sidelobe energy. */
+    constexpr double bw_t = SINC_ORDER <= 8 ? 0.0 : SINC_ORDER >= 72 ? 1.0 : (SINC_ORDER - 8.0) / 64.0;
+    constexpr double bw = 4.0 + 3.0 * bw_t;
+    static signalsmith::windows::Kaiser w = signalsmith::windows::Kaiser::withBandwidth(bw, /*heuristicOptimal=*/true);
+
+    /* Map tap offset i_shifted ∈ [-halfD, +halfD] to unit ∈ [0, 1].
+     * signalsmith Kaiser uses unit = 0.5 for center (window peak),
+     * unit = 0 or 1 for the edges. Clamp for the outermost fractional taps. */
+    constexpr fluid_real_t halfD = (fluid_real_t)(SINC_ORDER / 2.0);
+    const double unit = (double)(i_shifted / halfD) * 0.5 + 0.5;
+    const double clamped = unit < 0.0 ? 0.0 : unit > 1.0 ? 1.0 : unit;
+    return (fluid_real_t)w(clamped);
+}
+#endif // USE_KAISER_WINDOW == 2
 
 /**
  * Normalized windowed-sinc interpolation kernel of order SINC_ORDER.
@@ -114,8 +147,11 @@ static inline fluid_real_t fluid_interp_sinc_kernel(const std::array<fluid_real_
         if(std::fabs(arg) > 1e-6f)
         {
             v = std::sin(arg) / arg;
-#if USE_KAISER_WINDOW
+#if USE_KAISER_WINDOW == 1
             const fluid_real_t k = kaiser<SINC_ORDER>(i_shifted);
+            v *= k;
+#elif USE_KAISER_WINDOW == 2
+            const fluid_real_t k = kaiser_signalsmith<SINC_ORDER>(i_shifted);
             v *= k;
 #else
             /* Hanning window: */


### PR DESCRIPTION
Address some points mentioned in #1826:

* Fix a bug that might cause samples from outside the sample loop to be considered for interpolation, when the interpolation order is larger than the sample loop length
* Implement compile-time support for Signalsmith's Kaiser window for testing purposes (didn't yield a notable difference between our Kaiser window yet)
* Implement `FLUID_INTERP_HIGH` and set it to sinc17 (since after additional testing I was not able to produce anything better than sinc25)