### PR TITLE
Extend FreeBSD pipeline

### DIFF
--- a/.github/workflows/api_doc_build.yml
+++ b/.github/workflows/api_doc_build.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - '.azure/**'
       - '.circleci/**'
+      - '.github/workflows/freebsd.yml'
       - '.github/workflows/rendering-regression.yml'
       - '.github/workflows/linux.yml'
       - '.github/workflows/ios.yml'

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -38,7 +38,7 @@ jobs:
                 arch: "aarch64"
               - release: "15"
                 arch: "riscv64"
-              - release: "12"
+              - release: "13"
                 arch: "x86_64"
         steps:
         - name: Checkout

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -36,7 +36,7 @@ jobs:
                 arch: "x86_64"
               - release: "15"
                 arch: "aarch64"
-              - release: "15"
+              - release: "14"
                 arch: "riscv64"
               - release: "13"
                 arch: "x86_64"

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -30,14 +30,13 @@ jobs:
         name: FreeBSD
         runs-on: ubuntu-latest
         strategy:
+          fail-fast: false
           matrix:
             include:
               - release: "15"
                 arch: "x86_64"
               - release: "15"
                 arch: "aarch64"
-              - release: "14"
-                arch: "riscv64"
               - release: "13"
                 arch: "x86_64"
         steps:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -28,6 +28,17 @@ jobs:
     freebsd:
         name: FreeBSD
         runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            include:
+              - release: "15"
+                arch: "x86_64"
+              - release: "15"
+                arch: "aarch64"
+              - release: "15"
+                arch: "riscv64"
+              - release: "12"
+                arch: "x86_64"
         steps:
         - name: Checkout
           uses: actions/checkout@v7
@@ -37,7 +48,8 @@ jobs:
         - name: Build & test
           uses: vmactions/freebsd-vm@v1
           with:
-            release: "15"
+            release: ${{ matrix.release }}
+            arch: ${{ matrix.arch }}
             prepare: |
                 pkg install -y \
                   cmake \

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -35,8 +35,8 @@ jobs:
             include:
               - release: "15"
                 arch: "x86_64"
-              - release: "15"
-                arch: "aarch64"
+              - release: "14"
+                arch: "x86_64"
               - release: "13"
                 arch: "x86_64"
         steps:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -14,6 +14,7 @@ on:
       - '.github/workflows/os2.yml'
       - '.github/workflows/rendering-regression.yml'
       - '.github/workflows/sonarcloud.yml'
+      - '.github/workflows/solaris.yml'
       - '.github/workflows/windows.yml'
       - 'README.md'
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '.azure/**'
       - '.circleci/**'
+      - '.github/workflows/freebsd.yml'
       - '.github/workflows/api_doc_build.yml'
       - '.github/workflows/os2.yml'
       - '.github/workflows/linux.yml'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '.azure/**'
       - '.circleci/**'
+      - '.github/workflows/freebsd.yml'
       - '.github/workflows/api_doc_build.yml'
       - '.github/workflows/sonarcloud.yml'
       - '.github/workflows/solaris.yml'

--- a/.github/workflows/os2.yml
+++ b/.github/workflows/os2.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '.azure/**'
       - '.circleci/**'
+      - '.github/workflows/freebsd.yml'
       - '.github/workflows/api_doc_build.yml'
       - '.github/workflows/sonarcloud.yml'
       - '.github/workflows/solaris.yml'

--- a/.github/workflows/rendering-regression.yml
+++ b/.github/workflows/rendering-regression.yml
@@ -15,6 +15,7 @@ on:
     paths-ignore:
       - '.azure/**'
       - '.circleci/**'
+      - '.github/workflows/freebsd.yml'
       - '.github/workflows/api_doc_build.yml'
       - '.github/workflows/linux.yml'
       - '.github/workflows/ios.yml'

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -38,7 +38,7 @@ jobs:
             submodules: true
 
         - name: Build & test
-          uses: vmactions/solaris-vm@v1.3.1
+          uses: vmactions/solaris-vm@v1
           with:
             envs: 'CFLAGS_SOLARIS_CC'
             usesh: true

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '.azure/**'
       - '.circleci/**'
+      - '.github/workflows/freebsd.yml'
       - '.github/workflows/api_doc_build.yml'
       - '.github/workflows/linux.yml'
       - '.github/workflows/ios.yml'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '.azure/**'
       - '.circleci/**'
+      - '.github/workflows/freebsd.yml'
       - '.github/workflows/api_doc_build.yml'
       - '.github/workflows/linux.yml'
       - '.github/workflows/solaris.yml'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '.azure/**'
       - '.circleci/**'
+      - '.github/workflows/freebsd.yml'
       - '.github/workflows/api_doc_build.yml'
       - '.github/workflows/sonarcloud.yml'
       - '.github/workflows/solaris.yml'


### PR DESCRIPTION
Compile also for FreeBSD 13 and 14. Update `path-ignore` of other workflows. I also intended to add an ARMv7 build, but it takes way too long, since being emulated by QEMU.