### PR TITLE
Allow setting pipewire node name

### DIFF
--- a/doc/fluidsettings.xml
+++ b/doc/fluidsettings.xml
@@ -771,6 +771,14 @@ Developers:
             </desc>
         </setting>
         <setting>
+            <name>pipewire.id</name>
+            <type>str</type>
+            <def>fluidsynth</def>
+            <desc>
+                Unique identifier used when creating PipeWire client connection.
+            </desc>
+        </setting>
+        <setting>
             <name>pipewire.media-category</name>
             <type>str</type>
             <def>Playback</def>

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -202,6 +202,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     char *media_role = NULL;
     char *media_type = NULL;
     char *media_category = NULL;
+    char *node_name = NULL;
     float *buffer = NULL;
     const struct spa_pod *params[1];
     struct pw_properties *props;
@@ -224,6 +225,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     fluid_settings_dupstr(settings, "audio.pipewire.media-role", &media_role);
     fluid_settings_dupstr(settings, "audio.pipewire.media-type", &media_type);
     fluid_settings_dupstr(settings, "audio.pipewire.media-category", &media_category);
+    fluid_settings_dupstr(settings, "audio.pipewire.node-name", &node_name);
 
     max_latency_frames = period_size * periods;
 
@@ -273,17 +275,12 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     pw_core_add_listener(drv->pw_core, &drv->core_listener,
                             &core_events, NULL);
 
-    props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, NULL);
+    props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, PW_KEY_NODE_NAME, node_name, NULL);
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
     if(async)
     {
-#if PW_CHECK_VERSION(1,1,81)
         pw_properties_set(props, PW_KEY_NODE_ASYNC, "true");
-#else
-        FLUID_LOG(FLUID_WARN, "Fluidsynth must be compiled against Pipewire 1.1.81 or newer to support asynchronous scheduling. Falling back to synchronous scheduling.");
-        FLUID_LOG(FLUID_INFO, "Hint: Set audio.pipewire.async=0 to hide this warning.");
-#endif
     }
 
     drv->pw_stream = pw_stream_new(drv->pw_core, "FluidSynth", props);
@@ -424,6 +421,7 @@ void fluid_pipewire_audio_driver_settings(fluid_settings_t *settings)
     fluid_settings_register_str(settings, "audio.pipewire.media-role", "Music", 0);
     fluid_settings_register_str(settings, "audio.pipewire.media-type", "Audio", 0);
     fluid_settings_register_str(settings, "audio.pipewire.media-category", "Playback", 0);
+    fluid_settings_register_str(settings, "audio.pipewire.node-name", "fluidsynth", 0);
     fluid_settings_register_int(settings, "audio.pipewire.async", 1, 0, 1, 0);
 }
 

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -363,6 +363,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     FLUID_FREE(media_role);
     FLUID_FREE(media_type);
     FLUID_FREE(media_category);
+    FLUID_FREE(client_name);
 
     return (fluid_audio_driver_t *)drv;
 
@@ -370,6 +371,7 @@ driver_cleanup:
     FLUID_FREE(media_role);
     FLUID_FREE(media_type);
     FLUID_FREE(media_category);
+    FLUID_FREE(client_name);
 
     delete_fluid_pipewire_audio_driver((fluid_audio_driver_t *)drv);
     return NULL;

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -280,7 +280,12 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
     if(async)
     {
+#if PW_CHECK_VERSION(1,1,81)
         pw_properties_set(props, PW_KEY_NODE_ASYNC, "true");
+#else
+        FLUID_LOG(FLUID_WARN, "Fluidsynth must be compiled against Pipewire 1.1.81 or newer to support asynchronous scheduling. Falling back to synchronous scheduling.");
+        FLUID_LOG(FLUID_INFO, "Hint: Set audio.pipewire.async=0 to hide this warning.");
+#endif
     }
 
     drv->pw_stream = pw_stream_new(drv->pw_core, "FluidSynth", props);

--- a/src/drivers/fluid_pipewire.c
+++ b/src/drivers/fluid_pipewire.c
@@ -202,7 +202,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     char *media_role = NULL;
     char *media_type = NULL;
     char *media_category = NULL;
-    char *node_name = NULL;
+    char *client_name = NULL;
     float *buffer = NULL;
     const struct spa_pod *params[1];
     struct pw_properties *props;
@@ -225,7 +225,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     fluid_settings_dupstr(settings, "audio.pipewire.media-role", &media_role);
     fluid_settings_dupstr(settings, "audio.pipewire.media-type", &media_type);
     fluid_settings_dupstr(settings, "audio.pipewire.media-category", &media_category);
-    fluid_settings_dupstr(settings, "audio.pipewire.node-name", &node_name);
+    fluid_settings_dupstr(settings, "audio.pipewire.id", &client_name);
 
     max_latency_frames = period_size * periods;
 
@@ -275,7 +275,7 @@ new_fluid_pipewire_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t 
     pw_core_add_listener(drv->pw_core, &drv->core_listener,
                             &core_events, NULL);
 
-    props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, PW_KEY_NODE_NAME, node_name, NULL);
+    props = pw_properties_new(PW_KEY_MEDIA_TYPE, media_type, PW_KEY_MEDIA_CATEGORY, media_category, PW_KEY_MEDIA_ROLE, media_role, PW_KEY_NODE_NAME, client_name, NULL);
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%d/%d", max_latency_frames, (int) sample_rate);
     pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%d", (int) sample_rate);
     if(async)
@@ -426,7 +426,7 @@ void fluid_pipewire_audio_driver_settings(fluid_settings_t *settings)
     fluid_settings_register_str(settings, "audio.pipewire.media-role", "Music", 0);
     fluid_settings_register_str(settings, "audio.pipewire.media-type", "Audio", 0);
     fluid_settings_register_str(settings, "audio.pipewire.media-category", "Playback", 0);
-    fluid_settings_register_str(settings, "audio.pipewire.node-name", "fluidsynth", 0);
+    fluid_settings_register_str(settings, "audio.pipewire.id", "fluidsynth", 0);
     fluid_settings_register_int(settings, "audio.pipewire.async", 1, 0, 1, 0);
 }
 


### PR DESCRIPTION
Pipewire supports setting a device name when creating a node. Currently there is no way to set the node name when using pipewire audio driver backend. 

This patch introduces a new settings entry named ~`audio.pipewire.node-name`~`audio.pipewire.id`, which sets the pipewire node name property when using the pipewire audio backend driver.
If node name is not set, the device name defaults to `fluidsynth`

Update: As discussed below, the property name has been updated to `audio.pipewire.id` to be consistent with other audio backend drivers