### PR TITLE
Reduce pulled in packages for FreeBSD workflow

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -52,9 +52,9 @@ jobs:
             arch: ${{ matrix.arch }}
             prepare: |
                 pkg install -y \
-                  cmake \
+                  cmake-core \
                   pkgconf \
-                  git \
+                  git-lite \
                   ninja \
                   gcem \
                   libsndfile \


### PR DESCRIPTION
cmake is a meta package, cmake-core is cmake itself
git-lite has fewer dependencies and is enough for workflow