### PR TITLE
Remove FreeBSD 13 from workflow

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -37,8 +37,6 @@ jobs:
                 arch: "x86_64"
               - release: "14"
                 arch: "x86_64"
-              - release: "13"
-                arch: "x86_64"
         steps:
         - name: Checkout
           uses: actions/checkout@v7


### PR DESCRIPTION
Support for 13 ended April 30, 2026