### PR TITLE
Fix doxygen commands not rendering for enum values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ RUN zypper refresh && zypper --non-interactive install --no-recommends \
 #   python3 + pipx     -- for zensical
 #   libxslt-tools      -- provides xsltproc for the XSLT pipeline
 RUN zypper refresh && zypper install --no-recommends -y python3 python311-pipx libxslt-tools xsltproc
-RUN pipx install zensical && pipx ensurepath
 
-ENV PATH="/root/.local/bin:${PATH}"
+# Make zensical accessible to all users in Docker
+ENV PIPX_HOME=/opt/pipx
+ENV PIPX_BIN_DIR=/usr/local/bin
+RUN pipx install zensical && pipx ensurepath
 
 ENTRYPOINT ["/bin/bash"]

--- a/doc/zensical/xslt/doxy2md.xsl
+++ b/doc/zensical/xslt/doxy2md.xsl
@@ -234,20 +234,18 @@
 
     <xsl:apply-templates select="briefdescription"/>
 
-    <!-- Enum value table -->
-    <xsl:if test="enumvalue">
-      <xsl:text>| Value | Description |&#xa;</xsl:text>
-      <xsl:text>|-------|-------------|&#xa;</xsl:text>
-      <xsl:for-each select="enumvalue">
-        <xsl:text>| `</xsl:text>
-        <xsl:value-of select="name"/>
-        <xsl:text>` | </xsl:text>
-        <xsl:apply-templates select="briefdescription" mode="inline"/>
-        <xsl:apply-templates select="detaileddescription" mode="inline"/>
-        <xsl:text> |&#xa;</xsl:text>
-      </xsl:for-each>
-      <xsl:text>&#xa;</xsl:text>
-    </xsl:if>
+    <!-- Enum value definitions -->
+    <xsl:for-each select="enumvalue">
+      <xsl:text>#### `</xsl:text>
+      <xsl:value-of select="name"/>
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="initializer"/>
+      <xsl:text>` {#</xsl:text>
+      <xsl:value-of select="name"/>
+      <xsl:text>}&#xa;&#xa;</xsl:text>
+      <xsl:apply-templates select="briefdescription"/>
+      <xsl:apply-templates select="detaileddescription"/>
+    </xsl:for-each>
 
     <xsl:apply-templates select="detaileddescription"/>
   </xsl:template>

--- a/doc/zensical/xslt/doxy2md.xsl
+++ b/doc/zensical/xslt/doxy2md.xsl
@@ -515,8 +515,20 @@
     </xsl:choose>
   </xsl:template>
 
-  <!-- Inline simplesect (used inside table cells) -->
+  <!-- Inline simplesect (used inside table cells): include a bold label prefix -->
   <xsl:template match="simplesect" mode="inline">
+    <xsl:variable name="kind" select="@kind"/>
+    <xsl:choose>
+      <xsl:when test="$kind='note'"><xsl:text> **Note:** </xsl:text></xsl:when>
+      <xsl:when test="$kind='warning'"><xsl:text> **Warning:** </xsl:text></xsl:when>
+      <xsl:when test="$kind='important'"><xsl:text> **Important:** </xsl:text></xsl:when>
+      <xsl:when test="$kind='attention'"><xsl:text> **Attention:** </xsl:text></xsl:when>
+      <xsl:when test="$kind='see'"><xsl:text> **See also:** </xsl:text></xsl:when>
+      <xsl:when test="$kind='since'"><xsl:text> **Since:** </xsl:text></xsl:when>
+      <xsl:when test="$kind='deprecated'"><xsl:text> **Deprecated:** </xsl:text></xsl:when>
+      <xsl:when test="$kind='return'"><xsl:text> **Returns:** </xsl:text></xsl:when>
+      <xsl:otherwise><xsl:text> </xsl:text></xsl:otherwise>
+    </xsl:choose>
     <xsl:apply-templates mode="inline"/>
   </xsl:template>
 
@@ -541,6 +553,9 @@
     <xsl:value-of select="@url"/>
     <xsl:text>)</xsl:text>
   </xsl:template>
+
+  <!-- Suppress whitespace-only text nodes in inline mode to prevent newlines breaking table rows -->
+  <xsl:template match="text()[normalize-space(.) = '']" mode="inline"/>
 
   <!-- Inline text nodes: escape [ and ] to prevent spurious Markdown link references -->
   <xsl:template match="text()" mode="inline">
@@ -837,6 +852,14 @@
   <!-- Suppress the xreftitle (already consumed by xrefsect template above) -->
   <xsl:template match="xreftitle"/>
   <xsl:template match="xreftitle" mode="inline"/>
+
+  <!-- xrefsect in inline mode (e.g. inside enum-value table cells): render as bold label + content -->
+  <xsl:template match="xrefsect" mode="inline">
+    <xsl:text> **</xsl:text>
+    <xsl:value-of select="normalize-space(xreftitle)"/>
+    <xsl:text>:** </xsl:text>
+    <xsl:apply-templates select="xrefdescription" mode="inline"/>
+  </xsl:template>
 
   <!-- xrefdescription: block container inside xrefsect -->
   <xsl:template match="xrefdescription">


### PR DESCRIPTION
Previously, enum values were rendered as markdown tables in the API docs.  While looks quite good, it wastes page space and it's impossible to use other markdown constructs like admonitions in a table cell.

Therefore, this PR makes enum values render as sub-sections with text. It also fixes doxygen commands not rendering correctly for enum values.

Fixes #1827
